### PR TITLE
userland: bumped version and backport khronos typedef for EGL_EXT_image_dma_buf_import

### DIFF
--- a/recipes-graphics/userland/userland/0017-khronos-backport-typedef-for-EGL_EXT_image_dma_buf_i.patch
+++ b/recipes-graphics/userland/userland/0017-khronos-backport-typedef-for-EGL_EXT_image_dma_buf_i.patch
@@ -1,0 +1,35 @@
+From 8403fb3869f56ea7492fa6265bd6cd1dd5146e6e Mon Sep 17 00:00:00 2001
+From: Hugo Hromic <hhromic@gmail.com>
+Date: Sun, 13 May 2018 10:49:04 +0100
+Subject: [PATCH] khronos: backport typedef for EGL_EXT_image_dma_buf_import
+
+The `gstreamer1.0-plugins-base` package version `1.14` uses `EGL_EXT_image_dma_buf_import`, which
+expects the `EGLuint64KHR` typedef that is present in recent versions of Khronos.
+However, the older version included in userland does not provide it.
+
+This patch backports the missing typedef from recent Khronos into userland.
+See: <https://www.khronos.org/registry/EGL/api/EGL/eglext.h>
+
+Submitted to userland in <https://github.com/raspberrypi/userland/pull/467>
+
+Upstream-Status: Submitted
+
+---
+ interface/khronos/include/EGL/eglext.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/interface/khronos/include/EGL/eglext.h b/interface/khronos/include/EGL/eglext.h
+index d7e5ba7..4ce762d 100755
+--- a/interface/khronos/include/EGL/eglext.h
++++ b/interface/khronos/include/EGL/eglext.h
+@@ -190,6 +190,10 @@ typedef EGLBoolean (EGLAPIENTRYP PFNEGLSIGNALSYNCKHRPROC) (EGLDisplay dpy, EGLSy
+ typedef EGLBoolean (EGLAPIENTRYP PFNEGLGETSYNCATTRIBKHRPROC) (EGLDisplay dpy, EGLSyncKHR sync, EGLint attribute, EGLint *value);
+ #endif
+ 
++#ifndef EGL_KHR_stream
++#define EGL_KHR_stream 1
++typedef khronos_uint64_t EGLuint64KHR;
++#endif /* EGL_KHR_stream */
+ 
+ #ifndef EGL_WL_bind_wayland_display
+ #define EGL_WL_bind_wayland_display 1

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -14,11 +14,11 @@ COMPATIBLE_MACHINE = "^rpi$"
 
 SRCBRANCH = "master"
 SRCFORK = "raspberrypi"
-SRCREV = "11389772c79685442e0ab8aa9be8ad0e32703f68"
+SRCREV = "2448644657e5fbfd82299416d218396ee1115ece"
 
 # Use the date of the above commit as the package version. Update this when
 # SRCREV is changed.
-PV = "20180219"
+PV = "20180511"
 
 SRC_URI = "\
     git://github.com/${SRCFORK}/userland.git;protocol=git;branch=${SRCBRANCH} \
@@ -38,6 +38,7 @@ SRC_URI = "\
     file://0014-GLES2-gl2ext.h-Define-GL_R8_EXT-and-GL_RG8_EXT.patch \
     file://0015-EGL-glplatform.h-define-EGL_CAST.patch \
     file://0016-Allow-multiple-wayland-compositor-state-data-per-pro.patch \
+    file://0017-khronos-backport-typedef-for-EGL_EXT_image_dma_buf_i.patch \
 "
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The `gstreamer1.0-plugins-base` package version `1.14` uses `EGL_EXT_image_dma_buf_import`, which
expects the `EGLuint64KHR` typedef that is present in recent versions of Khronos.
However, the older version included in userland does not provide it.

This patch backports the missing typedef from recent Khronos into userland.
See: <https://www.khronos.org/registry/EGL/api/EGL/eglext.h>

Related to PR #247 and Issue #243 