### PR TITLE
Allow network traffic to be avoided unless development kernel recipe is selected

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-dev:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
 LINUX_VERSION ?= "4.11"
 LINUX_RPI_DEV_BRANCH ?= "rpi-4.11.y"

--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -1,3 +1,10 @@
+python __anonymous() {
+    if "linux-raspberrypi-dev" not in d.getVar("PREFERRED_PROVIDER_virtual/kernel"):
+        msg = "Skipping linux-raspberrypi-dev as it is not the preferred " + \
+              "provider of virtual/kernel."
+        raise bb.parse.SkipRecipe(msg)
+}
+
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
 LINUX_VERSION ?= "4.11"


### PR DESCRIPTION
Using ${AUTOREV} requires network access to run 'git ls-remote' and causes parsing to fail if BB_NO_NETWORK is set to 1. So we need to avoid having to resolve ${AUTOREV} for builds which include the meta-raspberrypi layer but don't actually use the linux-raspberrypi dev branch recipe.

We can do this by renaming the recipe to linux-raspberrypi-dev so that it is a separate provider of virtual/kernel. Then we can skip the recipe unless it is selected as the preferred provider of virtual/kernel.