### PR TITLE
rpi-base: wic: generate entries for u-boot

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -83,7 +83,9 @@ def make_dtb_boot_files(d):
 
 IMAGE_BOOT_FILES ?= "bcm2835-bootfiles/* \
                  ${@make_dtb_boot_files(d)} \
-                 ${KERNEL_IMAGETYPE};${SDIMG_KERNELIMAGE} \
+                 ${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', '${KERNEL_IMAGETYPE}', '${KERNEL_IMAGETYPE};${SDIMG_KERNELIMAGE}', d)} \
+                 ${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', 'u-boot.bin;${SDIMG_KERNELIMAGE}', '', d)} \
+                 ${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', 'boot.scr;boot.scr', '', d)} \
                  "
 
 # The kernel image is installed into the FAT32 boot partition and does not need


### PR DESCRIPTION
This commit allow wic generated images to work when we want u-boot to
load the kernel image.

Augment IMAGE_BOOT_FILES with the proper entries when KERNEL_IMAGETYPE
is "uImage". More specifically add u-boot image and boot.scr to deployed files
and give the proper name to the kernel image accordingly.

Signed-off-by: Andrea Galbusera <gizero@gmail.com>