### PR TITLE
Fix raspberrypi3-64 kernel Image.

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -51,7 +51,7 @@ KERNEL_DEVICETREE ?= " \
 #   within u-boot to load the kernel.
 KERNEL_BOOTCMD ??= "bootm"
 KERNEL_IMAGETYPE_UBOOT ??= "uImage"
-KERNEL_IMAGETYPE ?= "${@bb.utils.contains('RPI_USE_U_BOOT', '1', '${KERNEL_IMAGETYPE_UBOOT}', 'zImage', d)}"
+KERNEL_IMAGETYPE ??= "${@bb.utils.contains('RPI_USE_U_BOOT', '1', '${KERNEL_IMAGETYPE_UBOOT}', 'zImage', d)}"
 
 MACHINE_FEATURES += "apm usbhost keyboard vfat ext2 screen touchscreen alsa bluetooth wifi sdio"
 

--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -43,4 +43,6 @@ MACHINE_FEATURES_append = " vc4graphics"
 # When u-boot is enabled we need to use the "Image" format and the "booti"
 # command to load the kernel
 KERNEL_IMAGETYPE_UBOOT ?= "Image"
+# "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet
+KERNEL_IMAGETYPE ?= "Image"
 KERNEL_BOOTCMD ?= "booti"


### PR DESCRIPTION
Fix: 50fd319205d8 for raspberrypi3-64.
Set default kernel image to "Image" because compressed images "zImage"
are not supported by arm64 platforms.
".gz" images are not handled by bootloader yet.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>
