### PR TITLE
rpio: Add RDEPENDS To rpio For python-logging & python-threading

### DIFF
--- a/recipes-devtools/python/rpio_0.10.0.bb
+++ b/recipes-devtools/python/rpio_0.10.0.bb
@@ -16,5 +16,10 @@ inherit setuptools
 
 COMPATIBLE_MACHINE = "raspberrypi"
 
+RDEPENDS_${PN} = "\
+    python-logging \
+    python-threading \
+"
+
 SRC_URI[md5sum] = "cefc45422833dcafcd59b78dffc540f4"
 SRC_URI[sha256sum] = "b89f75dec9de354681209ebfaedfe22b7c178aacd91a604a7bd6d92024e4cf7e"


### PR DESCRIPTION
[GitHub Ticket #98 - rpio requires the logging and threading Python
packages but does not RDEPENDS them in recipe]

The rpio tool needs the Python logging and threading packages installed
on the target system for it to work.  The packages are not included when
doing a rpi-basci-image.  This change updates the recipe so that all the
required dependencies of the prio script are identified by the recipie.

Fixes #98 

Signed-off-by: Thomas A F Thorne <TafThorne@GoogleMail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

** What I did **

Ensured all dependencies are met for the prio script.

** How I did it **

Updated the recipe to indicate the missing dependencies.

This is the second pull request that addresses this issue.  I made a mess of pull request #99 and could not cleanly get it to sit ontop of master.  
