### PR TITLE
sdimage-raspberrypi.wks: find /boot partition on mmcblk0

### DIFF
--- a/wic/sdimage-raspberrypi.wks
+++ b/wic/sdimage-raspberrypi.wks
@@ -2,5 +2,5 @@
 # long-description: Creates a partitioned SD card image for use with
 # Raspberry Pi. Boot files are located in the first vfat partition.
 
-part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 20
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 20
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4096


### PR DESCRIPTION
Recently wic was modified to no longer exclude /boot from partitions
added to fstab.  The --on parameter in many kickstart specifications
insufficiently resolved the MMC device, resulting in attempts to mount
/dev/mmcblkp1 as boot when the device should be /dev/mmcblk0p1.

With systemd the mount failure is an error and the system drops into
emergency mode.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>
(cherry picked from commit 0e1e2c6e0aebab8a7536f81dc25f50c0f2f6d518)
Signed-off-by: Phong Tran <tranmanphong@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
For fixing the /boot partition with wic image.
**- How I did it**
Cherry pick from 0e1e2c6 
build and boot fine with AGL distro on rpi3