### PR TITLE
linux-rasbperrypi: Update to 4.9.27 and minor tidyup

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.9.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.9.bb
@@ -3,8 +3,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 LINUX_VERSION ?= "4.9.27"
 
 SRCREV = "9a5f215eda12bad29b35040dff00d0346fe517e2"
-SRC_URI = "git://github.com/raspberrypi/linux.git;protocol=git;branch=rpi-4.9.y \
-"
+SRC_URI = "git://github.com/raspberrypi/linux.git;branch=rpi-4.9.y"
+
 require linux-raspberrypi.inc
 
 # A LOADADDR is needed when building a uImage format kernel. This value is not

--- a/recipes-kernel/linux/linux-raspberrypi_4.9.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.9.bb
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
-LINUX_VERSION ?= "4.9.23"
+LINUX_VERSION ?= "4.9.27"
 
-SRCREV = "53460a0a50f3dd5e60266e945d0ac794ce0eca77"
+SRCREV = "9a5f215eda12bad29b35040dff00d0346fe517e2"
 SRC_URI = "git://github.com/raspberrypi/linux.git;protocol=git;branch=rpi-4.9.y \
 "
 require linux-raspberrypi.inc


### PR DESCRIPTION
Boot tested on raspberrypi (Model B+) and raspberrypi3.