### PR TITLE
rpi-base.inc: Fix KERNEL_IMAGETYPE assignment

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -51,7 +51,9 @@ KERNEL_DEVICETREE ?= " \
 #   within u-boot to load the kernel.
 KERNEL_BOOTCMD ??= "bootm"
 KERNEL_IMAGETYPE_UBOOT ??= "uImage"
-KERNEL_IMAGETYPE ??= "${@bb.utils.contains('RPI_USE_U_BOOT', '1', '${KERNEL_IMAGETYPE_UBOOT}', 'zImage', d)}"
+KERNEL_IMAGETYPE_DIRECT ??= "zImage"
+KERNEL_IMAGETYPE ?= "${@bb.utils.contains('RPI_USE_U_BOOT', '1', \
+        '${KERNEL_IMAGETYPE_UBOOT}', '${KERNEL_IMAGETYPE_DIRECT}', d)}"
 
 MACHINE_FEATURES += "apm usbhost keyboard vfat ext2 screen touchscreen alsa bluetooth wifi sdio"
 

--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -44,5 +44,5 @@ MACHINE_FEATURES_append = " vc4graphics"
 # command to load the kernel
 KERNEL_IMAGETYPE_UBOOT ?= "Image"
 # "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet
-KERNEL_IMAGETYPE ?= "Image"
+KERNEL_IMAGETYPE_DIRECT ?= "Image"
 KERNEL_BOOTCMD ?= "booti"


### PR DESCRIPTION
We can't just override KERNEL_IMAGETYPE in machine-specific conf files without
breaking the implementation of RPI_USE_U_BOOT. Instead we need to define a new
KERNEL_IMAGETYPE_DIRECT variable which will control the value when u-boot is not
in use. This new variable may then be overridden as needed without breaking our
u-boot support.