### PR TITLE
linux-raspberrypi: Fix bitbake fetch error

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.7.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.7.bb
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
-LINUX_VERSION ?= "4.7.0"
+LINUX_VERSION ?= "4.7.7"
 
-SRCREV = "d38b45a21294eaf01aa7568aaeb161d7553477e9"
+SRCREV = "${AUTOREV}"
 SRC_URI = "git://github.com/raspberrypi/linux.git;protocol=git;branch=rpi-4.7.y \
            file://0001-fix-dtbo-rules.patch \
 "


### PR DESCRIPTION
The commit ID was changed, bitbake do_fetch will fail,
Update the commit to the same patch as before:
https://github.com/raspberrypi/linux/commit/d38b45a21294eaf01aa7568aaeb161d7553477e9

Signed-off-by: Yong Li <sdliyong@gmail.com>