### PR TITLE
[kronos]wayland lib linking added for libbrcmEGL to avoid undefined symbol while linking libbrcmEGL.so

### DIFF
--- a/recipes-graphics/userland/userland/0016-WAYLAND-dependency-for-khronos.patch
+++ b/recipes-graphics/userland/userland/0016-WAYLAND-dependency-for-khronos.patch
@@ -1,0 +1,13 @@
+diff --git a/interface/khronos/CMakeLists.txt b/interface/khronos/CMakeLists.txt
+index 3d3571a..2419846 100644
+--- a/interface/khronos/CMakeLists.txt
++++ b/interface/khronos/CMakeLists.txt
+@@ -136,7 +136,7 @@ add_library(brcmGLESv2 ${SHARED} ${GLES_SOURCE})
+ add_library(brcmOpenVG ${SHARED} ${VG_SOURCE})
+ add_library(brcmWFC ${SHARED} ${WFC_SOURCE})
+ 
+-target_link_libraries(brcmEGL khrn_client vchiq_arm vcos bcm_host ${VCSM_LIBS} -lm)
++target_link_libraries(brcmEGL khrn_client vchiq_arm vcos bcm_host ${VCSM_LIBS} -lm ${WAYLAND_SERVER_LIBRARIES} ${WAYLAND_CLIENT_LIBRARIES})
+ target_link_libraries(brcmGLESv2 brcmEGL khrn_client vcos)
+ target_link_libraries(brcmWFC brcmEGL)
+ target_link_libraries(brcmOpenVG brcmEGL)

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -37,6 +37,7 @@ SRC_URI = "\
     file://0013-Implement-triple-buffering-for-wayland.patch \
     file://0014-GLES2-gl2ext.h-Define-GL_R8_EXT-and-GL_RG8_EXT.patch \
     file://0015-EGL-glplatform.h-define-EGL_CAST.patch \
+    file://0016-WAYLAND-dependency-for-khronos.patch \
 "
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
In wayland enabled build libbrcmEGL lib is using wayland functions, but during the build it is not linking with wayland libraries. Hence if we try to link libbrcmEGL, will get undefined symbols. 

I have created patch against userland libbrcmEGL.so creation part to include wayland libraries also int he linking list

