### PR TITLE
base-files: add 'i2c_dev' to auto loaded modules

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,9 @@
+do_install_append_rpi () {
+    # ensure that files and directories are created as required
+    mkdir -p ${D}${sysconfdir}/modules-load.d/
+    touch ${D}${sysconfdir}/modules-load.d/i2c_dev.conf
+    cat >> ${D}${sysconfdir}/modules-load.d/i2c_dev.conf <<EOF
+# Autoload i2c_dev
+i2c_dev
+EOF
+}


### PR DESCRIPTION
the Kernel module i2c_dev is required in order to be able
to successfully interact with the i2c buses on the Raspberry's
expansion pins.
Putting this module in modules-load.d, we ensure that the i2c
subsystem is properly loaded, so whenever the i2c buses are
enabled in config.txt, udev will be able to create the
necessary device nodes in /dev.

This very same file is also present on Raspian official distro.

Signed-off-by: Francesco Giancane <francescogiancane8@gmail.com>

If I remember well, there is also a Kernel class variable to solve this issue. Let's discuss; if hand-crafting the file is not appropriate, I will fix the patch in a properly manner.