### PR TITLE
[linux-firmare] fix addition of NVRAM file to image (fixes #184)

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -21,6 +21,6 @@ do_install_append_rpi() {
     install -m 0644 $_firmware ${WORKDIR}/brcmfmac43430-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm
 }
 
-FILES_${PN}-bcm43430_rpi += " \
+FILES_${PN}-bcm43430_append_rpi = " \
     ${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.txt \
 "


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->
This PR fixes #184, where the Wifi module is not brought up because of missing firmware file.

**- What I did**
The NVRAM text file for the BCM firmware was not properly added in the built image. This is because the recipe `recipes-kernel/linux-firmware/linux-firmware_%.bbappend` is using `+=` for adding the extra file instead of `_append` in `FILES_${PN}-bcm43430`.
This results in only the NVRAM text file being added to the built image and not the firmware binary file (`.bin`), causing the Wifi module to not work.
I tested the images also enabling the bluetooth module (as discussed in #184) to ensure this doesn't interfere with other connectivity components.
After this fix, both files (`.txt` and `.bin`) of the firmware are now correctly installed in `/lib/firmware`.

**- How I did it**
I simply replaced the `+=` construction with an `_append` construction as seen in the PR.