### PR TITLE
Add support of official Rapsberry Pi touchscreen (kernel 4.1.8)

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -17,12 +17,7 @@ XSERVER = " \
     xf86-video-fbdev \
     "
 
-# Really supported starting from linux-raspberrypi 3.18.y only
-KERNEL_DEVICETREE ?= " \
-    bcm2708-rpi-b.dtb \
-    bcm2708-rpi-b-plus.dtb \
-    bcm2709-rpi-2-b.dtb \
-    \
+KERNEL_DEVICETREE_3.18.y = " \
     ds1307-rtc-overlay.dtb \
     hifiberry-amp-overlay.dtb \
     hifiberry-dac-overlay.dtb \
@@ -35,6 +30,30 @@ KERNEL_DEVICETREE ?= " \
     pps-gpio-overlay.dtb \
     w1-gpio-overlay.dtb \
     w1-gpio-pullup-overlay.dtb \
+    "
+
+KERNEL_DEVICETREE_4.1.y = " \
+    overlays/hifiberry-amp-overlay.dtb \
+    overlays/hifiberry-dac-overlay.dtb \
+    overlays/hifiberry-dacplus-overlay.dtb \
+    overlays/hifiberry-digi-overlay.dtb \
+    overlays/i2c-rtc-overlay.dtb \
+    overlays/iqaudio-dac-overlay.dtb \
+    overlays/iqaudio-dacplus-overlay.dtb \
+    overlays/lirc-rpi-overlay.dtb \
+    overlays/pps-gpio-overlay.dtb \
+    overlays/w1-gpio-overlay.dtb \
+    overlays/w1-gpio-pullup-overlay.dtb \
+    overlays/rpi-ft5406-overlay.dtb \
+    "
+
+# Really supported starting from linux-raspberrypi 3.18.y only
+KERNEL_DEVICETREE ?= " \
+    bcm2708-rpi-b.dtb \
+    bcm2708-rpi-b-plus.dtb \
+    bcm2709-rpi-2-b.dtb \
+    ${@bb.utils.contains('PREFERRED_VERSION_linux-raspberrypi', '3.18.%', '${KERNEL_DEVICETREE_3.18.y}', '', d)} \
+    ${@bb.utils.contains('PREFERRED_VERSION_linux-raspberrypi', '4.1.%', '${KERNEL_DEVICETREE_4.1.y}', '', d)} \
     "
 KERNEL_IMAGETYPE ?= "Image"
 

--- a/conf/machine/include/rpi-default-versions.inc
+++ b/conf/machine/include/rpi-default-versions.inc
@@ -1,3 +1,3 @@
 # RaspberryPi BSP default versions
 
-PREFERRED_VERSION_linux-raspberrypi ?= "3.18.%"
+PREFERRED_VERSION_linux-raspberrypi ?= "4.1.%"

--- a/recipes-kernel/linux/linux-raspberrypi_4.1.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.1.bb
@@ -1,0 +1,7 @@
+LINUX_VERSION ?= "4.1.8"
+
+SRCREV = "d2b2388d05d8a97b0ba14fcf2b71f19f66bc4d02"
+SRC_URI = "git://github.com/raspberrypi/linux.git;protocol=git;branch=rpi-4.1.y"
+
+require linux-raspberrypi.inc
+


### PR DESCRIPTION
I have added the support of the official rapsberry pi touchscreen by changing `PREFERRED_VERSION_linux-raspberrypi` to `4.1.%` and adding the associated kernel recipe.

I'm not shure it is the best way to do it, I'm quite new in Yocto and BSP dev.