### PR TITLE
linux-raspberrypi-dev: Switch to rpi-4.12.y

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -7,8 +7,8 @@ python __anonymous() {
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
-LINUX_VERSION ?= "4.11"
-LINUX_RPI_DEV_BRANCH ?= "rpi-4.11.y"
+LINUX_VERSION ?= "4.12"
+LINUX_RPI_DEV_BRANCH ?= "rpi-4.12.y"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_DEV_BRANCH} \


### PR DESCRIPTION
Linux v4.12 is now released.