### PR TITLE
wayland: do not install libwayland-egl from wayland

### DIFF
--- a/recipes-graphics/wayland/wayland_%.bbappend
+++ b/recipes-graphics/wayland/wayland_%.bbappend
@@ -1,0 +1,6 @@
+# remove provided `libwayland-egl` library in favour of the version in `userland` until fully tested
+
+do_install_append_rpi () {
+    rm -f ${D}${libdir}/libwayland-egl*
+    rm -f ${D}${libdir}/pkgconfig/wayland-egl.pc
+}


### PR DESCRIPTION
Wayland was updated recently in Poky, and now includes `libwayland-egl`:

    commit 8097bf7012a0d97d3b8b48eceb5dc20cc4ae7ca9
    Author: Denys Dmytriyenko <denys@ti.com>
    Date:   Tue Apr 10 15:06:09 2018 -0400

        wayland: upgrade to 1.15.0

        Official announcement:
        https://lists.freedesktop.org/archives/wayland-devel/2018-April/037767.html

        | libwayland-egl is now part of libwayland, and will presumably be removed
        | from mesa in the not too distant future.

        Update mesa recipe by removing corresponding libwayland-egl entries.

        (From OE-Core rev: 6e5952fcfc13ff4b63c9376bd41a1dbba957f425)

        Signed-off-by: Denys Dmytriyenko <denys@ti.com>
        Signed-off-by: Ross Burton <ross.burton@intel.com>
        Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

However, the `userland` ships its own version of the library (see issue #243).
Until further testing, discard the version in `wayland` in favour of the version in `userland`.

This PR closes #243 