### PR TITLE
rpi-base.inc: use $KERNEL_PACKAGE_NAME for the kernel package name

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -106,4 +106,4 @@ do_image_wic[depends] += " \
 
 # The kernel image is installed into the FAT32 boot partition and does not need
 # to also be installed into the rootfs.
-RDEPENDS_kernel-base = ""
+RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""


### PR DESCRIPTION
The kernel class is now using $KERNEL_PACKAGE_NAME to set the default
kernel package name in order to allow alternate kernel flavors.

This fixes the following bitbake warning:
Variable key RDEPENDS_${KERNEL_PACKAGE_NAME}-base (${KERNEL_PACKAGE_NAME}-image) replaces original key RDEPENDS_kernel-base ().

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com> 