### PR TITLE
raspberrypi3-64.conf: Don't use raspberrypi as MACHINEOVERRIDES

### DIFF
--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -2,7 +2,7 @@
 #@NAME: RaspberryPi 3 Development Board
 #@DESCRIPTION: Machine configuration for the RaspberryPi 3 in 64 bits mode
 
-MACHINEOVERRIDES = "raspberrypi3:raspberrypi:${MACHINE}"
+MACHINEOVERRIDES = "raspberrypi3:${MACHINE}"
 
 MACHINE_EXTRA_RRECOMMENDS += "linux-firmware-bcm43430"
 


### PR DESCRIPTION
The current setup broke the build for rpi3-64 when we wanted to port
some changes from rpi3 to rpi0.