### PR TITLE
U-boot support for RPi Zero W

### DIFF
--- a/conf/machine/raspberrypi0-wifi.conf
+++ b/conf/machine/raspberrypi0-wifi.conf
@@ -9,6 +9,6 @@ include conf/machine/include/rpi-base.inc
 MACHINE_EXTRA_RRECOMMENDS += "linux-firmware-bcm43430"
 
 SDIMG_KERNELIMAGE ?= "kernel.img"
-UBOOT_MACHINE ?= "rpi_config"
+UBOOT_MACHINE ?= "rpi_0_w_defconfig"
 SERIAL_CONSOLE ?= "115200 ttyS0"
 VC4_CMA_SIZE ?= "cma-128"

--- a/recipes-bsp/u-boot/u-boot/0001-add-support-for-Raspberry-Pi-Zero-W.patch
+++ b/recipes-bsp/u-boot/u-boot/0001-add-support-for-Raspberry-Pi-Zero-W.patch
@@ -1,0 +1,143 @@
+From 8993056fb3d4af4f0cd078df20130d4e7c35c2f7 Mon Sep 17 00:00:00 2001
+From: Dmitry Korunov <dessel.k@gmail.com>
+Date: Sun, 26 Nov 2017 13:38:53 +0400
+Subject: [PATCH 1/1] add support for Raspberry Pi Zero W
+
+Signed-off-by: Dmitry Korunov <dessel.k@gmail.com>
+Signed-off-by: Mirza Krak <mirza.krak@gmail.com>
+Upstream-status: Backport
+---
+ arch/arm/dts/bcm2835-rpi-zero-w.dts | 26 ++++++++++++++++++++++++++
+ arch/arm/mach-bcm283x/Kconfig       | 16 ++++++++++++++++
+ board/raspberrypi/rpi/rpi.c         |  5 +++++
+ configs/rpi_0_w_defconfig           | 28 ++++++++++++++++++++++++++++
+ include/configs/rpi.h               |  2 +-
+ 5 files changed, 76 insertions(+), 1 deletion(-)
+ create mode 100644 arch/arm/dts/bcm2835-rpi-zero-w.dts
+ create mode 100644 configs/rpi_0_w_defconfig
+
+diff --git a/arch/arm/dts/bcm2835-rpi-zero-w.dts b/arch/arm/dts/bcm2835-rpi-zero-w.dts
+new file mode 100644
+index 0000000..7817054
+--- /dev/null
++++ b/arch/arm/dts/bcm2835-rpi-zero-w.dts
+@@ -0,0 +1,26 @@
++/dts-v1/;
++#include "bcm2835.dtsi"
++#include "bcm2835-rpi.dtsi"
++#include "bcm283x-rpi-smsc9512.dtsi"
++#include "bcm283x-rpi-usb-host.dtsi"
++
++/ {
++	compatible = "raspberrypi,model-zero-w", "brcm,bcm2835";
++	model = "Raspberry Pi Zero W";
++
++	leds {
++		act {
++			gpios = <&gpio 47 0>;
++		};
++	};
++};
++
++&uart1 {
++    pinctrl-names = "default";
++    pinctrl-0 = <&uart1_gpio14>;
++    status = "okay";
++};
++
++&hdmi {
++	hpd-gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
++};
+diff --git a/arch/arm/mach-bcm283x/Kconfig b/arch/arm/mach-bcm283x/Kconfig
+index 69f7a46..a78239d 100644
+--- a/arch/arm/mach-bcm283x/Kconfig
++++ b/arch/arm/mach-bcm283x/Kconfig
+@@ -44,6 +44,22 @@ config TARGET_RPI
+ 	  This option creates a build targetting the ARM1176 ISA.
+ 	select BCM2835
+ 
++config TARGET_RPI_0_W
++	bool "Raspberry Pi Zero W"
++	help
++	  Support for all ARM1176-/BCM2835-based Raspberry Pi variants, such as
++	  the RPi Zero model W.
++
++	  This option assumes the VideoCore firmware is configured to use the
++	  mini UART (rather than PL011) for the serial console. This is the
++	  default on the RPi Zero W. To enable the UART console, the following
++	  non-default option must be present in config.txt: enable_uart=1.
++	  This is required for U-Boot to operate correctly, even if you only
++	  care about the HDMI/usbkbd console.
++
++	  This option creates a build targetting the ARMv7/AArch32 ISA.
++	select BCM2835
++
+ config TARGET_RPI_2
+ 	bool "Raspberry Pi 2"
+ 	help
+diff --git a/board/raspberrypi/rpi/rpi.c b/board/raspberrypi/rpi/rpi.c
+index 530f149..3b7a54f 100644
+--- a/board/raspberrypi/rpi/rpi.c
++++ b/board/raspberrypi/rpi/rpi.c
+@@ -105,6 +105,11 @@ static const struct rpi_model rpi_models_new_scheme[] = {
+ 		DTB_DIR "bcm2835-rpi-zero.dtb",
+ 		false,
+ 	},
++	[0xC] = {
++		"Zero W",
++		DTB_DIR "bcm2835-rpi-zero-w.dtb",
++		false,
++	},
+ };
+ 
+ static const struct rpi_model rpi_models_old_scheme[] = {
+diff --git a/configs/rpi_0_w_defconfig b/configs/rpi_0_w_defconfig
+new file mode 100644
+index 0000000..092f378
+--- /dev/null
++++ b/configs/rpi_0_w_defconfig
+@@ -0,0 +1,28 @@
++CONFIG_ARM=y
++CONFIG_ARCH_BCM283X=y
++CONFIG_TARGET_RPI_0_W=y
++CONFIG_DEFAULT_DEVICE_TREE="bcm2835-rpi-zero-w"
++CONFIG_DISTRO_DEFAULTS=y
++CONFIG_OF_BOARD_SETUP=y
++# CONFIG_DISPLAY_CPUINFO is not set
++# CONFIG_DISPLAY_BOARDINFO is not set
++CONFIG_SYS_PROMPT="U-Boot> "
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_FLASH is not set
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_FPGA is not set
++CONFIG_CMD_GPIO=y
++CONFIG_DM_MMC=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_BCM2835=y
++CONFIG_DM_ETH=y
++CONFIG_USB=y
++CONFIG_DM_USB=y
++CONFIG_USB_STORAGE=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_DM_VIDEO=y
++CONFIG_SYS_WHITE_ON_BLACK=y
++CONFIG_CONSOLE_SCROLL_LINES=10
++CONFIG_PHYS_TO_BUS=y
++CONFIG_OF_LIBFDT_OVERLAY=y
+diff --git a/include/configs/rpi.h b/include/configs/rpi.h
+index c499b45..cab8661 100644
+--- a/include/configs/rpi.h
++++ b/include/configs/rpi.h
+@@ -76,7 +76,7 @@
+ #endif
+ 
+ /* Console UART */
+-#ifdef CONFIG_BCM2837
++#if defined (CONFIG_BCM2837) || defined(CONFIG_TARGET_RPI_0_W)
+ #define CONFIG_BCM283X_MU_SERIAL
+ #else
+ #define CONFIG_PL01X_SERIAL
+-- 
+2.1.4
+

--- a/recipes-bsp/u-boot/u-boot/0002-rpi_0_w-Add-configs-consistent-with-RpI3.patch
+++ b/recipes-bsp/u-boot/u-boot/0002-rpi_0_w-Add-configs-consistent-with-RpI3.patch
@@ -1,0 +1,42 @@
+From ee4328553b1a10d2686d60c7b184223b09d76cdc Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Sun, 7 Jan 2018 10:00:10 -0500
+Subject: [PATCH] rpi_0_w: Add configs consistent with RpI3
+
+Upstream-Status: Submitted [https://patchwork.ozlabs.org/patch/856572/]
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ configs/rpi_0_w_defconfig | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/configs/rpi_0_w_defconfig b/configs/rpi_0_w_defconfig
+index 092f378..623aad3 100644
+--- a/configs/rpi_0_w_defconfig
++++ b/configs/rpi_0_w_defconfig
+@@ -11,6 +11,10 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ # CONFIG_CMD_FLASH is not set
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_FAT_INTERFACE="mmc"
++CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
++CONFIG_DM_KEYBOARD=y
+ # CONFIG_CMD_FPGA is not set
+ CONFIG_CMD_GPIO=y
+ CONFIG_DM_MMC=y
+@@ -19,8 +23,11 @@ CONFIG_MMC_SDHCI_BCM2835=y
+ CONFIG_DM_ETH=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_USB_DWC2=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_USB_KEYBOARD=y
++CONFIG_USB_HOST_ETHER=y
++CONFIG_USB_ETHER_SMSC95XX=y
+ CONFIG_DM_VIDEO=y
+ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot:"
 
 SRC_URI_append_rpi = " \
     file://0001-add-support-for-Raspberry-Pi-Zero-W.patch \
+    file://0002-rpi_0_w-Add-configs-consistent-with-RpI3.patch \
 "
 
 RDEPENDS_${PN}_append_rpi = " rpi-u-boot-scr"

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,1 +1,7 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot:"
+
+SRC_URI_append_rpi = " \
+    file://0001-add-support-for-Raspberry-Pi-Zero-W.patch \
+"
+
 RDEPENDS_${PN}_append_rpi = " rpi-u-boot-scr"


### PR DESCRIPTION
This series adds U-boot support for RPi Zero W.

It contains one back-ported patch from upstream U-boot which adds initial support for RPi Zero W, and it contains a patch from @drewmoseley that fixes an issue with DTB forwarding (this patch has also been sent upstream).

I do not have this board and @drewmoseley has helped out testing this series. Further testing is welcome.

This pull-request is based on discussion from #160 


