### PR TITLE
docs: Remove reference to deprecated images

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This layer depends on:
 1. source poky/oe-init-build-env rpi-build
 2. Add this layer to bblayers.conf and the dependencies above
 3. Set MACHINE in local.conf to one of the supported boards
-4. bitbake rpi-hwup-image
+4. bitbake core-image-base
 5. dd to a SD card the generated sdimg file (use xzcat if rpi-sdimg.xz is used)
 6. Boot your RPI.
 

--- a/docs/layer-contents.md
+++ b/docs/layer-contents.md
@@ -13,12 +13,10 @@
 
 ## Images
 
-* rpi-hwup-image
-  * Hardware up image
-
-* rpi-basic-image
-  * Based on rpi-hwup-image with some added features (ex: splash)
-
 * rpi-test-image
-  * Image based on rpi-basic-image which includes most of the packages in this
+  * Image based on core-image-base which includes most of the packages in this
     layer and some media samples.
+
+For other uses it's recommended to base images on `core-image-minimal` or
+`core-image-base` as appropriate. The old image names (`rpi-hwup-image` and
+`rpi-basic-image`) are deprecated.


### PR DESCRIPTION
This finishes the remaining tasks in #199.