### PR TITLE
gstreamer1.0-plugins: App proper appends for base and bad plugins

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,12 +1,1 @@
-EXTRA_OECONF_append_rpi = " CPPFLAGS='-I${STAGING_INCDIR}/interface/vcos/pthreads \
-                                   -I${STAGING_INCDIR}/interface/vmcs_host/linux'"
-
-# if using bcm driver enable dispmanx not when using VC4 driver
-
-PACKAGECONFIG_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' dispmanx', d)}"
-
-PACKAGECONFIG_GL_rpi = "egl gles2"
-
 PACKAGECONFIG_append_rpi = " hls libmms faad"
-
-PACKAGECONFIG[dispmanx] = "--enable-dispmanx,,userland"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,0 +1,10 @@
+EXTRA_OECONF_append_rpi = " CPPFLAGS='-I${STAGING_INCDIR}/interface/vcos/pthreads \
+                                   -I${STAGING_INCDIR}/interface/vmcs_host/linux'"
+
+# if using bcm driver enable dispmanx not when using VC4 driver
+
+PACKAGECONFIG_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' dispmanx', d)}"
+
+PACKAGECONFIG_GL_rpi = "egl gles2"
+
+PACKAGECONFIG[dispmanx] = "--enable-dispmanx,--disable-dispmanx,userland"


### PR DESCRIPTION
This patch accounts for the fact that rpi dispmanx plugin migrated
from bad to base stating 1.14 release

Signed-off-by: Khem Raj <raj.khem@gmail.com>

should fix

https://github.com/agherzan/meta-raspberrypi/pull/250#issuecomment-390263798