### PR TITLE
Patch to work around kernel config not working.

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -6,18 +6,15 @@ SECTION = "kernel"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
-SRC_URI += " \
-        file://defconfig \
-        "
-
 COMPATIBLE_MACHINE = "raspberrypi"
 
 PE = "1"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
-# NOTE: For now we pull in the default config from the RPi kernel GIT tree.
-KERNEL_DEFCONFIG_raspberrypi ?= "bcmrpi_defconfig"
-KERNEL_DEFCONFIG_raspberrypi2 ?= "bcm2709_defconfig"
+KMACHINE ?= "${MACHINE}"
+KCONFIG_MODE = "--alldefconfig"
+KBUILD_DEFCONFIG_raspberrypi ?= "bcmrpi_defconfig"
+KBUILD_DEFCONFIG_raspberrypi2 ?= "bcm2709_defconfig"
 
 # CMDLINE for raspberrypi
 CMDLINE = "dwc_otg.lpm_enable=0 console=serial0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait"
@@ -35,10 +32,6 @@ python __anonymous () {
     kerneltype = d.getVar('KERNEL_IMAGETYPE', True)
     kerneldt = get_dts(d, d.getVar('LINUX_VERSION', True))
     d.setVar("KERNEL_DEVICETREE", kerneldt)
-}
-
-do_kernel_configme_prepend() {
-    install -m 0644 ${S}/arch/${ARCH}/configs/${KERNEL_DEFCONFIG} ${WORKDIR}/defconfig || die "No default configuration for ${MACHINE} / ${KERNEL_DEFCONFIG} available."
 }
 
 do_install_prepend() {

--- a/recipes-kernel/linux/linux-raspberrypi/defconfig
+++ b/recipes-kernel/linux/linux-raspberrypi/defconfig
@@ -1,1 +1,0 @@
-# Dummy file to get through do_kernel_configme.

--- a/recipes-kernel/linux/linux-rpi.inc
+++ b/recipes-kernel/linux/linux-rpi.inc
@@ -35,8 +35,7 @@ kernel_configure_variable() {
 }
 
 do_configure_prepend() {
-    # Clean .config
-    echo "" > ${B}/.config
+    mv -f ${B}/.config ${B}/.config.patched
     CONF_SED_SCRIPT=""
 
     # oabi / eabi support
@@ -113,7 +112,8 @@ do_configure_prepend() {
 
     # Keep this the last line
     # Remove all modified configs and add the rest to .config
-    sed -e "${CONF_SED_SCRIPT}" < '${WORKDIR}/defconfig' >> '${B}/.config'
+    sed -e "${CONF_SED_SCRIPT}" < '${B}/.config.patched' >> '${B}/.config'
+    rm -f ${B}/.config.patched
 
     yes '' | oe_runmake oldconfig
 }


### PR DESCRIPTION
This simply applies [this patch](https://lists.yoctoproject.org/pipermail/yocto/2015-August/026101.html) and fixes #14 .

I need this support to enable a touch screen module that's patched in for the Raspberry Pi.
