### PR TITLE
Kernel updates, removal of obsolete config and dependency/task cleanup

### DIFF
--- a/recipes-bsp/bootfiles/bcm2835-bootfiles.bb
+++ b/recipes-bsp/bootfiles/bcm2835-bootfiles.bb
@@ -9,7 +9,7 @@ include recipes-bsp/common/firmware.inc
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-RDEPENDS_${PN} = "rpi-config"
+DEPENDS = "rpi-config"
 
 COMPATIBLE_MACHINE = "^rpi$"
 

--- a/recipes-bsp/bootfiles/bcm2835-bootfiles.bb
+++ b/recipes-bsp/bootfiles/bcm2835-bootfiles.bb
@@ -3,9 +3,11 @@ LICENSE = "Proprietary"
 
 LIC_FILES_CHKSUM = "file://LICENCE.broadcom;md5=4a4d169737c0786fb9482bb6d30401d1"
 
-inherit deploy
+inherit deploy nopackages
 
 include recipes-bsp/common/firmware.inc
+
+INHIBIT_DEFAULT_DEPS = "1"
 
 RDEPENDS_${PN} = "rpi-config"
 
@@ -32,7 +34,7 @@ do_deploy() {
     touch ${DEPLOYDIR}/${PN}/${PN}-${PV}.stamp
 }
 
-addtask deploy before do_package after do_install
+addtask deploy before do_build after do_install
 do_deploy[dirs] += "${DEPLOYDIR}/${PN}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -15,6 +15,8 @@ S = "${WORKDIR}/git"
 
 PR = "r5"
 
+INHIBIT_DEFAULT_DEPS = "1"
+
 PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
 PITFT22="${@bb.utils.contains("MACHINE_FEATURES", "pitft22", "1", "0", d)}"
 PITFT28r="${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "1", "0", d)}"
@@ -23,7 +25,8 @@ PITFT35r="${@bb.utils.contains("MACHINE_FEATURES", "pitft35r", "1", "0", d)}"
 VC4GRAPHICS="${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"
 VC4DTBO_raspberrypi3-64 ?= "vc4-fkms-v3d"
 VC4DTBO ?= "vc4-kms-v3d"
-inherit deploy
+
+inherit deploy nopackages
 
 do_deploy() {
     install -d ${DEPLOYDIR}/bcm2835-bootfiles
@@ -185,7 +188,7 @@ do_deploy_append_raspberrypi3-64() {
     echo "device_tree=bcm2710-rpi-3-b.dtb" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
 }
 
-addtask deploy before do_package after do_install
+addtask deploy before do_build after do_install
 do_deploy[dirs] += "${DEPLOYDIR}/bcm2835-bootfiles"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -5,6 +5,8 @@ COMPATIBLE_MACHINE = "^rpi$"
 
 DEPENDS = "u-boot-mkimage-native"
 
+INHIBIT_DEFAULT_DEPS = "1"
+
 SRC_URI = "file://boot.cmd.in"
 
 do_compile() {
@@ -14,7 +16,7 @@ do_compile() {
     mkimage -A arm -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
 }
 
-inherit deploy
+inherit deploy nopackages
 
 do_deploy() {
     install -d ${DEPLOYDIR}

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -4,4 +4,4 @@ SRC_URI_append_rpi = " \
     file://0002-rpi_0_w-Add-configs-consistent-with-RpI3.patch \
 "
 
-RDEPENDS_${PN}_append_rpi = " rpi-u-boot-scr"
+DEPENDS_append_rpi = " rpi-u-boot-scr"

--- a/recipes-core/udev/udev-rules-rpi.bb
+++ b/recipes-core/udev/udev-rules-rpi.bb
@@ -6,6 +6,8 @@ SRC_URI = " file://99-com.rules"
 
 S = "${WORKDIR}"
 
+INHIBIT_DEFAULT_DEPS = "1"
+
 do_install () {
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${WORKDIR}/99-com.rules ${D}${sysconfdir}/udev/rules.d/

--- a/recipes-core/udev/udev-rules-udisks-rpi_1.0.bb
+++ b/recipes-core/udev/udev-rules-udisks-rpi_1.0.bb
@@ -3,6 +3,8 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SRC_URI = "file://80-udisks-rpi.rules"
 
+INHIBIT_DEFAULT_DEPS = "1"
+
 do_install () {
 	install -d ${D}${base_libdir}/udev/rules.d
 	install -m 644 ${WORKDIR}/80-udisks-rpi.rules ${D}${base_libdir}/udev/rules.d

--- a/recipes-graphics/vc-graphics/vc-graphics.inc
+++ b/recipes-graphics/vc-graphics/vc-graphics.inc
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://LICENCE;md5=86e53f5f5909ee66900418028de11780"
 PROVIDES = "virtual/libgles2 virtual/egl"
 COMPATIBLE_MACHINE = "^rpi$"
 
+INHIBIT_DEFAULT_DEPS = "1"
+
 include recipes-bsp/common/firmware.inc
 
 SRC_URI += " \

--- a/recipes-kernel/linux-firmware/linux-firmware-raspbian.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware-raspbian.bb
@@ -5,6 +5,8 @@ LICENSE = "Firmware-broadcom_bcm43xx"
 
 LIC_FILES_CHKSUM = "file://LICENCE.broadcom_bcm43xx;md5=3160c14df7228891b868060e1951dfbc"
 
+INHIBIT_DEFAULT_DEPS = "1"
+
 # These are not common licenses, set NO_GENERIC_LICENSE for them
 # so that the license files will be copied from fetched source
 NO_GENERIC_LICENSE[Firmware-broadcom_bcm43xx] = "LICENCE.broadcom_bcm43xx"

--- a/recipes-kernel/linux/files/0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch
+++ b/recipes-kernel/linux/files/0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch
@@ -1,0 +1,62 @@
+From e6ebc8e654bba53f28af5229a1069fc74fa58b7b Mon Sep 17 00:00:00 2001
+From: Jason Wessel <jason.wessel@windriver.com>
+Date: Thu, 25 Sep 2014 11:26:49 -0700
+Subject: [PATCH] menuconfig,check-lxdiaglog.sh: Allow specification of ncurses
+ location
+
+In some cross build environments such as the Yocto Project build
+environment it provides an ncurses library that is compiled
+differently than the host's version.  This causes display corruption
+problems when the host's curses includes are used instead of the
+includes from the provided compiler are overridden.  There is a second
+case where there is no curses libraries at all on the host system and
+menuconfig will just fail entirely.
+
+The solution is simply to allow an override variable in
+check-lxdialog.sh for environments such as the Yocto Project.  Adding
+a CROSS_CURSES_LIB and CROSS_CURSES_INC solves the issue and allowing
+compiling and linking against the right headers and libraries.
+
+Upstream-Status: submitted [https://lkml.org/lkml/2013/3/3/103]
+
+Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
+cc: Michal Marek <mmarek@suse.cz>
+cc: linux-kbuild@vger.kernel.org
+Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
+Signed-off-by: California Sullivan <california.l.sullivan@intel.com>
+---
+ scripts/kconfig/lxdialog/check-lxdialog.sh | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+ mode change 100755 => 100644 scripts/kconfig/lxdialog/check-lxdialog.sh
+
+diff --git a/scripts/kconfig/lxdialog/check-lxdialog.sh b/scripts/kconfig/lxdialog/check-lxdialog.sh
+old mode 100755
+new mode 100644
+index 5075ebf2d3b9..ba9242101190
+--- a/scripts/kconfig/lxdialog/check-lxdialog.sh
++++ b/scripts/kconfig/lxdialog/check-lxdialog.sh
+@@ -4,6 +4,10 @@
+ # What library to link
+ ldflags()
+ {
++	if [ "$CROSS_CURSES_LIB" != "" ]; then
++		echo "$CROSS_CURSES_LIB"
++		exit
++	fi
+ 	pkg-config --libs ncursesw 2>/dev/null && exit
+ 	pkg-config --libs ncurses 2>/dev/null && exit
+ 	for ext in so a dll.a dylib ; do
+@@ -21,6 +25,10 @@ ldflags()
+ # Where is ncurses.h?
+ ccflags()
+ {
++	if [ x"$CROSS_CURSES_INC" != x ]; then
++		echo "$CROSS_CURSES_INC"
++		exit
++	fi
+ 	if pkg-config --cflags ncursesw 2>/dev/null; then
+ 		echo '-DCURSES_LOC="<ncurses.h>" -DNCURSES_WIDECHAR=1'
+ 	elif pkg-config --cflags ncurses 2>/dev/null; then
+-- 
+2.14.3
+

--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -7,8 +7,8 @@ python __anonymous() {
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
-LINUX_VERSION ?= "4.15"
-LINUX_RPI_DEV_BRANCH ?= "rpi-4.15.y"
+LINUX_VERSION ?= "4.16"
+LINUX_RPI_DEV_BRANCH ?= "rpi-4.16.y"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = " \

--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -11,8 +11,10 @@ LINUX_VERSION ?= "4.15"
 LINUX_RPI_DEV_BRANCH ?= "rpi-4.15.y"
 
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_DEV_BRANCH} \
-"
+SRC_URI = " \
+    git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_DEV_BRANCH} \
+    file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \
+    "
 require linux-raspberrypi.inc
 
 # Disable version check so that we don't have to edit this recipe every time

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -32,9 +32,6 @@ CMDLINE_append += ' ${@oe.utils.conditional("DISABLE_RPI_BOOT_LOGO", "1", "logo.
 CMDLINE_DEBUG ?= ""
 CMDLINE_append = " ${CMDLINE_DEBUG}"
 
-# Quirk for udev greater or equal 141
-UDEV_GE_141 ?= "1"
-
 # Enable OABI compat for people stuck with obsolete userspace
 ARM_KEEP_OABI ?= "1"
 
@@ -102,11 +99,8 @@ do_configure_prepend() {
     CONF_SED_SCRIPT=""
 
     # oabi / eabi support
-    kernel_configure_variable AEABI y
     if [ "${ARM_KEEP_OABI}" = "1" ] ; then
         kernel_configure_variable OABI_COMPAT y
-    else
-        kernel_configure_variable OABI_COMPAT n
     fi
 
     # Set cmdline
@@ -114,39 +108,6 @@ do_configure_prepend() {
 
     # Localversion
     kernel_configure_variable LOCALVERSION "\"\""
-    kernel_configure_variable LOCALVERSION_AUTO n
-
-    # Udev quirks
-    # Newer versions of udev mandate that sysfs doesn't have deprecated entries
-    if [ "${UDEV_GE_141}" = "1" ] ; then
-        kernel_configure_variable SYSFS_DEPRECATED n
-        kernel_configure_variable SYSFS_DEPRECATED_V2 n
-        kernel_configure_variable HOTPLUG y
-        kernel_configure_variable UEVENT_HELPER_PATH "\"\""
-        kernel_configure_variable UNIX y
-        kernel_configure_variable SYSFS y
-        kernel_configure_variable PROC_FS y
-        kernel_configure_variable TMPFS y
-        kernel_configure_variable INOTIFY_USER y
-        kernel_configure_variable SIGNALFD y
-        kernel_configure_variable TMPFS_POSIX_ACL y
-        kernel_configure_variable BLK_DEV_BSG y
-        kernel_configure_variable DEVTMPFS y
-        kernel_configure_variable DEVTMPFS_MOUNT y
-    fi
-
-    # Newer inits like systemd need cgroup support
-    if [ "${KERNEL_ENABLE_CGROUPS}" = "1" ] ; then
-        kernel_configure_variable CGROUP_SCHED y
-        kernel_configure_variable CGROUPS y
-        kernel_configure_variable CGROUP_NS y
-        kernel_configure_variable CGROUP_FREEZER y
-        kernel_configure_variable CGROUP_DEVICE y
-        kernel_configure_variable CPUSETS y
-        kernel_configure_variable PROC_PID_CPUSET y
-        kernel_configure_variable CGROUP_CPUACCT y
-        kernel_configure_variable RESOURCE_COUNTERS y
-    fi
 
     # root-over-nfs-over-usb-eth support. Limited, but should cover some cases
     # Enable this by setting a proper CMDLINE_NFSROOT_USB.
@@ -163,9 +124,6 @@ do_configure_prepend() {
         kernel_configure_variable CMDLINE "\"${CMDLINE_NFSROOT_USB}\""
     fi
     if [ ! -z "${KERNEL_INITRAMFS}" ]; then
-        kernel_configure_variable BLK_DEV_INITRD y
-        kernel_configure_variable INITRAMFS_SOURCE ""
-        kernel_configure_variable RD_GZIP y
         kernel_configure_variable OVERLAY_FS y
         kernel_configure_variable SQUASHFS y
         kernel_configure_variable UBIFS_FS y

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -109,20 +109,6 @@ do_configure_prepend() {
     # Localversion
     kernel_configure_variable LOCALVERSION "\"\""
 
-    # root-over-nfs-over-usb-eth support. Limited, but should cover some cases
-    # Enable this by setting a proper CMDLINE_NFSROOT_USB.
-    if [ ! -z "${CMDLINE_NFSROOT_USB}" ]; then
-        oenote "Configuring the kernel for root-over-nfs-over-usb-eth with CMDLINE ${CMDLINE_NFSROOT_USB}"
-        kernel_configure_variable INET y
-        kernel_configure_variable IP_PNP y
-        kernel_configure_variable USB_GADGET y
-        kernel_configure_variable USB_GADGET_SELECTED y
-        kernel_configure_variable USB_ETH y
-        kernel_configure_variable NFS_FS y
-        kernel_configure_variable ROOT_NFS y
-        kernel_configure_variable ROOT_NFS y
-        kernel_configure_variable CMDLINE "\"${CMDLINE_NFSROOT_USB}\""
-    fi
     if [ ! -z "${KERNEL_INITRAMFS}" ]; then
         kernel_configure_variable OVERLAY_FS y
         kernel_configure_variable SQUASHFS y

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -32,9 +32,6 @@ CMDLINE_append += ' ${@oe.utils.conditional("DISABLE_RPI_BOOT_LOGO", "1", "logo.
 CMDLINE_DEBUG ?= ""
 CMDLINE_append = " ${CMDLINE_DEBUG}"
 
-# Enable OABI compat for people stuck with obsolete userspace
-ARM_KEEP_OABI ?= "1"
-
 KERNEL_INITRAMFS ?= '${@oe.utils.conditional("INITRAMFS_IMAGE_BUNDLE", "1", "1", "", d)}'
 
 KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "stmpe-ts", "", d)}"
@@ -97,11 +94,6 @@ do_configure_prepend() {
 
     mv -f ${B}/.config ${B}/.config.patched
     CONF_SED_SCRIPT=""
-
-    # oabi / eabi support
-    if [ "${ARM_KEEP_OABI}" = "1" ] ; then
-        kernel_configure_variable OABI_COMPAT y
-    fi
 
     # Localversion
     kernel_configure_variable LOCALVERSION "\"\""

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -103,9 +103,6 @@ do_configure_prepend() {
         kernel_configure_variable OABI_COMPAT y
     fi
 
-    # Set cmdline
-    kernel_configure_variable CMDLINE "\"${CMDLINE}\""
-
     # Localversion
     kernel_configure_variable LOCALVERSION "\"\""
 

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -111,10 +111,6 @@ do_configure_prepend() {
         kernel_configure_variable SQUASHFS y
         kernel_configure_variable UBIFS_FS y
     fi
-    # Activate CONFIG_LEGACY_PTYS
-    kernel_configure_variable LEGACY_PTYS y
-    # this module is built externally via drbd-utils
-    kernel_configure_variable BLK_DEV_DRBD n
 
     # Activate the configuration options for VC4
     VC4GRAPHICS="${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"

--- a/recipes-kernel/linux/linux-raspberrypi_4.14.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.14.bb
@@ -1,6 +1,9 @@
 LINUX_VERSION ?= "4.14.30"
 
 SRCREV = "9696aab22bb8163fb3a2a262dd6c67f6d05b70a1"
-SRC_URI = "git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y"
+SRC_URI = " \
+    git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y \
+    file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \
+    "
 
 require linux-raspberrypi.inc

--- a/recipes-kernel/linux/linux-raspberrypi_4.14.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.14.bb
@@ -1,6 +1,6 @@
-LINUX_VERSION ?= "4.14.30"
+LINUX_VERSION ?= "4.14.34"
 
-SRCREV = "9696aab22bb8163fb3a2a262dd6c67f6d05b70a1"
+SRCREV = "f70eae405b5d75f7c41ea300b9f790656f99a203"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y \
     file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \

--- a/recipes-kernel/linux/linux-raspberrypi_4.9.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.9.bb
@@ -3,6 +3,9 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 LINUX_VERSION ?= "4.9.80"
 
 SRCREV = "a7b4dd27c1c0d6510b8066b91ef01be0928d8529"
-SRC_URI = "git://github.com/raspberrypi/linux.git;branch=rpi-4.9.y"
+SRC_URI = " \
+    git://github.com/raspberrypi/linux.git;branch=rpi-4.9.y \
+    file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \
+    "
 
 require linux-raspberrypi.inc

--- a/recipes-kernel/linux/linux-raspberrypi_4.9.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.9.bb
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
 LINUX_VERSION ?= "4.9.80"
 
-SRCREV = "a7b4dd27c1c0d6510b8066b91ef01be0928d8529"
+SRCREV = "ffd7bf4085b09447e5db96edd74e524f118ca3fe"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;branch=rpi-4.9.y \
     file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \


### PR DESCRIPTION
## Changes

* Apply patch to fix `bitbake linux-raspberrypi -c menuconfig` on distros where the native ncurses differs from the one we build. Discussed on oe-core list here: http://lists.openembedded.org/pipermail/openembedded-core/2018-April/149912.html

* Updates for all our kernel recipes.

* Drop unnecessary dependencies and tasks from a few recipes.

* Switch from RDEPENDS to DEPENDS for recipes which don't create a package.

* Major cleanup of kernel `do_configure_prepend` function. Everything has been reviewed against the kernel config created when running `make bcmrpi_defconfig` and `make bcm2709_defconfig` for `ARCH=arm` and `make bcmrpi3_defconfig` for `ARCH=arm64` in the linux-raspberrypi sources. I've kept all settings which appear to be functional and not horrifically obsolete.

I'm hoping that we can replace everything in `do_configure_prepend` with the use of KERNEL_FEATURES and config fragments as supported by `kernel-yocto.bbclass`. That would allow us to drop the `config_setup` and `kernel_configure_variable` functions as well. This is essentially a first step towards that - we drop obsolete config options so that there's less to convert and so we have a baseline of functional config options to test against.

## Testing
Done: build testing
Done: Boot tested with and without u-boot on RPi 1, 2, 3 and 3-64, plus some basic command line messing around.

I wanted to get this up for review now though so people can comment and in case anyone else has kernel changes in progress. I'd like to get this merged before we branch for the 'sumo' release so we have less obsolete stuff to maintain.