### PR TITLE
Split '-' as '.'

### DIFF
--- a/classes/linux-raspberrypi-base.bbclass
+++ b/classes/linux-raspberrypi-base.bbclass
@@ -15,7 +15,7 @@ def get_dts(d, ver=None):
         ver = get_kernelversion_file(staging_dir)
 
     if ver is not None:
-        min_ver = ver.split('.', 3)
+        min_ver = ver.replace('-', '.').split('.', 3)
     else:
         return dts
 


### PR DESCRIPTION
Treats a '-' character in a kernel version as a '.' when splitting as to support something like 4.9-rc6.