### PR TITLE
WIP: changes to fix sdcard_image-rpi.bbclass for DISTROs with modified KERNEL_IMAGE_SYMLINK_NAME

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -56,6 +56,7 @@ do_image_rpi_sdimg[depends] = " \
 			virtual/kernel:do_deploy \
 			${IMAGE_BOOTLOADER}:do_deploy \
 			${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
+			${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'rpi-u-boot-scr:do_deploy', '',d)} \
 			"
 
 # SD card image name

--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -77,6 +77,7 @@ SDIMG_LINK_VFAT = "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.vfat"
 
 def split_overlays(d, out, ver=None):
     dts = d.getVar("KERNEL_DEVICETREE")
+    # Device Tree Overlays are assumed to be suffixed by '-overlay.dtb' (4.1.x) or by '.dtbo' (4.4.9+) string and will be put in a dedicated folder
     if out:
         overlays = oe.utils.str_filter_out('\S+\-overlay\.dtb$', dts, d)
         overlays = oe.utils.str_filter_out('\S+\.dtbo$', overlays, d)
@@ -116,24 +117,17 @@ IMAGE_CMD_rpi-sdimg () {
 	mkfs.vfat -n "${BOOTDD_VOLUME_ID}" -S 512 -C ${WORKDIR}/boot.img $BOOT_BLOCKS
 	mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/* ::/
 	if test -n "${DTS}"; then
-		# Device Tree Overlays are assumed to be suffixed by '-overlay.dtb' (4.1.x) or by '.dtbo' (4.4.9+) string and will be put in a dedicated folder
-		DT_OVERLAYS="${@split_overlays(d, 0)}"
-		DT_ROOT="${@split_overlays(d, 1)}"
-
 		# Copy board device trees to root folder
-		for DTB in $DT_ROOT; do
-			DTB_BASE_NAME=`basename ${DTB} .dtb`
-
-			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${DTB_BASE_NAME}.dtb ::${DTB_BASE_NAME}.dtb
+		for dtbf in ${@split_overlays(d, True)}; do
+			dtb=`basename $dtbf`
+			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::$dtb
 		done
 
 		# Copy device tree overlays to dedicated folder
 		mmd -i ${WORKDIR}/boot.img overlays
-		for DTB in $DT_OVERLAYS; do
-				DTB_EXT=${DTB##*.}
-				DTB_BASE_NAME=`basename ${DTB} ."${DTB_EXT}"`
-
-			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${DTB_BASE_NAME}.${DTB_EXT} ::overlays/${DTB_BASE_NAME}.${DTB_EXT}
+		for dtbf in ${@split_overlays(d, False)}; do
+			dtb=`basename $dtbf`
+			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::overlays/$dtb
 		done
 	fi
         if [ "${RPI_USE_U_BOOT}" = "1" ]; then

--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -28,9 +28,6 @@ IMAGE_TYPEDEP_rpi-sdimg = "${SDIMG_ROOTFS_TYPE}"
 # Set kernel and boot loader
 IMAGE_BOOTLOADER ?= "bcm2835-bootfiles"
 
-# Set initramfs extension
-KERNEL_INITRAMFS ?= ""
-
 # Kernel image name
 SDIMG_KERNELIMAGE_raspberrypi  ?= "kernel.img"
 SDIMG_KERNELIMAGE_raspberrypi2 ?= "kernel7.img"
@@ -48,6 +45,9 @@ IMAGE_ROOTFS_ALIGNMENT = "4096"
 # Use an uncompressed ext3 by default as rootfs
 SDIMG_ROOTFS_TYPE ?= "ext3"
 SDIMG_ROOTFS = "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${SDIMG_ROOTFS_TYPE}"
+
+# For the names of kernel artifacts
+inherit kernel-artifact-names
 
 do_image_rpi_sdimg[depends] = " \
 			parted-native:do_populate_sysroot \
@@ -132,10 +132,18 @@ IMAGE_CMD_rpi-sdimg () {
 	fi
         if [ "${RPI_USE_U_BOOT}" = "1" ]; then
 		mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/u-boot.bin ::${SDIMG_KERNELIMAGE}
-		mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin ::${KERNEL_IMAGETYPE}
 		mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/boot.scr ::boot.scr
+		if [ ! -z "${INITRAMFS_IMAGE}" -a x"${INITRAMFS_IMAGE_BUNDLE}" = x1 ]; then
+			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${INITRAMFS_SYMLINK_NAME}.bin ::${KERNEL_IMAGETYPE}
+		else
+			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE} ::${KERNEL_IMAGETYPE}
+		fi
 	else
-		mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin ::${SDIMG_KERNELIMAGE}
+		if [ ! -z "${INITRAMFS_IMAGE}" -a x"${INITRAMFS_IMAGE_BUNDLE}" = x1 ]; then
+			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${INITRAMFS_SYMLINK_NAME}.bin ::${SDIMG_KERNELIMAGE}
+		else
+			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE} ::${SDIMG_KERNELIMAGE}
+		fi
 	fi
 
 	if [ -n ${FATPAYLOAD} ] ; then

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -125,9 +125,6 @@ To build an initramfs image:
   - `INITRAMFS_IMAGE = "<a name for your initramfs image>"`
   - `INITRAMFS_IMAGE_BUNDLE = "1"`
 
-* Set the meta-rasberrypi variable (in raspberrypi.conf for example)
-  - `KERNEL_INITRAMFS = "-initramfs"`
-
 ## Enable SPI bus
 
 When using device tree kernels, set this variable to enable the SPI bus:

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -38,8 +38,6 @@ UDEV_GE_141 ?= "1"
 # Enable OABI compat for people stuck with obsolete userspace
 ARM_KEEP_OABI ?= "1"
 
-KERNEL_INITRAMFS ?= '${@oe.utils.conditional("INITRAMFS_IMAGE_BUNDLE", "1", "1", "", d)}'
-
 KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "stmpe-ts", "", d)}"
 
 # A LOADADDR is needed when building a uImage format kernel. This value is not
@@ -162,7 +160,7 @@ do_configure_prepend() {
         kernel_configure_variable ROOT_NFS y
         kernel_configure_variable CMDLINE "\"${CMDLINE_NFSROOT_USB}\""
     fi
-    if [ ! -z "${KERNEL_INITRAMFS}" ]; then
+    if [ "${@oe.utils.conditional('INITRAMFS_IMAGE_BUNDLE', '1', 'True', 'False', d)}" ]; then
         kernel_configure_variable BLK_DEV_INITRD y
         kernel_configure_variable INITRAMFS_SOURCE ""
         kernel_configure_variable RD_GZIP y


### PR DESCRIPTION
2 changes to simplify installing DTB files (this might be backwards compatible) and to remove probably broken KERNEL_INITRAMFS variable and replace it with INITRAMFS_SYMLINK_NAME (which needs new bbclass from oe-core).