### PR TITLE
Added sample configuration and a new image

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -1,0 +1,19 @@
+# POKY_BBLAYERS_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+POKY_BBLAYERS_CONF_VERSION = "2"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+    ##COREBASE##/meta \
+    ##COREBASE##/meta-poky \
+    ##COREBASE##/../meta-openembedded/meta-oe \
+    ##COREBASE##/../meta-openembedded/meta-multimedia \
+    ##COREBASE##/../meta-openembedded/meta-networking \
+    ##COREBASE##/../meta-openembedded/meta-webserver \
+    ##COREBASE##/../meta-openembedded/meta-python \
+    ##COREBASE##/../meta-qt5 \
+    ##COREBASE##/../meta-raspberrypi \
+  "
+

--- a/conf/conf-notes.txt
+++ b/conf/conf-notes.txt
@@ -1,0 +1,7 @@
+Some custom targets are
+
+    rpi-basic-image
+    rpi-hwup-image
+    rpi-test-image
+    rpi-av-image
+

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -1,0 +1,51 @@
+MACHINE ??= "raspberrypi3"
+
+DL_DIR ?= "${TOPDIR}/downloads"
+SSTATE_DIR ?= "${TOPDIR}/sstate-cache"
+TMPDIR = "${TOPDIR}/tmp"
+
+DISTRO ?= "poky"
+DISTRO_FEATURES_append = " pam egl gles"
+DISTRO_FEATURES_remove = " x11 wayland vulkan"
+
+PACKAGE_CLASSES ?= "package_ipk"
+
+# SDK target architecture
+#SDKMACHINE ?= "x86_64"
+
+EXTRA_IMAGE_FEATURES ?= "debug-tweaks dev-pkgs tools-sdk tools-profile tools-testapps"
+
+USER_CLASSES ?= "buildstats image-mklibs image-prelink"
+
+OE_TERMINAL = "auto"
+
+PATCHRESOLVE = "noop"
+
+BB_DISKMON_DIRS = "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    STOPTASKS,/tmp,100M,100K \
+    ABORT,${TMPDIR},100M,1K \
+    ABORT,${DL_DIR},100M,1K \
+    ABORT,${SSTATE_DIR},100M,1K \
+    ABORT,/tmp,10M,1K"
+
+CONF_VERSION = "1"
+
+BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"
+PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
+
+RM_OLD_IMAGE = "1"
+# INHERIT += "rm_work"
+
+LICENSE_FLAGS_WHITELIST = "commercial"
+
+ENABLE_UART = "1"
+ENABLE_RPI3_SERIAL_CONSOLE = "1"
+ENABLE_SPI_BUS = "1"
+ENABLE_I2C = "1"
+
+GPU_MEM = "128"
+VIDEO_CAMERA = "1"
+

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -13,7 +13,7 @@ PACKAGE_CLASSES ?= "package_ipk"
 # SDK target architecture
 #SDKMACHINE ?= "x86_64"
 
-EXTRA_IMAGE_FEATURES ?= "debug-tweaks dev-pkgs tools-sdk tools-profile tools-testapps"
+EXTRA_IMAGE_FEATURES ?= "debug-tweaks dev-pkgs tools-sdk tools-profile tools-debug tools-testapps"
 
 USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 

--- a/recipes-core/images/rpi-av-image.bb
+++ b/recipes-core/images/rpi-av-image.bb
@@ -17,6 +17,7 @@ IMAGE_INSTALL_append = " \
 
 # toolbox
 IMAGE_INSTALL_append += " \
+  ntp \
   python-modules \
   python3-modules \
   nano \

--- a/recipes-core/images/rpi-av-image.bb
+++ b/recipes-core/images/rpi-av-image.bb
@@ -1,6 +1,10 @@
 # Base this image on rpi-basic-image
 include rpi-basic-image.bb
 
+IMAGE_FEATURES += " package-management"
+
+IMAGE_LINGUAS = "en-us"
+
 COMPATIBLE_MACHINE = "^rpi$"
 
 OMXPLAYER_rpi = "omxplayer"
@@ -17,7 +21,6 @@ IMAGE_INSTALL_append = " \
 
 # toolbox
 IMAGE_INSTALL_append += " \
-  ntp \
   python-modules \
   python3-modules \
   nano \
@@ -69,7 +72,7 @@ IMAGE_INSTALL_append += " \
   hostapd \
   dnsmasq \
   iptables \
-  rfkill \
+  ntp \
   crda \
   iw \
 "
@@ -86,5 +89,17 @@ IMAGE_INSTALL_append += " \
   lttng-modules \
   lttng-ust \
   babeltrace \
+"
+
+set_date_and_time() {
+  ln -sf /usr/share/zoneinfo/CET ${IMAGE_ROOTFS}/etc/localtime
+  echo "server 3.pool.ntp.org iburst" >> ${IMAGE_ROOTFS}/etc/ntp.conf
+  echo "server 2.pool.ntp.org iburst" >> ${IMAGE_ROOTFS}/etc/ntp.conf
+  echo "server 1.pool.ntp.org iburst" >> ${IMAGE_ROOTFS}/etc/ntp.conf
+  echo "server 0.pool.ntp.org iburst" >> ${IMAGE_ROOTFS}/etc/ntp.conf
+}
+
+ROOTFS_POSTPROCESS_COMMAND += " \
+  set_date_and_time ; \
 "
 

--- a/recipes-core/images/rpi-av-image.bb
+++ b/recipes-core/images/rpi-av-image.bb
@@ -1,0 +1,89 @@
+# Base this image on rpi-basic-image
+include rpi-basic-image.bb
+
+COMPATIBLE_MACHINE = "^rpi$"
+
+OMXPLAYER_rpi = "omxplayer"
+OMXPLAYER_rpi_aarch64 = ""
+
+IMAGE_INSTALL_append = " \
+  packagegroup-core-full-cmdline \
+  packagegroup-gstreamer1.0 \
+  ${OMXPLAYER} \
+  sintel-trailer-480p \
+  sintel-trailer-720p \
+  sintel-trailer-1080p \
+"
+
+# toolbox
+IMAGE_INSTALL_append += " \
+  python-modules \
+  python3-modules \
+  nano \
+  cpufrequtils \
+  strace \
+  perf \
+  tree \
+  htop \
+  tcpdump \
+  i2c-tools \
+  can-utils \
+  usbutils \
+  spitools \
+  iperf3 \
+  stress \
+  cmake \
+  automake \
+  autoconf \
+  git \
+  subversion \
+  wget \
+  e2fsprogs \
+  tzdata \
+  watchdog \
+  start-stop-daemon \
+  logrotate \
+"
+
+IMAGE_INSTALL_append += " v4l-utils"
+
+#IMAGE_INSTALL_append += " \
+#  opencv \
+#  ffmpeg \
+#"
+
+# web server stuff
+IMAGE_INSTALL_append += " \
+  lighttpd \
+  lighttpd-module-fastcgi \
+  php \
+  php-cli \
+"
+
+# for WiFi client & access point
+IMAGE_INSTALL_append += " \
+  linux-firmware-bcm43430 \
+  wireless-tools \
+  wpa-supplicant \
+  hostapd \
+  dnsmasq \
+  iptables \
+  rfkill \
+  crda \
+  iw \
+"
+
+# blueetooth stuff
+IMAGE_INSTALL_append += " \
+  bluez5 \
+  bluez5-noinst-tools \
+"
+
+# lttng tracing tools, see http://lttng.org/docs/
+IMAGE_INSTALL_append += " \
+  lttng-tools \
+  lttng-modules \
+  lttng-ust \
+  babeltrace \
+"
+

--- a/recipes-core/packagegroups/packagegroup-gstreamer1.0.bb
+++ b/recipes-core/packagegroups/packagegroup-gstreamer1.0.bb
@@ -1,0 +1,23 @@
+DESCRIPTION = "RaspberryPi GStreamer Packagegroup"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+inherit packagegroup
+
+COMPATIBLE_MACHINE = "^rpi$"
+
+OMXPLAYER_rpi = "omxplayer"
+OMXPLAYER_rpi_aarch64 = ""
+
+RDEPENDS_${PN} = "\
+  glib-2.0 \
+  gstreamer1.0 \
+  gstreamer1.0-omx \
+  gstreamer1.0-libav \
+  gstreamer1.0-plugins-base \
+  gstreamer1.0-plugins-good \
+  gstreamer1.0-plugins-bad \
+  gstreamer1.0-plugins-ugly \
+  gstreamer1.0-rtsp-server \
+"
+

--- a/recipes-core/packagegroups/packagegroup-qt5.bb
+++ b/recipes-core/packagegroups/packagegroup-qt5.bb
@@ -1,0 +1,27 @@
+DESCRIPTION = "RaspberryPi Qt5 Packagegroup"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+inherit packagegroup
+
+COMPATIBLE_MACHINE = "^rpi$"
+
+RDEPENDS_${PN} = "\
+    qtbase \
+    qt3d \
+    qtcharts \
+    qtdeclarative \
+    qtdeclarative-plugins \
+    qtdeclarative-qmlplugins \
+    qtgraphicaleffects \
+    qtlocation-plugins \
+    qtmultimedia \
+    qtquickcontrols2 \
+    qtsensors-plugins \
+    qtserialbus \
+    qtsvg \
+    qtwebsockets-qmlplugins \
+    qtvirtualkeyboard \
+    qtxmlpatterns \
+"
+

--- a/recipes-multimedia/sample-content/sintel-trailer-1080p.bb
+++ b/recipes-multimedia/sample-content/sintel-trailer-1080p.bb
@@ -1,0 +1,16 @@
+SUMMARY = "Sintel movie - 1080P"
+LICENSE = "CC-BY-3.0"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/CC-BY-3.0;md5=dfa02b5755629022e267f10b9c0a2ab7"
+
+SRC_URI = "https://download.blender.org/durian/trailer/sintel_trailer-1080p.mp4"
+SRC_URI[md5sum] = "bfd19c4e7ad04c72bfb327cf7e6b9576"
+SRC_URI[sha256sum] = "34bbd52a4b89fdf63c8ace50b268da26653a59508288100cd3c23de276db7931"
+
+inherit allarch
+
+do_install() {
+    install -d ${D}${datadir}/movies
+    install -m 0644 ${WORKDIR}/sintel_trailer-1080p.mp4 ${D}${datadir}/movies/
+}
+
+FILES_${PN} += "${datadir}/movies"

--- a/recipes-multimedia/sample-content/sintel-trailer-480p.bb
+++ b/recipes-multimedia/sample-content/sintel-trailer-480p.bb
@@ -1,0 +1,16 @@
+SUMMARY = "Sintel movie - 480P"
+LICENSE = "CC-BY-3.0"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/CC-BY-3.0;md5=dfa02b5755629022e267f10b9c0a2ab7"
+
+SRC_URI = "https://download.blender.org/durian/trailer/sintel_trailer-480p.mp4"
+SRC_URI[md5sum] = "df6ed4bbc93613c68c8525e21bbddf98"
+SRC_URI[sha256sum] = "b670602fa00934ca27c4351bb0efe7ea7a07fae57284e44226025eeed7c51254"
+
+inherit allarch
+
+do_install() {
+    install -d ${D}${datadir}/movies
+    install -m 0644 ${WORKDIR}/sintel_trailer-480p.mp4 ${D}${datadir}/movies/
+}
+
+FILES_${PN} += "${datadir}/movies"

--- a/recipes-multimedia/sample-content/sintel-trailer-720p.bb
+++ b/recipes-multimedia/sample-content/sintel-trailer-720p.bb
@@ -1,0 +1,16 @@
+SUMMARY = "Sintel movie - 720P"
+LICENSE = "CC-BY-3.0"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/CC-BY-3.0;md5=dfa02b5755629022e267f10b9c0a2ab7"
+
+SRC_URI = "https://download.blender.org/durian/trailer/sintel_trailer-720p.mp4"
+SRC_URI[md5sum] = "f62221dc4447d60073335a68cf4ac69f"
+SRC_URI[sha256sum] = "cb0fe73fc0a7d543459996c0cdab730997e6eac1013d3ede18796f777cb7f273"
+
+inherit allarch
+
+do_install() {
+    install -d ${D}${datadir}/movies
+    install -m 0644 ${WORKDIR}/sintel_trailer-720p.mp4 ${D}${datadir}/movies/
+}
+
+FILES_${PN} += "${datadir}/movies"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

I have added sample conf files for images with EGL support but no X11. This makes it more clear (at least to me) how the meta-raspberrypi layer could be used.

I have also added a richer audio+video image rpi-av-image demonstrating the EGL support with gstreamer, OpenGL ES and on-target software development.

First tests with this image are described here: https://github.com/FrankBau/raspi-repo-manifest/wiki/regression-testing

The new image contains smaller .mp4 movies (sintel trailer) in a .mp4 container instead of the often used huge bbb movies in meanwhile outdated .avi format.

I'm using this image an my lab and will continue using it in the foreseeable future.