### PR TITLE
u-boot: Update RPi Zero W defconfig to support DTB.

### DIFF
--- a/recipes-bsp/u-boot/u-boot/0002-rpi_0_w-Add-configs-consistent-with-RpI3.patch
+++ b/recipes-bsp/u-boot/u-boot/0002-rpi_0_w-Add-configs-consistent-with-RpI3.patch
@@ -1,0 +1,41 @@
+From 5d113dc0130ea2ea9faaa000fba9c737266b9747 Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Fri, 9 Feb 2018 18:10:09 -0500
+Subject: [PATCH] rpi_0_w: Add configs consistent with RpI3
+
+Upstream-Status: Accepted [https://patchwork.ozlabs.org/patch/856572/]
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ configs/rpi_0_w_defconfig | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/configs/rpi_0_w_defconfig b/configs/rpi_0_w_defconfig
+index 9a6d24b..1248294 100644
+--- a/configs/rpi_0_w_defconfig
++++ b/configs/rpi_0_w_defconfig
+@@ -12,14 +12,21 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_FAT_INTERFACE="mmc"
++CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
++CONFIG_DM_KEYBOARD=y
+ CONFIG_DM_MMC=y
+ CONFIG_MMC_SDHCI=y
+ CONFIG_MMC_SDHCI_BCM2835=y
+ CONFIG_DM_ETH=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_USB_DWC2=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_USB_KEYBOARD=y
++CONFIG_USB_HOST_ETHER=y
++CONFIG_USB_ETHER_SMSC95XX=y
+ CONFIG_DM_VIDEO=y
+ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,1 +1,7 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot:"
+
+SRC_URI_append_rpi = " \
+    file://0002-rpi_0_w-Add-configs-consistent-with-RpI3.patch \
+"
+
 RDEPENDS_${PN}_append_rpi = " rpi-u-boot-scr"


### PR DESCRIPTION
This makes the defconfig more consistent with the RPi 3 and
CONFIG_OF_EMBED is needed to get the RPi firmware provided
DTB to function.

Recently removed by:
    a50e19695f2cc655ef6248b77c8244519dbb468c u-boot: drop upstreamed patches in v2018.01
however this change missed the cutoff for v2018.01

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
