### PR TITLE
linux-raspberrypi_4.9.bb: Update to 4.9.23

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.9.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.9.bb
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
-LINUX_VERSION ?= "4.9.21"
+LINUX_VERSION ?= "4.9.23"
 
-SRCREV = "5e4ee836560d4c0371e109bf469e1ad808ae7a44"
+SRCREV = "53460a0a50f3dd5e60266e945d0ac794ce0eca77"
 SRC_URI = "git://github.com/raspberrypi/linux.git;protocol=git;branch=rpi-4.9.y \
 "
 require linux-raspberrypi.inc


### PR DESCRIPTION
This is a backport of Khem's patch from master. Boot tested on a raspberrypi (Model B+) and raspberrypi3.