### PR TITLE
Backports for pyro

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -73,7 +73,7 @@ SDIMG = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.rpi-sdimg"
 FATPAYLOAD ?= ""
 
 # SD card vfat partition image name
-SDIMG_VFAT = "${IMGDEPLOYDIR}/${IMAGE_NAME}.vfat"
+SDIMG_VFAT = "${IMAGE_NAME}.vfat"
 SDIMG_LINK_VFAT = "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.vfat"
 
 IMAGE_CMD_rpi-sdimg () {
@@ -152,7 +152,7 @@ IMAGE_CMD_rpi-sdimg () {
         # Deploy vfat partition (for u-boot case only)
         case "${KERNEL_IMAGETYPE}" in
         "uImage")
-                cp ${WORKDIR}/boot.img ${SDIMG_VFAT}
+                cp ${WORKDIR}/boot.img ${IMGDEPLOYDIR}/${SDIMG_VFAT}
                 ln -sf ${SDIMG_VFAT} ${SDIMG_LINK_VFAT}
                 ;;
         *)

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -83,9 +83,9 @@ def make_dtb_boot_files(d):
 
 IMAGE_BOOT_FILES ?= "bcm2835-bootfiles/* \
                  ${@make_dtb_boot_files(d)} \
-                 ${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', '${KERNEL_IMAGETYPE}', '${KERNEL_IMAGETYPE};${SDIMG_KERNELIMAGE}', d)} \
-                 ${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', 'u-boot.bin;${SDIMG_KERNELIMAGE}', '', d)} \
-                 ${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', 'boot.scr;boot.scr', '', d)} \
+                 ${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', \
+                    '${KERNEL_IMAGETYPE} u-boot.bin;${SDIMG_KERNELIMAGE} boot.scr', \
+                    '${KERNEL_IMAGETYPE};${SDIMG_KERNELIMAGE}', d)} \
                  "
 
 # The kernel image is installed into the FAT32 boot partition and does not need

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -83,7 +83,9 @@ def make_dtb_boot_files(d):
 
 IMAGE_BOOT_FILES ?= "bcm2835-bootfiles/* \
                  ${@make_dtb_boot_files(d)} \
-                 ${KERNEL_IMAGETYPE};${SDIMG_KERNELIMAGE} \
+                 ${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', '${KERNEL_IMAGETYPE}', '${KERNEL_IMAGETYPE};${SDIMG_KERNELIMAGE}', d)} \
+                 ${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', 'u-boot.bin;${SDIMG_KERNELIMAGE}', '', d)} \
+                 ${@bb.utils.contains('KERNEL_IMAGETYPE', 'uImage', 'boot.scr;boot.scr', '', d)} \
                  "
 
 # The kernel image is installed into the FAT32 boot partition and does not need

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -87,6 +87,10 @@ IMAGE_BOOT_FILES ?= "bcm2835-bootfiles/* \
                     '${KERNEL_IMAGETYPE} u-boot.bin;${SDIMG_KERNELIMAGE} boot.scr', \
                     '${KERNEL_IMAGETYPE};${SDIMG_KERNELIMAGE}', d)} \
                  "
+do_image_wic[depends] += " \
+    bcm2835-bootfiles:do_deploy \
+    ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
+    "
 
 # The kernel image is installed into the FAT32 boot partition and does not need
 # to also be installed into the rootfs.

--- a/recipes-kernel/linux/linux-raspberrypi_4.9.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.9.bb
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
-LINUX_VERSION ?= "4.9.41"
+LINUX_VERSION ?= "4.9.50"
 
-SRCREV = "4153f509b449f1c1c816cf124c314975c3daa824"
+SRCREV = "46e2d4d1bd2c17e2f84dd90768321ee0bbaa6b8a"
 SRC_URI = "git://github.com/raspberrypi/linux.git;branch=rpi-4.9.y"
 
 require linux-raspberrypi.inc


### PR DESCRIPTION
The following changes from master are backported:

* Update linux-raspberrypi to v4.9.50.

* Fix path used in symlink when deploying the vfat boot partition image.

* Fix wic image creation.