### PR TITLE
[morty] Backport kernel upgrage and update readme

### DIFF
--- a/README
+++ b/README
@@ -320,11 +320,12 @@ Feel free to ask any kind of questions but always prepend your email subject
 with "[meta-raspberrypi]". This is because we use the 'yocto' mailing list and
 not a perticular 'meta-raspberrypi' mailing list.
 
-To contribute to this layer you should send the patches for review to the
-above specified mailing list.
-The patches should be compliant with the openembedded patch guidelines:
-http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines
+7.B. Patches and pull requests
+==============================
 
+To contribute to this project you should send pull requests to the github mirror
+(<https://github.com/agherzan/meta-raspberrypi>). **Additionally** you can send
+the patches for review to the above specified mailing list.
 
 When creating patches, please use something like:
 
@@ -334,7 +335,7 @@ When sending patches to mailing list, please use something like:
 
     git send-email --to yocto@yoctoproject.org <generated patch>
 
-7.B. Github issues
+7.C. Github issues
 ==================
 In order to manage and trace the meta-raspberrypi issues, we use github issues:
     https://github.com/agherzan/meta-raspberrypi/issues

--- a/recipes-kernel/linux/linux-raspberrypi_4.9.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.9.bb
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
-LINUX_VERSION ?= "4.9.23"
+LINUX_VERSION ?= "4.9.27"
 
-SRCREV = "53460a0a50f3dd5e60266e945d0ac794ce0eca77"
+SRCREV = "9a5f215eda12bad29b35040dff00d0346fe517e2"
 SRC_URI = "git://github.com/raspberrypi/linux.git;protocol=git;branch=rpi-4.9.y \
 "
 require linux-raspberrypi.inc


### PR DESCRIPTION
* Backport linux-raspberrypi v4.9.27 upgrade.

* Update README to point contributors at GitHub pull requests.

Boot tested on raspberrypi (Model B+), raspberrypi3 and raspberrypi3-64.