### PR TITLE
rpio: Use pypi.bbclass

### DIFF
--- a/recipes-devtools/python/rpio_0.10.0.bb
+++ b/recipes-devtools/python/rpio_0.10.0.bb
@@ -5,12 +5,10 @@ SECTION = "devel/python"
 LICENSE = "LGPLv3+"
 LIC_FILES_CHKSUM = "file://README.rst;beginline=41;endline=53;md5=d5d95d7486a4d98c999675c23196b25a"
 
-SRCNAME = "RPIO"
+PYPI_PACKAGE = "RPIO"
+inherit pypi
 
-SRC_URI = "http://pypi.python.org/packages/source/R/RPIO/${SRCNAME}-${PV}.tar.gz \
-           file://0001-include-sys-types.h-explicitly-for-getting-caddr_t-d.patch \
-           "
-S = "${WORKDIR}/${SRCNAME}-${PV}"
+SRC_URI += "file://0001-include-sys-types.h-explicitly-for-getting-caddr_t-d.patch"
 
 inherit setuptools
 


### PR DESCRIPTION
This should resolve recent issues with the non-https URL in SRC_URI. 
fixes #146

Signed-off-by: Paul Barker <pbarker@toganlabs.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
