### PR TITLE
userland package is the Raspberry Pi 3 provider for the openGL stack.

### DIFF
--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -10,7 +10,7 @@ PR = "r5"
 PROVIDES = "virtual/libgles2 \
             virtual/egl"
 
-RPROVIDES_${PN} += "libgles2 egl"
+RPROVIDES_${PN} += "libgles2 egl libegl"
 
 COMPATIBLE_MACHINE = "^rpi$"
 


### PR DESCRIPTION
If selected, it shall provide the gles2 and egl stacks in conjunction
with mesa-gl.

libegl was missing in the RPROVIDES variable, thus some run-time
dependencies were not met when using userland as provider.

Signed-off-by: Francesco Giancane <francescogiancane8@gmail.com>
