### PR TITLE
Minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Yocto BSP layer for the Raspberry Pi boards - <http://www.raspberrypi.org/>.
 ## Quick links
 
 * Git repository web frontend:
-  <http://git.yoctoproject.org/cgit/cgit.cgi/meta-raspberrypi/>
+  <https://github.com/agherzan/meta-raspberrypi>
 * Mailing list (yocto mailing list): <yocto@yoctoproject.org>
 * Issues management (Github Issues):
   <https://github.com/agherzan/meta-raspberrypi/issues>
+* Documentation: <http://meta-raspberrypi.readthedocs.io/en/latest/>
 
 ## Description
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+# html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -186,3 +186,19 @@ RaspberryPi3 will have to explicitely set in local.conf:
 Ref.:
 * <https://github.com/raspberrypi/firmware/issues/553>
 * <https://github.com/RPi-Distro/repo/issues/22>
+
+## Manual additions to config.txt
+
+The `RPI_EXTRA_CONFIG` variable can be used to manually add additional lines to
+the `config.txt` file if there is not a specific option above for the
+configuration you need. To add multiple lines you must include `\n` separators.
+If double-quotes are needed in the lines you are adding you can use single
+quotes around the whole string.
+
+For example, to add a comment containing a double-quote and a configuration
+option:
+
+    RPI_EXTRA_CONFIG = ' \n \
+        # Raspberry Pi 7\" display/touch screen \n \
+        lcd_rotate=2 \n \
+        '

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -127,6 +127,9 @@ do_deploy() {
         echo "hdmi_cvt 1024 600 60 6 0 0 0" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "hdmi_drive=1" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
+
+    # Append extra config if the user has provided any
+    echo "${RPI_EXTRA_CONFIG}" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
 }
 
 do_deploy_append_raspberrypi3-64() {

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -5,8 +5,6 @@ vcos, openmaxil, vchiq_arm, bcm_host, WFC, OpenVG."
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENCE;md5=0448d6488ef8cc380632b1569ee6d196"
 
-PR = "r5"
-
 PROVIDES = "virtual/libgles2 \
             virtual/egl"
 
@@ -17,6 +15,10 @@ COMPATIBLE_MACHINE = "^rpi$"
 SRCBRANCH = "master"
 SRCFORK = "raspberrypi"
 SRCREV = "bc3c52a51315399a9f31ed24049eb4bc81fd1c60"
+
+# Use the date of the above commit as the package version. Update this when
+# SRCREV is changed.
+PV = "20171114"
 
 SRC_URI = "\
     git://github.com/${SRCFORK}/userland.git;protocol=git;branch=${SRCBRANCH} \


### PR DESCRIPTION
* Update quick links in readme

* Add RPI_EXTRA_CONFIG option (#169)

* Use commit date as package version in userland (as discussed on 9b1a796c)

* Allow Read the Docs to use their default theme for the documentation