### PR TITLE
wayland: only remove libwayland-egl if not using vc4graphics, e.g. when using userland

### DIFF
--- a/recipes-graphics/wayland/wayland_%.bbappend
+++ b/recipes-graphics/wayland/wayland_%.bbappend
@@ -1,6 +1,7 @@
-# remove provided `libwayland-egl` library in favour of the version in `userland` until fully tested
-
+# until fully tested, prefer `libwayland-egl` provided by `userland` instead of `wayland` when not using vc4graphics
 do_install_append_rpi () {
-    rm -f ${D}${libdir}/libwayland-egl*
-    rm -f ${D}${libdir}/pkgconfig/wayland-egl.pc
+    if [ "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}" = "0" ]; then
+        rm -f ${D}${libdir}/libwayland-egl*
+        rm -f ${D}${libdir}/pkgconfig/wayland-egl.pc
+    fi
 }


### PR DESCRIPTION
Related to PR #247.
