### PR TITLE
simplify use of usb gadget mode

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -24,6 +24,7 @@ KERNEL_DEVICETREE ?= " \
     bcm2708-rpi-cm.dtb \
     bcm2710-rpi-cm3.dtb \
     \
+    overlays/dwc2.dtbo \
     overlays/hifiberry-amp.dtbo \
     overlays/hifiberry-dac.dtbo \
     overlays/hifiberry-dacplus.dtbo \

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -221,13 +221,21 @@ needs a fixed core frequency and enable_uart wil set it to the minimum. Certain
 operations - 60fps h264 decode, high quality deinterlace - which aren't
 performed on the ARM may be affected, and we wouldn't want to do that to users
 who don't want to use the serial port. Users who want serial console support on
-RaspberryPi3 will have to explicitely set in local.conf:
+RaspberryPi3 will have to explicitly set in local.conf:
 
     ENABLE_UART = "1"
 
 Ref.:
 * <https://github.com/raspberrypi/firmware/issues/553>
 * <https://github.com/RPi-Distro/repo/issues/22>
+
+## Enable USB Peripheral (Gadget) support
+
+The standard USB driver only supports host mode operations.  Users who
+want to use gadget modules like g_ether should set the following in
+local.conf:
+
+    ENABLE_DWC2_PERIPHERAL = "1"
 
 ## Manual additions to config.txt
 

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -172,6 +172,12 @@ do_deploy() {
         echo "hdmi_drive=1" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
+    # DWC2 USB peripheral support
+    if [ "${ENABLE_DWC2_PERIPHERAL}" = "1" ]; then
+        echo "# Enable USB peripheral mode" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "dtoverlay=dwc2,dr_mode=peripheral" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+    
     # Append extra config if the user has provided any
     echo "${RPI_EXTRA_CONFIG}" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
 }


### PR DESCRIPTION
When initially provisioning a headless device it's nice to be able to connect it to a computer using USB networking.  This requires using a USB driver that understands peripheral (gadget) mode.  These patches add the required dt overlay and provide a short-hand to add it to config.txt.