### PR TITLE
sdcard_image-rpi: replace IMAGE_DEPENDS_rpi-sdimg by do_image_rpi-sdi…

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -50,13 +50,13 @@ IMAGE_ROOTFS_ALIGNMENT = "4096"
 SDIMG_ROOTFS_TYPE ?= "ext3"
 SDIMG_ROOTFS = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.${SDIMG_ROOTFS_TYPE}"
 
-IMAGE_DEPENDS_rpi-sdimg = " \
-			parted-native \
-			mtools-native \
-			dosfstools-native \
+do_image_rpi_sdimg[depends] = " \
+			parted-native:do_populate_sysroot \
+			mtools-native:do_populate_sysroot \
+			dosfstools-native:do_populate_sysroot \
 			virtual/kernel:do_deploy \
-			${IMAGE_BOOTLOADER} \
-			${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', 'u-boot', '',d)} \
+			${IMAGE_BOOTLOADER}:do_deploy \
+			${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', 'u-boot:do_deploy', '',d)} \
 			"
 
 # SD card image name


### PR DESCRIPTION
…mg[depends]

* oe-core removed IMAGE_DEPENDS -> parsing fails with hint how to fix
* add required task for each recipe

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
