### PR TITLE
Remove dependency of bcm2835-dev on bcm2835

### DIFF
--- a/recipes-devtools/bcm2835/bcm2835_1.46.bb
+++ b/recipes-devtools/bcm2835/bcm2835_1.46.bb
@@ -35,6 +35,8 @@ do_install_append() {
 
 PACKAGES += "${PN}-tests"
 
+RDEPENDS_${PN}-dev = ""
+
 FILES_${PN} = ""
 FILES_${PN}-tests = "${libdir}/${BPN}"
 FILES_${PN}-dbg += "${libdir}/${BPN}/.debug"


### PR DESCRIPTION
By default, the ${PN}-dev package of a recipe depends on the ${PN}
package.  However, since the bcm2835 package contains no file, it is not
generated.  As a result, when trying to include bcm2835-dev in an image
(or another package that depends on bcm2835-dev, such as
bcm2835-staticdev), we receive an error message saying that the bcm2835
package is not found.

A solution would be to define ALLOW_EMPTY for bcm2835, so that an empty
package is generated.  However, that would causes a useless package to
be installed on the target.  This patch uses another solution, which is
to empty the RDEPENDS variable of bcm2835-dev, so that it doesn't pull
in bcm2835.

Fixes #22.

Signed-off-by: Simon Marchi simon.marchi@polymtl.ca
