### PR TITLE
rpi-config: set init_uart_clock to 3 MHz

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -110,6 +110,15 @@ do_deploy() {
         echo "# Enable VC4 Graphics" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dtoverlay=vc4-kms-v3d,${VC4_CMA_SIZE}" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
+    
+    # Recently the default clock rate for uart changed to 48 MHz. This is
+    # setup by boot firmware. This update has not been aligned in u-boot yet.
+    # Linux should be able to handle this since the firmware patches the dtb
+    # file.
+    #
+    # Override the default with the previous default which is 3 MHz. Until
+    # this has been also updated in u-boot.
+    sed -i '/#init_uart_clock/ c\init_uart_clock=3000000' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
 }
 
 addtask deploy before do_package after do_install


### PR DESCRIPTION
In recent RPi firmware the default clock rate of UART changed from 3 MHz to 48 MHz. This breaks the serial port support in u-boot, because it uses a hard-coded fixed rate of 3 MHz.

Until this is updated in u-boot we need to explicitly set the init_uart_clock to 3 MHz which was the previous default and which is the one that is supported in u-boot.

Signed-off-by: Mirza Krak <mirza.krak@gmail.com>