### PR TITLE
Fix HDMI output issues on raspberrypi3-64

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -133,9 +133,6 @@ do_deploy_append_raspberrypi3-64() {
     echo "# have a properly sized image" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     echo "disable_overscan=1" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
 
-    echo "# for sound over HDMI" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-    echo "hdmi_drive=2" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-
     echo "# Enable audio (loads snd_bcm2835)" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     echo "dtparam=audio=on" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
 

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -146,7 +146,6 @@ do_configure_prepend() {
         kernel_configure_variable DRM y
         kernel_configure_variable DRM_FBDEV_EMULATION y
         kernel_configure_variable DRM_VC4 y
-        kernel_configure_variable FB_BCM2708 n
     fi
 
     # Keep this the last line


### PR DESCRIPTION
These changes fix the HDMI output issues I've been facing with raspberrypi3-64 and a DVI monitor (connected via a HDMI to DVI cable).