### PR TITLE
rpio: use https instead of http

### DIFF
--- a/recipes-devtools/python/rpio_0.10.0.bb
+++ b/recipes-devtools/python/rpio_0.10.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://README.rst;beginline=41;endline=53;md5=d5d95d7486a4d9
 
 SRCNAME = "RPIO"
 
-SRC_URI = "http://pypi.python.org/packages/source/R/RPIO/${SRCNAME}-${PV}.tar.gz \
+SRC_URI = "https://pypi.python.org/packages/source/R/RPIO/${SRCNAME}-${PV}.tar.gz \
            file://0001-include-sys-types.h-explicitly-for-getting-caddr_t-d.patch \
            "
 S = "${WORKDIR}/${SRCNAME}-${PV}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
I changed the way to download rpio
On my machine, using morty versions, trying to fetch rpio leaded me to this error:

    WARNING: rpio-0.10.0-r0 do_fetch: Failed to fetch URL http://pypi.python.org/packages/source/R/RPIO/RPIO-0.10.0.tar.gz, attempting MIRRORS if available
    ERROR: rpio-0.10.0-r0 do_fetch: Fetcher failure: Fetch command export SSH_AGENT_PID="2117"; export SSH_AUTH_SOCK="/tmp/ssh-cxc9tur4GQEc/agent.2116"; export PATH="/home/yocto/yocto_topdir/tmp/sysroots-uninative/x86_64-linux/usr/bin:/home/yocto/yocto_topdir/tmp/sysroots/x86_64-linux/usr/bin/python-native:/home/yocto/NEOCORTEX-OS/poky/scripts:/home/yocto/yocto_topdir/tmp/sysroots/x86_64-linux/usr/bin/aarch64-poky-linux:/home/yocto/yocto_topdir/tmp/sysroots/raspberrypi3-64/usr/bin/crossscripts:/home/yocto/yocto_topdir/tmp/sysroots/x86_64-linux/usr/sbin:/home/yocto/yocto_topdir/tmp/sysroots/x86_64-linux/usr/bin:/home/yocto/yocto_topdir/tmp/sysroots/x86_64-linux/sbin:/home/yocto/yocto_topdir/tmp/sysroots/x86_64-linux/bin:/home/yocto/NEOCORTEX-OS/poky/scripts:/home/yocto/NEOCORTEX-OS/poky/bitbake/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"; export HOME="/home/dbensoussan"; /usr/bin/env wget -t 2 -T 30 -nv --passive-ftp --no-check-certificate -P /home/yocto/yocto_topdir/downloads 'http://pypi.python.org/packages/source/R/RPIO/RPIO-0.10.0.tar.gz' --progress=dot -v failed with exit code 8, output:
    --2017-12-08 13:38:55--  http://pypi.python.org/packages/source/R/RPIO/RPIO-0.10.0.tar.gz
    Resolving pypi.python.org (pypi.python.org)... 151.101.200.223, 2a04:4e42:8::223
    Connecting to pypi.python.org (pypi.python.org)|151.101.200.223|:80... connected.
    HTTP request sent, awaiting response... 403 SSL is required
    2017-12-08 13:38:55 ERROR 403: SSL is required.


    ERROR: rpio-0.10.0-r0 do_fetch: Fetcher failure for URL: 'http://pypi.python.org/packages/source/R/RPIO/RPIO-0.10.0.tar.gz'. Unable to fetch URL from any source.
    ERROR: rpio-0.10.0-r0 do_fetch: Function failed: base_do_fetch
    ERROR: Logfile of failure stored in: /home/yocto/yocto_topdir/tmp/work/aarch64-poky-linux/rpio/0.10.0-r0/temp/log.do_fetch.21118
    ERROR: Task (/home/yocto/NEOCORTEX-OS/raspberrypi3-64/../meta-raspberrypi/recipes-devtools/python/rpio_0.10.0.bb:do_fetch) failed with exit code '1'


