### PR TITLE
bbclass: Fix a typo in comment

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -1,7 +1,7 @@
 inherit image_types
 
 #
-# Create an image that can by written onto a SD card using dd.
+# Create an image that can be written onto a SD card using dd.
 #
 # The disk layout used is:
 #


### PR DESCRIPTION
Only a small typo on bbclass header.
