### PR TITLE
linux-firmware update LIC_FILES_CHKSUM for d114732 revision from oe-core

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -8,7 +8,7 @@ LICENSE_append_rpi = "\
 "
 
 LIC_FILES_CHKSUM_append_rpi = "\
-    file://LICENCE.cypress;md5=cbc5f665d04f741f1e006d2096236ba7 \
+    file://LICENCE.cypress;md5=48cd9436c763bf873961f9ed7b5c147b \
 "
 NO_GENERIC_LICENSE[Firmware-cypress] = "LICENCE.cypress"
 


### PR DESCRIPTION
* unfortunately the LICENCE.cypress was updated in last upgrade:
  http://git.openembedded.org/openembedded-core/commit/?id=6be8744d1b8ee35eb47acd517cfa29b2a7f455d5
  ba51e86 Update Cypress license termination clause
  https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/LICENCE.cypress?id=ba51e861f4444f51e7e83f778575a8146dc514d0

* it's unfortunate, because now meta-raspberrypi/master is compatible only with oe-core master after 6be8744d1b8ee35eb47acd517cfa29b2a7f455d5
  it would be nice to upstream some of these changes to linux-firmware recipes and leave only the rpi specific packaging here

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>