### PR TITLE
Apply -T flag for xz SD image compression to use all available CPU cores

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -183,7 +183,7 @@ IMAGE_CMD_rpi-sdimg () {
 		bzip2 -k9 "${SDIMG}"
 		;;
 	"xz")
-		xz -k "${SDIMG}"
+		xz -T -k "${SDIMG}"
 		;;
 	esac
 }


### PR DESCRIPTION
I need generated SD image compression so I could transfer the image from my build server in a less amount of time. I found out that compression step takes a long time, although my server is very capable. So I have added -T flag for `xz` call to automatically use all available cores and compress an image in least possible time. It makes sense to update all release branches as well, shouldn't break anything.