### PR TITLE
raspberrypi0-wifi.conf: change to refer to raspberrypi0.conf

### DIFF
--- a/conf/machine/raspberrypi0-wifi.conf
+++ b/conf/machine/raspberrypi0-wifi.conf
@@ -2,14 +2,8 @@
 #@NAME: RaspberryPi Zero WiFi Development Board
 #@DESCRIPTION: Machine configuration for the RaspberryPi Zero  WiFi board (https://www.raspberrypi.org/blog/raspberry-pi-zero-w-joins-family/)
 
-DEFAULTTUNE ?= "arm1176jzfshf"
-require conf/machine/include/tune-arm1176jzf-s.inc
-include conf/machine/include/rpi-base.inc
+SERIAL_CONSOLE ?= "115200 ttyS0"
 
 MACHINE_EXTRA_RRECOMMENDS += "linux-firmware-bcm43430"
 
-SDIMG_KERNELIMAGE ?= "kernel.img"
-KERNEL_DEFCONFIG ?= "bcmrpi_defconfig"
-UBOOT_MACHINE ?= "rpi_config"
-SERIAL_CONSOLE ?= "115200 ttyS0"
-VC4_CMA_SIZE ?= "cma-128"
+include conf/machine/raspberrypi0.conf


### PR DESCRIPTION
do_kernel_configme is failed at building the kernel for raspberrypi0-wifi in master branch.

It seems based on raspberrypi3.conf.
But We think that it is more like raspberrypi0 than raspberrypi3.

So, We change raspberrypi0-wifi.conf to refer to raspberrypi0.conf.

Signed-off-by: Yusuke Mitsuki <mickey.happygolucky@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
I changed raspberrypi0-wifi.conf to avoiding the build error.

**- How I did it**

