### PR TITLE
patches to improve wic support

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -6,6 +6,7 @@ SOC_FAMILY = "rpi"
 include conf/machine/include/soc-family.inc
 
 IMAGE_FSTYPES ?= "tar.bz2 ext3 rpi-sdimg"
+WKS_FILE ?= "sdimage-raspberrypi.wks"
 
 XSERVER = " \
     xserver-xorg \

--- a/wic/sdimage-raspberrypi.wks
+++ b/wic/sdimage-raspberrypi.wks
@@ -2,5 +2,5 @@
 # long-description: Creates a partitioned SD card image for use with
 # Raspberry Pi. Boot files are located in the first vfat partition.
 
-part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 20
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 20
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4096


### PR DESCRIPTION
Many kickstart files used `--on mmcblk` for SD builds, which produces the image but breaks runtime now that wic no longer excludes /boot from the set of partitions added to fstab for mount on boot.  The first commit patches the raspberrypi kickstart file to set the correct device.

The second  commit simply provides a default for `WKS_FILE`, to make it simpler for people to add wic as an image fstype in `local.conf` as with:

    IMAGE_FSTYPES_append = " wic wic.bmap"
