### PR TITLE
linux-raspberrypi: Add option for disabling rpi boot logo.

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -95,6 +95,12 @@ this variable in local.conf:
 
     ENABLE_KGDB = "1"
 
+## Disable rpi boot logo
+
+To disable rpi boot logo, set this variable in local.conf:
+
+    DISABLE_RPI_BOOT_LOGO = "1"
+
 ## Boot to U-Boot
 
 To have u-boot load kernel image, set in your local.conf:

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -26,6 +26,9 @@ CMDLINE ?= "dwc_otg.lpm_enable=0 console=serial0,115200 root=/dev/mmcblk0p2 root
 # Add the kernel debugger over console kernel command line option if enabled
 CMDLINE_append = ' ${@base_conditional("ENABLE_KGDB", "1", "kgdboc=serial0,115200", "", d)}'
 
+# Disable rpi logo on boot
+CMDLINE_append += ' ${@base_conditional("DISABLE_RPI_BOOT_LOGO", "1", "logo.nologo", "", d)}'
+
 UDEV_GE_141 ?= "1"
 
 KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "stmpe-ts", "", d)}"


### PR DESCRIPTION
Signed-off-by Zdzisław Krajewski <zdzichucb@gmail.com>

**- What I did**
I added option for removing rpi logo from boot screen.
**- How I did it**
I added line in `recipes-kernel/linux/linux-raspberrypi-dev.bb` which appends `logo.nologo` option to `/boot/cmdline.txt` file according to `DISABLE_RPI_BOOT_LOGO` variable.