### PR TITLE
Kernel updates and other improvements

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -58,6 +58,8 @@ do_image_rpi_sdimg[depends] = " \
 			${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
 			"
 
+do_image_rpi_sdimg[recrdeps] = "do_build"
+
 # SD card image name
 SDIMG = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.rpi-sdimg"
 

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -104,6 +104,8 @@ do_image_wic[depends] += " \
     ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
     "
 
+do_image_wic[recrdeps] = "do_build"
+
 # The kernel image is installed into the FAT32 boot partition and does not need
 # to also be installed into the rootfs.
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""

--- a/conf/machine/include/rpi-default-versions.inc
+++ b/conf/machine/include/rpi-default-versions.inc
@@ -1,3 +1,3 @@
 # RaspberryPi BSP default versions
 
-PREFERRED_VERSION_linux-raspberrypi ??= "4.9.%"
+PREFERRED_VERSION_linux-raspberrypi ??= "4.14.%"

--- a/recipes-bsp/common/firmware.inc
+++ b/recipes-bsp/common/firmware.inc
@@ -1,9 +1,9 @@
-RPIFW_DATE ?= "20171029"
-RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/1.${RPIFW_DATE}.tar.gz"
-RPIFW_S ?= "${WORKDIR}/firmware-1.${RPIFW_DATE}"
+RPIFW_DATE ?= "20180209"
+RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/b1a7f4aea6cbd380319c2849ecc5988f9a4dba70.tar.gz"
+RPIFW_S ?= "${WORKDIR}/firmware-b1a7f4aea6cbd380319c2849ecc5988f9a4dba70"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[md5sum] = "4d27c1888a7bab3097471906e7b4a319"
-SRC_URI[sha256sum] = "46ce28c8d87ef22bdcc57ac1836ca3f04d1ec6f46580ff5a30bf76b3c0822117"
+SRC_URI[md5sum] = "08ed10d92ee064711d73790557267f84"
+SRC_URI[sha256sum] = "0ad8b66c02ba14917dfdc15f11d702da650c473681d100efb3f8d47aee9b8ece"
 PV = "${RPIFW_DATE}"
 

--- a/recipes-core/images/rpi-basic-image.bb
+++ b/recipes-core/images/rpi-basic-image.bb
@@ -4,3 +4,7 @@ include rpi-hwup-image.bb
 SPLASH = "psplash-raspberrypi"
 
 IMAGE_FEATURES += "ssh-server-dropbear splash"
+
+do_image_prepend() {
+    bb.warn("The image 'rpi-basic-image' is deprecated, please use 'core-image-base' instead")
+}

--- a/recipes-core/images/rpi-basic-image.bb
+++ b/recipes-core/images/rpi-basic-image.bb
@@ -1,5 +1,10 @@
-# Base this image on rpi-hwup-image
-include rpi-hwup-image.bb
+# Base this image on core-image-minimal
+include recipes-core/images/core-image-minimal.bb
+
+# Include modules in rootfs
+IMAGE_INSTALL += " \
+	kernel-modules \
+	"
 
 SPLASH = "psplash-raspberrypi"
 

--- a/recipes-core/images/rpi-hwup-image.bb
+++ b/recipes-core/images/rpi-hwup-image.bb
@@ -5,3 +5,7 @@ include recipes-core/images/core-image-minimal.bb
 IMAGE_INSTALL += " \
 	kernel-modules \
 	"
+
+do_image_prepend() {
+    bb.warn("The image 'rpi-hwup-image' is deprecated, please use 'core-image-minimal' instead")
+}

--- a/recipes-core/images/rpi-test-image.bb
+++ b/recipes-core/images/rpi-test-image.bb
@@ -1,5 +1,5 @@
-# Base this image on rpi-basic-image
-include rpi-basic-image.bb
+# Base this image on core-image-base
+include recipes-core/images/core-image-base.bb
 
 COMPATIBLE_MACHINE = "^rpi$"
 

--- a/recipes-devtools/python/rpio_0.10.0.bb
+++ b/recipes-devtools/python/rpio_0.10.0.bb
@@ -5,12 +5,10 @@ SECTION = "devel/python"
 LICENSE = "LGPLv3+"
 LIC_FILES_CHKSUM = "file://README.rst;beginline=41;endline=53;md5=d5d95d7486a4d98c999675c23196b25a"
 
-SRCNAME = "RPIO"
+PYPI_PACKAGE = "RPIO"
+inherit pypi
 
-SRC_URI = "http://pypi.python.org/packages/source/R/RPIO/${SRCNAME}-${PV}.tar.gz \
-           file://0001-include-sys-types.h-explicitly-for-getting-caddr_t-d.patch \
-           "
-S = "${WORKDIR}/${SRCNAME}-${PV}"
+SRC_URI += "file://0001-include-sys-types.h-explicitly-for-getting-caddr_t-d.patch"
 
 inherit setuptools
 

--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -7,8 +7,8 @@ python __anonymous() {
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
-LINUX_VERSION ?= "4.14"
-LINUX_RPI_DEV_BRANCH ?= "rpi-4.14.y"
+LINUX_VERSION ?= "4.15"
+LINUX_RPI_DEV_BRANCH ?= "rpi-4.15.y"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_DEV_BRANCH} \

--- a/recipes-kernel/linux/linux-raspberrypi_4.14.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.14.bb
@@ -1,0 +1,6 @@
+LINUX_VERSION ?= "4.14.22"
+
+SRCREV = "d95cdf3e6a0506e3a728b0c80ae02368779d2768"
+SRC_URI = "git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y"
+
+require linux-raspberrypi.inc

--- a/recipes-kernel/linux/linux-raspberrypi_4.9.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.9.bb
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
-LINUX_VERSION ?= "4.9.77"
+LINUX_VERSION ?= "4.9.80"
 
-SRCREV = "c7b6645458053c75009559e66bd5e3034e82969f"
+SRCREV = "027885087faa515133534cf767a1cd66cbd6cd1e"
 SRC_URI = "git://github.com/raspberrypi/linux.git;branch=rpi-4.9.y"
 
 require linux-raspberrypi.inc


### PR DESCRIPTION
* Fix do_image_rpi_sdimg/do_image_wic dependencies
* rpio: Use pypi.bbclass
* rpi-*-image: Deprecate old image names
* Update kernels to 4.9.80, 4.14.22, 4.15.y
* Update firmware
* Switch default kernel to 4.14.y series

Tested a mix of different distros, images, configurations (with/without u-boot, 4.9.y/4.14.y kernels, etc) and devices (original rpi, rpi2, rpi3, rpi-64). All boots to a login prompt happily :)