### PR TITLE
bluez5: brcm43438: update device dependency

### DIFF
--- a/recipes-connectivity/bluez5/bluez5/brcm43438.service
+++ b/recipes-connectivity/bluez5/bluez5/brcm43438.service
@@ -2,7 +2,7 @@
 Description=Broadcom BCM43438 bluetooth HCI
 ConditionPathIsDirectory=/proc/device-tree/soc/gpio@7e200000/bt_pins
 Before=bluetooth.service
-After=dev-ttyAMA0.device
+After=dev-serial1.device
 
 [Service]
 Type=simple


### PR DESCRIPTION
A previous patch changed the BT serial device to the alias, but did not
update the device dependency resulting in the service failing to start
on boot.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>