### PR TITLE
rpi-config: support more commonly used config variables and update documentation

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -32,6 +32,8 @@ Accommodate the values above to your own needs (ex: ext3 / ext4).
 * `GPU_MEM_1024`: GPU memory in megabyte for the 1024MB Raspberry Pi. Ignored by
   the 256MB/512MB RP. Overrides gpu_mem. Max 944. Default not set.
 
+See: <https://www.raspberrypi.org/documentation/configuration/config-txt/memory.md>
+
 ## Add purchased license codecs
 
 To add you own licenses use variables `KEY_DECODE_MPG2` and `KEY_DECODE_WVC1` in
@@ -44,6 +46,7 @@ You can supply more licenses separated by comma. Example:
 
     KEY_DECODE_WVC1 = "0x12345678,0xabcdabcd,0x87654321"
 
+See: <https://www.raspberrypi.org/documentation/configuration/config-txt/codeclicence.md>
 
 ## Disable overscan
 
@@ -53,17 +56,56 @@ local.conf:
 
     DISABLE_OVERSCAN = "1"
 
+## Disable splash screen
+
+By default a rainbow splash screen is shown after the GPU firmware is loaded.
+To disable this set this variable in local.conf:
+
+    DISABLE_SPLASH = "1"
+
+## Boot delay
+
+The Raspberry Pi waits a number of seconds after loading the GPU firmware and
+before loading the kernel. By default it is one second. This is useful if your
+SD card needs a while to get ready before Linux is able to boot from it.
+To remove (or adjust) this delay set these variables in local.conf:
+
+    BOOT_DELAY = "0"
+    BOOT_DELAY_MS = "0"
+
 ## Set overclocking options
 
-The Raspberry PI can be overclocked. As of now overclocking up to the "Turbo
+The Raspberry Pi can be overclocked. As of now overclocking up to the "Turbo
 Mode" is officially supported by the raspbery and does not void warranty. Check
-the config.txt for a detailed description of options and modes. Example turbo
-mode:
+the config.txt for a detailed description of options and modes. The following
+variables are supported in local.conf: `ARM_FREQ`, `GPU_FREQ`, `CORE_FREQ`,
+`SDRAM_FREQ` and `OVER_VOLTAGE`.
+
+Example official settings for Turbo Mode in Raspberry Pi 2:
 
     ARM_FREQ = "1000"
     CORE_FREQ = "500"
     SDRAM_FREQ = "500"
     OVER_VOLTAGE = "6"
+
+See: <https://www.raspberrypi.org/documentation/configuration/config-txt/overclocking.md>
+
+## HDMI and composite video options
+
+The Raspberry Pi can output video over HDMI or SDTV composite (the RCA connector).
+By default the video mode for these is autodetected on boot: the HDMI mode is
+selected according to the connected monitor's EDID information and the composite
+mode is defaulted to NTSC using a 4:3 aspect ratio. Check the config.txt for a
+detailed description of options and modes. The following variables are supported in
+local.conf: `HDMI_FORCE_HOTPLUG`, `HDMI_DRIVE`, `HDMI_GROUP`, `HDMI_MODE`,
+`CONFIG_HDMI_BOOST`, `SDTV_MODE`, `SDTV_ASPECT` and `DISPLAY_ROTATE`.
+
+Example to force HDMI output to 720p in CEA mode:
+
+    HDMI_GROUP = "1"
+    HDMI_MODE = "4"
+
+See: <https://www.raspberrypi.org/documentation/configuration/config-txt/video.md>
 
 ## Video camera support with V4L2 drivers
 

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -39,8 +39,16 @@ do_deploy() {
     if [ -n "${DISABLE_OVERSCAN}" ]; then
         sed -i '/#disable_overscan=/ c\disable_overscan=${DISABLE_OVERSCAN}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
+    if [ -n "${DISABLE_SPLASH}" ]; then
+        sed -i '/#disable_splash=/ c\disable_splash=${DISABLE_SPLASH}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+
+    # Set overclocking options
     if [ -n "${ARM_FREQ}" ]; then
         sed -i '/#arm_freq=/ c\arm_freq=${ARM_FREQ}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+    if [ -n "${GPU_FREQ}" ]; then
+        sed -i '/#gpu_freq=/ c\gpu_freq=${GPU_FREQ}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
     if [ -n "${CORE_FREQ}" ]; then
         sed -i '/#core_freq=/ c\core_freq=${CORE_FREQ}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
@@ -66,6 +74,40 @@ do_deploy() {
         sed -i '/#gpu_mem_1024=/ c\gpu_mem_1024=${GPU_MEM_1024}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
+    # Set boot delay
+    if [ -n "${BOOT_DELAY}" ]; then
+        sed -i '/#boot_delay=/ c\boot_delay=${BOOT_DELAY}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+    if [ -n "${BOOT_DELAY_MS}" ]; then
+        sed -i '/#boot_delay_ms=/ c\boot_delay_ms=${BOOT_DELAY_MS}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+
+    # Set HDMI and composite video options
+    if [ -n "${HDMI_FORCE_HOTPLUG}" ]; then
+        sed -i '/#hdmi_force_hotplug=/ c\hdmi_force_hotplug=${HDMI_FORCE_HOTPLUG}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+    if [ -n "${HDMI_DRIVE}" ]; then
+        sed -i '/#hdmi_drive=/ c\hdmi_drive=${HDMI_DRIVE}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+    if [ -n "${HDMI_GROUP}" ]; then
+        sed -i '/#hdmi_group=/ c\hdmi_group=${HDMI_GROUP}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+    if [ -n "${HDMI_MODE}" ]; then
+        sed -i '/#hdmi_mode=/ c\hdmi_mode=${HDMI_MODE}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+    if [ -n "${CONFIG_HDMI_BOOST}" ]; then
+        sed -i '/#config_hdmi_boost=/ c\config_hdmi_boost=${CONFIG_HDMI_BOOST}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+    if [ -n "${SDTV_MODE}" ]; then
+        sed -i '/#sdtv_mode=/ c\sdtv_mode=${SDTV_MODE}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+    if [ -n "${SDTV_ASPECT}" ]; then
+        sed -i '/#sdtv_aspect=/ c\sdtv_aspect=${SDTV_ASPECT}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+    if [ -n "${DISPLAY_ROTATE}" ]; then
+        sed -i '/#display_rotate=/ c\display_rotate=${DISPLAY_ROTATE}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+
     # Video camera support
     if [ -n "${VIDEO_CAMERA}" ]; then
         echo "# Enable video camera" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
@@ -84,6 +126,7 @@ do_deploy() {
         echo "dtparam=spi=on" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
+    # I2C support
     if [ -n "${ENABLE_I2C}" ] || [ "${PITFT}" = "1" ]; then
         echo "# Enable I2C" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dtparam=i2c1=on" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
@@ -95,12 +138,10 @@ do_deploy() {
         echo "# Enable PITFT22 display" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dtoverlay=pitft22,rotate=270,speed=32000000,txbuflen=32768" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
-
     if [ "${PITFT28r}" = "1" ]; then
         echo "# Enable PITFT28r display" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dtoverlay=pitft28-resistive,rotate=90,speed=32000000,txbuflen=32768" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
-
     if [ "${PITFT35r}" = "1" ]; then
         echo "# Enable PITFT35r display" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dtoverlay=pitft35-resistive,rotate=90,speed=42000000,fps=20" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt


### PR DESCRIPTION
Added support for and documented the following new extra build options:

* gpu_freq overclocking option
* disable boot rainbow splash screen
* configure the boot delay after GPU firmware loading
* configure common HDMI and composite video options

**- What I did**
Implemented new config.txt options in the `rpi-config` recipe.

**- How I did it**
Followed the same logic in the recipe and added new supported options.
Also updated the documentation.