### PR TITLE
userland: Add missing EGL_CAST defines

### DIFF
--- a/recipes-graphics/userland/userland/0015-EGL-glplatform.h-define-EGL_CAST.patch
+++ b/recipes-graphics/userland/userland/0015-EGL-glplatform.h-define-EGL_CAST.patch
@@ -1,0 +1,32 @@
+From 382e3b16cbcc09d825540d5bd3e45a2fca4484fe Mon Sep 17 00:00:00 2001
+From: Andrea Galbusera <gizero@gmail.com>
+Date: Fri, 14 Jul 2017 09:52:54 +0200
+Subject: [PATCH] EGL/glplatform.h: define EGL_CAST
+
+C++ / C typecast macros for special EGL handle values: used by libepoxy code
+The definition comes from the updated version of this header in mesa.
+
+Upstream-Status: Pending
+---
+ interface/khronos/include/EGL/eglplatform.h | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/interface/khronos/include/EGL/eglplatform.h b/interface/khronos/include/EGL/eglplatform.h
+index 1f7c930..c39d425 100644
+--- a/interface/khronos/include/EGL/eglplatform.h
++++ b/interface/khronos/include/EGL/eglplatform.h
+@@ -202,4 +202,11 @@ EGLAPI void EGLAPIENTRY BEGL_GetDefaultDriverInterfaces(BEGL_DriverInterfaces *i
+ #include "interface/khronos/common/khrn_client_mangle.h"
+ #endif
+ 
++/* C++ / C typecast macros for special EGL handle values */
++#if defined(__cplusplus)
++#define EGL_CAST(type, value) (static_cast<type>(value))
++#else
++#define EGL_CAST(type, value) ((type) (value))
++#endif
++
+ #endif /* __eglplatform_h */
+-- 
+2.7.4
+

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -34,6 +34,7 @@ SRC_URI = "\
     file://0012-implement-buffer-wrapping-interface-for-dispmanx.patch \
     file://0013-Implement-triple-buffering-for-wayland.patch \
     file://0014-GLES2-gl2ext.h-Define-GL_R8_EXT-and-GL_RG8_EXT.patch \
+    file://0015-EGL-glplatform.h-define-EGL_CAST.patch \
 "
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Recent updates of libepoxy in oe-core broke the build for raspberrypi of dependent packages like gtk+3, due to a missing definition in an glplatform.h header provided by userland.
This patch backports the missing define from the updated version of the header available in mesa, hence restoring successful builds.
The patch has been submitted upstream here: https://github.com/raspberrypi/userland/pull/407

See http://lists.openembedded.org/pipermail/openembedded-core/2017-July/139311.html for relevant discussions.