### PR TITLE
sumo: fix firmware support on aarch64

### DIFF
--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -16,6 +16,7 @@ include conf/machine/include/rpi-base.inc
 
 KERNEL_DEVICETREE = " \
     broadcom/bcm2710-rpi-3-b.dtb \
+    broadcom/bcm2710-rpi-3-b-plus.dtb \
     broadcom/bcm2837-rpi-3-b.dtb \
     \
     overlays/hifiberry-amp.dtbo \

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -188,10 +188,6 @@ do_deploy_append_raspberrypi3-64() {
 
     echo "# Enable audio (loads snd_bcm2835)" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     echo "dtparam=audio=on" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-
-    # Device Tree support
-    echo "# Load correct Device Tree for Aarch64" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-    echo "device_tree=bcm2710-rpi-3-b.dtb" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
 }
 
 addtask deploy before do_build after do_install


### PR DESCRIPTION
This resolves #253 on sumo and has been tested.

It is not sufficient by itself to address #251 as #254 must also be resolved (I made this change by hand for testing).