### PR TITLE
Do not rely on DISTRO_TYPE to enable/disable kernel debug

### DIFF
--- a/recipes-kernel/linux/linux-rpi.inc
+++ b/recipes-kernel/linux/linux-rpi.inc
@@ -13,9 +13,9 @@ ARM_KEEP_OABI ?= "1"
 # Quirk for udev greater or equal 141
 UDEV_GE_141 ?= "1"
 
-# Set the verbosity of kernel messages during runtime
-# You can define CMDLINE_DEBUG in your local.conf or distro.conf to override this behaviour
-CMDLINE_DEBUG ?= '${@base_conditional("DISTRO_TYPE", "release", "quiet", "debug", d)}'
+# You can define CMDLINE_DEBUG as "debug" in your local.conf or distro.conf
+# to enable kernel debugging.
+CMDLINE_DEBUG ?= ""
 CMDLINE_append = " ${CMDLINE_DEBUG}"
 
 KERNEL_INITRAMFS ?= '${@base_conditional("INITRAMFS_IMAGE_BUNDLE", "1", "1", "", d)}'


### PR DESCRIPTION
DISTRO_TYPE doesn't seem to be set anywhere in OE/poky. This causes
CMDLINE_DEBUG to default to "debug" which is very noisy. This is
especially true when building a systemd based system, as systemd
also looks at the kernel commandline to set the debug level.
Such a system is nearly unuseable from the serial console due
to the amount of data logged by systemd.