### PR TITLE
sdcard_image-rpi.bbclass: deploy vfat partition

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -72,6 +72,10 @@ SDIMG = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.rpi-sdimg"
 # Additional files and/or directories to be copied into the vfat partition from the IMAGE_ROOTFS.
 FATPAYLOAD ?= ""
 
+# SD card vfat partition image name
+SDIMG_VFAT = "${IMGDEPLOYDIR}/${IMAGE_NAME}.vfat"
+SDIMG_LINK_VFAT = "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.vfat"
+
 IMAGE_CMD_rpi-sdimg () {
 
 	# Align partitions
@@ -144,6 +148,16 @@ IMAGE_CMD_rpi-sdimg () {
 	# Add stamp file
 	echo "${IMAGE_NAME}" > ${WORKDIR}/image-version-info
 	mcopy -i ${WORKDIR}/boot.img -v ${WORKDIR}/image-version-info ::
+
+        # Deploy vfat partition (for u-boot case only)
+        case "${KERNEL_IMAGETYPE}" in
+        "uImage")
+                cp ${WORKDIR}/boot.img ${SDIMG_VFAT}
+                ln -sf ${SDIMG_VFAT} ${SDIMG_LINK_VFAT}
+                ;;
+        *)
+                ;;
+        esac
 
 	# Burn Partitions
 	dd if=${WORKDIR}/boot.img of=${SDIMG} conv=notrunc seek=1 bs=$(expr ${IMAGE_ROOTFS_ALIGNMENT} \* 1024) && sync && sync


### PR DESCRIPTION
This is useful to update the bootloader/vfat partition from u-boot when
you don't want to update everything:

U-Boot> tftpboot 0x1000000 tmp/0VXje
Waiting for Ethernet connection... done.
Using sms0 device
TFTP from server 192.168.0.1; our IP address is 192.168.0.26
Filename 'image.vfat'.
Load address: 0x1000000
Loading: ##################################################  40 MiB
	 2.1 MiB/s
done
Bytes transferred = 41943040 (2800000 hex)
U-Boot> mmc part

Partition Map for MMC device 0  --   Partition Type: DOS

Part	Start Sector	Num Sectors	UUID		Type
  1	8192      	81920     	a63a4fbc-01	0c Boot
  2	90112     	163840    	a63a4fbc-02	83
U-Boot> mmc erase 0x2000 0x14000

MMC erase: dev # 0, block # 8192, count 81920 ... 81920 blocks erased:
OK
U-Boot> mmc write 0x1000000 0x2000 0x14000

MMC write: dev # 0, block # 8192, count 81920 ... 81920 blocks written:
OK
U-Boot>

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
