### PR TITLE
Fix KERNEL vars having no effect on kernel recipes.

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -49,9 +49,9 @@ KERNEL_DEVICETREE ?= " \
 #
 # * When u-boot is enabled use the "uImage" format and the "bootm" command
 #   within u-boot to load the kernel.
-KERNEL_BOOTCMD ??= "bootm"
-KERNEL_IMAGETYPE_UBOOT ??= "uImage"
-KERNEL_IMAGETYPE ??= "${@bb.utils.contains('RPI_USE_U_BOOT', '1', '${KERNEL_IMAGETYPE_UBOOT}', 'zImage', d)}"
+KERNEL_BOOTCMD ?= "bootm"
+KERNEL_IMAGETYPE_UBOOT ?= "uImage"
+KERNEL_IMAGETYPE ?= "${@bb.utils.contains('RPI_USE_U_BOOT', '1', '${KERNEL_IMAGETYPE_UBOOT}', 'zImage', d)}"
 
 MACHINE_FEATURES += "apm usbhost keyboard vfat ext2 screen touchscreen alsa bluetooth wifi sdio"
 

--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -6,6 +6,16 @@ MACHINEOVERRIDES = "raspberrypi3:${MACHINE}"
 
 MACHINE_EXTRA_RRECOMMENDS += "linux-firmware-bcm43430"
 
+# When u-boot is enabled we need to use the "Image" format and the "booti"
+# command to load the kernel. Set this before including rpi-base.inc to
+# ensure that this default is the active one.
+KERNEL_IMAGETYPE_UBOOT ?= "Image"
+# "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet.
+# Set this before including rpi-base.inc to ensure that this default is the
+# active one.
+KERNEL_IMAGETYPE ?= "Image"
+KERNEL_BOOTCMD ?= "booti"
+
 require conf/machine/include/arm/arch-armv8.inc
 include conf/machine/include/rpi-base.inc
 
@@ -39,10 +49,3 @@ VC4_CMA_SIZE ?= "cma-256"
 
 UBOOT_MACHINE = "rpi_3_config"
 MACHINE_FEATURES_append = " vc4graphics"
-
-# When u-boot is enabled we need to use the "Image" format and the "booti"
-# command to load the kernel
-KERNEL_IMAGETYPE_UBOOT ?= "Image"
-# "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet
-KERNEL_IMAGETYPE ?= "Image"
-KERNEL_BOOTCMD ?= "booti"


### PR DESCRIPTION
In 4d3a148b8eaca, a new default to KERNEL_IMAGETYPE_UBOOT was added to
raspberrypi3-64.conf, which means that the generic default had to be
changed from '?=' to '??='. However, this presents a problem when
building the kernel recipes, because the '??=' assignment is no longer
strong enough to win over the '?=' which exists in the upstream
kernel.bbclass file. So instead, turn the assignment back to '?=', and
rely on ordering of include files to get correct assignments for
raspberrypi3-64.

connected to #153.