### PR TITLE
linux-raspberrypi: fix build with devtool

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -152,8 +152,6 @@ do_configure_prepend() {
     # Remove all modified configs and add the rest to .config
     sed -e "${CONF_SED_SCRIPT}" < '${B}/.config.patched' >> '${B}/.config'
     rm -f ${B}/.config.patched
-
-    yes '' | oe_runmake oldconfig
 }
 
 do_compile_append_raspberrypi3-64() {

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -61,7 +61,43 @@ kernel_configure_variable() {
     fi
 }
 
+config_setup() {
+    # From kernel.bbclass. Unfortunately, this is needed to support builds that
+    # use devtool. The reason is as follows:
+    #
+    # - In devtool builds, externalsrc.bbclass gets inherited and sets a list of
+    # SRCTREECOVEREDTASKS, which don't get run because they affect the source
+    # tree and, when using devtool, we want the developer's changes to be the
+    # single source of truth. kernel-yocto.bbclass adds do_kernel_configme to
+    # SRCTREECOVEREDTASKS, so it doesn't run in a devtool build., In a normal
+    # non-devtool build, do_kernel_configme creates ${B}.config.
+    #
+    # - Normally (e.g. in linux-yocto), it would be OK that do_kernel_configme
+    # doesn't run, because the first few lines of do_configure in kernel.bbclass
+    # populate ${B}.config from either ${S}.config (if it exists) for custom
+    # developer changes, or otherwise from ${WORDIR}/defconfig.
+    #
+    # - In linux-raspberrypi, we add do_configure_prepend, which tweaks
+    # ${B}.config. Since this runs *before* the kernel.bbclass do_configure,
+    # ${B}.config doesn't yet exist and we hit an error. Thus we need to move
+    # the logic from do_configure up to before our do_configure_prepend. Because
+    # we are copying only a portion of do_configure and not the whole thing,
+    # there is no clean way to do it using OE functionality, so we just
+    # copy-and-paste.
+    if [ "${S}" != "${B}" ] && [ -f "${S}/.config" ] && [ ! -f "${B}/.config" ]; then
+        mv "${S}/.config" "${B}/.config"
+    fi
+
+    # Copy defconfig to .config if .config does not exist. This allows
+    # recipes to manage the .config themselves in do_configure_prepend().
+    if [ -f "${WORKDIR}/defconfig" ] && [ ! -f "${B}/.config" ]; then
+        cp "${WORKDIR}/defconfig" "${B}/.config"
+    fi
+}
+
 do_configure_prepend() {
+    config_setup
+
     mv -f ${B}/.config ${B}/.config.patched
     CONF_SED_SCRIPT=""
 


### PR DESCRIPTION
Currently, building linux-raspberrypi with "devtool build" breaks
because the do_configure_prepend function assumes that ${S} == ${B}.
Thus it tries to touch ${B}.config, but ${B}.config does not exist yet.
${S}.config. It will get created in the kernel_do_configure function in
kernel.bbclass, but that code hasn't happened yet.

Thus the correct workflow is:

(1) Copy ${WORKDIR}/defconfig to ${B}.config
(2) Tweak ${B}.config
(3) Run configure

Since we need to add (2) in between (1) and (3), and since (1) and (3)
are in kernel_do_configure (in kernel.bbclass), there's no good way to
use prepend or append. So, we add step (1) at the start of (2).

This fixes #49.

Signed-off-by: Martin Kelly <mkelly@xevo.com>