### PR TITLE
weston: remove rpi-backend configuration switch

### DIFF
--- a/recipes-graphics/wayland/weston_%.bbappend
+++ b/recipes-graphics/wayland/weston_%.bbappend
@@ -4,9 +4,7 @@ EXTRA_OECONF_append_rpi = " \
     --disable-xwayland-test \
     --disable-simple-egl-clients \
     ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' \
-        --enable-rpi-compositor \
         --disable-resize-optimization \
         --disable-setuid-install \
-        WESTON_NATIVE_BACKEND=rpi-backend.so \
     ', d)} \
 "


### PR DESCRIPTION
rpi-backend.so was an attempt to create a specialized
weston backend to be used on raspberry pi like platforms.

At the moment, this backend's support has been dropped in favor
of using the standard drm backend, as the vc4 driver is now mainline
in mesa and in kernel (for kernel support).

As a result, weston on raspberry pi does not require the rpi-backend.so
anymore, nor it is buildable (weston's configure complains about
unrecognized configuration switch).

This patch enables weston to natively run on the DRM backend.

Signed-off-by: Francesco Giancane <francescogiancane8@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
