### PR TITLE
userland: fix backport khronos typedef patch

### DIFF
--- a/recipes-graphics/userland/userland/0017-khronos-backport-typedef-for-EGL_EXT_image_dma_buf_i.patch
+++ b/recipes-graphics/userland/userland/0017-khronos-backport-typedef-for-EGL_EXT_image_dma_buf_i.patch
@@ -26,10 +26,10 @@ index d7e5ba7..4ce762d 100755
  typedef EGLBoolean (EGLAPIENTRYP PFNEGLGETSYNCATTRIBKHRPROC) (EGLDisplay dpy, EGLSyncKHR sync, EGLint attribute, EGLint *value);
  #endif
  
-+#ifndef EGL_KHR_stream
-+#define EGL_KHR_stream 1
++#ifndef EGL_KHR_uint64_typedef
++#define EGL_KHR_uint64_typedef 1
 +typedef khronos_uint64_t EGLuint64KHR;
-+#endif /* EGL_KHR_stream */
++#endif /* EGL_KHR_uint64_typedef */
  
  #ifndef EGL_WL_bind_wayland_display
  #define EGL_WL_bind_wayland_display 1


### PR DESCRIPTION
The patch in 237e0c7 used a define guard that clashes with an actual feature of Khronos (EGL_KHR_stream).
This makes some packages such as `qtbase` to think that the outdated Krhonos in userland has newer features.
This fix uses a more specific name for the relevant define guard (EGL_KHR_uint64_typedef).

Fixes #273 