### PR TITLE
disable failing append to bundle_initramfs task

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -54,16 +54,3 @@ do_deploy_append() {
     fi
     echo "${CMDLINE}${PITFT_PARAMS}" > ${DEPLOYDIR}/bcm2835-bootfiles/cmdline.txt
 }
-
-do_bundle_initramfs_append() {
-    if [ ! -z "${INITRAMFS_IMAGE}" -a x"${INITRAMFS_IMAGE_BUNDLE}" = x1 ]; then
-        if test "x${KERNEL_IMAGETYPE}" != "xuImage" ; then
-            if test -n "${KERNEL_DEVICETREE}"; then
-                # Add RPi bootloader trailer to kernel image to enable DeviceTree support
-                for type in ${KERNEL_IMAGETYPES} ; do
-                    ${STAGING_BINDIR_NATIVE}/mkknlimg --dtok ${KERNEL_OUTPUT_DIR}/$type.initramfs ${KERNEL_OUTPUT_DIR}/$type.initramfs
-                done
-            fi
-        fi
-    fi
-}


### PR DESCRIPTION
Hi Andrei,
I'm not totally sure what this append is suppose to do, but I'm sure that "mkknlimg" tool is not in the ${STAGING_BINDIR_NATIVE} (I also think that it's not in the tools anymore).

I have built an image that is using initramfs and it is working with those lines removed.
Without removing them it fails on this step.
