### PR TITLE
linux-firmware: make rpi fw specific to rpi

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,26 +1,26 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS_prepend_rpi := "${THISDIR}/files:"
 
-SRC_URI += " \
-	file://brcmfmac43430-sdio.bin \
-	file://brcmfmac43430-sdio.txt \
-	"
+SRC_URI_append_rpi = " \
+    file://brcmfmac43430-sdio.bin \
+    file://brcmfmac43430-sdio.txt \
+"
 
-do_install_append() {
-	# Overwrite v7.45.41.26 by the one we currently provide in this layer
-	# (v7.45.41.46)
-	local _firmware="brcmfmac43430-sdio.bin"
-	local _oldmd5=9258986488eca9fe5343b0d6fe040f8e
-	if [ "$(md5sum ${D}${nonarch_base_libdir}/firmware/brcm/$_firmware | awk '{print $1}')" != "$_oldmd5" ]; then
-		_firmware=""
-		bbwarn "linux-firmware stopped providing brcmfmac43430 v7.45.41.26."
-	else
-		_firmware="${WORKDIR}/$_firmware"
-	fi
+do_install_append_rpi() {
+    # Overwrite v7.45.41.26 by the one we currently provide in this layer
+    # (v7.45.41.46)
+    local _firmware="brcmfmac43430-sdio.bin"
+    local _oldmd5=9258986488eca9fe5343b0d6fe040f8e
+    if [ "$(md5sum ${D}${nonarch_base_libdir}/firmware/brcm/$_firmware | awk '{print $1}')" != "$_oldmd5" ]; then
+        _firmware=""
+        bbwarn "linux-firmware stopped providing brcmfmac43430 v7.45.41.26."
+    else
+        _firmware="${WORKDIR}/$_firmware"
+    fi
 
-	mkdir -p ${D}/${nonarch_base_libdir}/firmware/brcm
-	install -m 0644 $_firmware ${WORKDIR}/brcmfmac43430-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm
+    mkdir -p ${D}/${nonarch_base_libdir}/firmware/brcm
+    install -m 0644 $_firmware ${WORKDIR}/brcmfmac43430-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm
 }
 
-FILES_${PN}-bcm43430 += " \
-	${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.txt \
+FILES_${PN}-bcm43430_rpi += " \
+    ${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.txt \
 "


### PR DESCRIPTION
Currently, we are installing the rpi custom txt and fw files whenever
the meta-raspberrypi layer is included in bblayers.conf. This breaks
other machines that need to use the bcm43430 drivers but with alternate
txt or fw files.

Add a MACHINE_FEATURE rpi-bcm43430 and make the linux-firmware.bbappend
conditional upon it. This is not pretty, but it does work and I don't
see a cleaner way to do it.

Signed-off-by: Martin Kelly <mkelly@xevo.com>