### PR TITLE
rpi-config: allow VC4DTBO override on raspberrypi3-64

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -21,7 +21,7 @@ PITFT28r="${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "1", "0", d)}"
 PITFT35r="${@bb.utils.contains("MACHINE_FEATURES", "pitft35r", "1", "0", d)}"
 
 VC4GRAPHICS="${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"
-VC4DTBO_raspberrypi3-64 = "vc4-fkms-v3d"
+VC4DTBO_raspberrypi3-64 ?= "vc4-fkms-v3d"
 VC4DTBO ?= "vc4-kms-v3d"
 inherit deploy
 


### PR DESCRIPTION
Allow user to replace VC4DTBO (e.g. vc4-kms-v3d) on raspberrypi3-64.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>