### PR TITLE
gstreamer1.0-plugins-bad_%.bbappend: Drop --disable-dispmanx

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -9,4 +9,4 @@ PACKAGECONFIG_GL_rpi = "egl gles2"
 
 PACKAGECONFIG_append_rpi = " hls libmms faad"
 
-PACKAGECONFIG[dispmanx] = "--enable-dispmanx,--disable-dispmanx,userland"
+PACKAGECONFIG[dispmanx] = "--enable-dispmanx,,userland"


### PR DESCRIPTION
1.14 does not support this option
Fixes
QA Issue: gstreamer1.0-plugins-bad: configure was passed unrecognised options: --disable-dispmanx [unknown-configure-option]

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
