### PR TITLE
Update kernel & firmware

### DIFF
--- a/recipes-bsp/common/firmware.inc
+++ b/recipes-bsp/common/firmware.inc
@@ -1,10 +1,10 @@
-RPIFW_DATE ?= "20170405"
+RPIFW_DATE ?= "20170811"
 RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/1.${RPIFW_DATE}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/firmware-1.${RPIFW_DATE}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[md5sum] = "ea82d14a7cd8cfae9b78e00d4e56bc71"
-SRC_URI[sha256sum] = "2f4e5bddbac1372590db203002c35cbba3fb9d6172a93c314ee27bf05ae13bff"
+SRC_URI[md5sum] = "afd09f9a6df14e32b6d832fd9f51d087"
+SRC_URI[sha256sum] = "a25f6281d64732892a2e838cc2346f1a88505b5c77a57a6540755362ea64043a"
 
 PV = "${RPIFW_DATE}"
 

--- a/recipes-kernel/linux/linux-raspberrypi_4.9.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.9.bb
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
-LINUX_VERSION ?= "4.9.35"
+LINUX_VERSION ?= "4.9.41"
 
-SRCREV = "be2540e540f5442d7b372208787fb64100af0c54"
+SRCREV = "4153f509b449f1c1c816cf124c314975c3daa824"
 SRC_URI = "git://github.com/raspberrypi/linux.git;branch=rpi-4.9.y"
 
 require linux-raspberrypi.inc


### PR DESCRIPTION
Both the Linux kernel and the rpi firmware are updated to the latest tags dated 2017-08-11.