### PR TITLE
sdcard_image-rpi.bbclass improvements

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -56,6 +56,7 @@ do_image_rpi_sdimg[depends] = " \
 			virtual/kernel:do_deploy \
 			${IMAGE_BOOTLOADER}:do_deploy \
 			${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
+			${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'rpi-u-boot-scr:do_deploy', '',d)} \
 			"
 
 do_image_rpi_sdimg[recrdeps] = "do_build"

--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -79,6 +79,7 @@ SDIMG_LINK_VFAT = "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.vfat"
 
 def split_overlays(d, out, ver=None):
     dts = d.getVar("KERNEL_DEVICETREE")
+    # Device Tree Overlays are assumed to be suffixed by '-overlay.dtb' (4.1.x) or by '.dtbo' (4.4.9+) string and will be put in a dedicated folder
     if out:
         overlays = oe.utils.str_filter_out('\S+\-overlay\.dtb$', dts, d)
         overlays = oe.utils.str_filter_out('\S+\.dtbo$', overlays, d)
@@ -118,24 +119,17 @@ IMAGE_CMD_rpi-sdimg () {
 	mkfs.vfat -n "${BOOTDD_VOLUME_ID}" -S 512 -C ${WORKDIR}/boot.img $BOOT_BLOCKS
 	mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/* ::/
 	if test -n "${DTS}"; then
-		# Device Tree Overlays are assumed to be suffixed by '-overlay.dtb' (4.1.x) or by '.dtbo' (4.4.9+) string and will be put in a dedicated folder
-		DT_OVERLAYS="${@split_overlays(d, 0)}"
-		DT_ROOT="${@split_overlays(d, 1)}"
-
 		# Copy board device trees to root folder
-		for DTB in $DT_ROOT; do
-			DTB_BASE_NAME=`basename ${DTB} .dtb`
-
-			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${DTB_BASE_NAME}.dtb ::${DTB_BASE_NAME}.dtb
+		for dtbf in ${@split_overlays(d, True)}; do
+			dtb=`basename $dtbf`
+			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::$dtb
 		done
 
 		# Copy device tree overlays to dedicated folder
 		mmd -i ${WORKDIR}/boot.img overlays
-		for DTB in $DT_OVERLAYS; do
-				DTB_EXT=${DTB##*.}
-				DTB_BASE_NAME=`basename ${DTB} ."${DTB_EXT}"`
-
-			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${DTB_BASE_NAME}.${DTB_EXT} ::overlays/${DTB_BASE_NAME}.${DTB_EXT}
+		for dtbf in ${@split_overlays(d, False)}; do
+			dtb=`basename $dtbf`
+			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::overlays/$dtb
 		done
 	fi
         if [ "${RPI_USE_U_BOOT}" = "1" ]; then

--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -50,14 +50,14 @@ SDIMG_ROOTFS_TYPE ?= "ext3"
 SDIMG_ROOTFS = "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${SDIMG_ROOTFS_TYPE}"
 
 do_image_rpi_sdimg[depends] = " \
-			parted-native:do_populate_sysroot \
-			mtools-native:do_populate_sysroot \
-			dosfstools-native:do_populate_sysroot \
-			virtual/kernel:do_deploy \
-			${IMAGE_BOOTLOADER}:do_deploy \
-			${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
-			${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'rpi-u-boot-scr:do_deploy', '',d)} \
-			"
+    parted-native:do_populate_sysroot \
+    mtools-native:do_populate_sysroot \
+    dosfstools-native:do_populate_sysroot \
+    virtual/kernel:do_deploy \
+    ${IMAGE_BOOTLOADER}:do_deploy \
+    ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
+    ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'rpi-u-boot-scr:do_deploy', '',d)} \
+"
 
 do_image_rpi_sdimg[recrdeps] = "do_build"
 
@@ -92,107 +92,107 @@ def split_overlays(d, out, ver=None):
 
 IMAGE_CMD_rpi-sdimg () {
 
-	# Align partitions
-	BOOT_SPACE_ALIGNED=$(expr ${BOOT_SPACE} + ${IMAGE_ROOTFS_ALIGNMENT} - 1)
-	BOOT_SPACE_ALIGNED=$(expr ${BOOT_SPACE_ALIGNED} - ${BOOT_SPACE_ALIGNED} % ${IMAGE_ROOTFS_ALIGNMENT})
-	SDIMG_SIZE=$(expr ${IMAGE_ROOTFS_ALIGNMENT} + ${BOOT_SPACE_ALIGNED} + $ROOTFS_SIZE)
+    # Align partitions
+    BOOT_SPACE_ALIGNED=$(expr ${BOOT_SPACE} + ${IMAGE_ROOTFS_ALIGNMENT} - 1)
+    BOOT_SPACE_ALIGNED=$(expr ${BOOT_SPACE_ALIGNED} - ${BOOT_SPACE_ALIGNED} % ${IMAGE_ROOTFS_ALIGNMENT})
+    SDIMG_SIZE=$(expr ${IMAGE_ROOTFS_ALIGNMENT} + ${BOOT_SPACE_ALIGNED} + $ROOTFS_SIZE)
 
-	echo "Creating filesystem with Boot partition ${BOOT_SPACE_ALIGNED} KiB and RootFS $ROOTFS_SIZE KiB"
+    echo "Creating filesystem with Boot partition ${BOOT_SPACE_ALIGNED} KiB and RootFS $ROOTFS_SIZE KiB"
 
-	# Check if we are building with device tree support
-	DTS="${KERNEL_DEVICETREE}"
+    # Check if we are building with device tree support
+    DTS="${KERNEL_DEVICETREE}"
 
-	# Initialize sdcard image file
-	dd if=/dev/zero of=${SDIMG} bs=1024 count=0 seek=${SDIMG_SIZE}
+    # Initialize sdcard image file
+    dd if=/dev/zero of=${SDIMG} bs=1024 count=0 seek=${SDIMG_SIZE}
 
-	# Create partition table
-	parted -s ${SDIMG} mklabel msdos
-	# Create boot partition and mark it as bootable
-	parted -s ${SDIMG} unit KiB mkpart primary fat32 ${IMAGE_ROOTFS_ALIGNMENT} $(expr ${BOOT_SPACE_ALIGNED} \+ ${IMAGE_ROOTFS_ALIGNMENT})
-	parted -s ${SDIMG} set 1 boot on
-	# Create rootfs partition to the end of disk
-	parted -s ${SDIMG} -- unit KiB mkpart primary ext2 $(expr ${BOOT_SPACE_ALIGNED} \+ ${IMAGE_ROOTFS_ALIGNMENT}) -1s
-	parted ${SDIMG} print
+    # Create partition table
+    parted -s ${SDIMG} mklabel msdos
+    # Create boot partition and mark it as bootable
+    parted -s ${SDIMG} unit KiB mkpart primary fat32 ${IMAGE_ROOTFS_ALIGNMENT} $(expr ${BOOT_SPACE_ALIGNED} \+ ${IMAGE_ROOTFS_ALIGNMENT})
+    parted -s ${SDIMG} set 1 boot on
+    # Create rootfs partition to the end of disk
+    parted -s ${SDIMG} -- unit KiB mkpart primary ext2 $(expr ${BOOT_SPACE_ALIGNED} \+ ${IMAGE_ROOTFS_ALIGNMENT}) -1s
+    parted ${SDIMG} print
 
-	# Create a vfat image with boot files
-	BOOT_BLOCKS=$(LC_ALL=C parted -s ${SDIMG} unit b print | awk '/ 1 / { print substr($4, 1, length($4 -1)) / 512 /2 }')
-	rm -f ${WORKDIR}/boot.img
-	mkfs.vfat -n "${BOOTDD_VOLUME_ID}" -S 512 -C ${WORKDIR}/boot.img $BOOT_BLOCKS
-	mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/* ::/
-	if test -n "${DTS}"; then
-		# Copy board device trees to root folder
-		for dtbf in ${@split_overlays(d, True)}; do
-			dtb=`basename $dtbf`
-			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::$dtb
-		done
+    # Create a vfat image with boot files
+    BOOT_BLOCKS=$(LC_ALL=C parted -s ${SDIMG} unit b print | awk '/ 1 / { print substr($4, 1, length($4 -1)) / 512 /2 }')
+    rm -f ${WORKDIR}/boot.img
+    mkfs.vfat -n "${BOOTDD_VOLUME_ID}" -S 512 -C ${WORKDIR}/boot.img $BOOT_BLOCKS
+    mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/* ::/
+    if test -n "${DTS}"; then
+        # Copy board device trees to root folder
+        for dtbf in ${@split_overlays(d, True)}; do
+            dtb=`basename $dtbf`
+            mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::$dtb
+        done
 
-		# Copy device tree overlays to dedicated folder
-		mmd -i ${WORKDIR}/boot.img overlays
-		for dtbf in ${@split_overlays(d, False)}; do
-			dtb=`basename $dtbf`
-			mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::overlays/$dtb
-		done
-	fi
-        if [ "${RPI_USE_U_BOOT}" = "1" ]; then
-		mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/u-boot.bin ::${SDIMG_KERNELIMAGE}
-		mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin ::${KERNEL_IMAGETYPE}
-		mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/boot.scr ::boot.scr
-	else
-		mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin ::${SDIMG_KERNELIMAGE}
-	fi
+        # Copy device tree overlays to dedicated folder
+        mmd -i ${WORKDIR}/boot.img overlays
+        for dtbf in ${@split_overlays(d, False)}; do
+            dtb=`basename $dtbf`
+            mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::overlays/$dtb
+        done
+    fi
+    if [ "${RPI_USE_U_BOOT}" = "1" ]; then
+        mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/u-boot.bin ::${SDIMG_KERNELIMAGE}
+        mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin ::${KERNEL_IMAGETYPE}
+        mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/boot.scr ::boot.scr
+    else
+        mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin ::${SDIMG_KERNELIMAGE}
+    fi
 
-	if [ -n ${FATPAYLOAD} ] ; then
-		echo "Copying payload into VFAT"
-		for entry in ${FATPAYLOAD} ; do
-				# add the || true to stop aborting on vfat issues like not supporting .~lock files
-				mcopy -i ${WORKDIR}/boot.img -s -v ${IMAGE_ROOTFS}$entry :: || true
-		done
-	fi
+    if [ -n ${FATPAYLOAD} ] ; then
+        echo "Copying payload into VFAT"
+        for entry in ${FATPAYLOAD} ; do
+            # add the || true to stop aborting on vfat issues like not supporting .~lock files
+            mcopy -i ${WORKDIR}/boot.img -s -v ${IMAGE_ROOTFS}$entry :: || true
+        done
+    fi
 
-	# Add stamp file
-	echo "${IMAGE_NAME}" > ${WORKDIR}/image-version-info
-	mcopy -i ${WORKDIR}/boot.img -v ${WORKDIR}/image-version-info ::
+    # Add stamp file
+    echo "${IMAGE_NAME}" > ${WORKDIR}/image-version-info
+    mcopy -i ${WORKDIR}/boot.img -v ${WORKDIR}/image-version-info ::
 
-        # Deploy vfat partition (for u-boot case only)
-        if [ "${RPI_USE_U_BOOT}" = "1" ]; then
-                cp ${WORKDIR}/boot.img ${IMGDEPLOYDIR}/${SDIMG_VFAT}
-                ln -sf ${SDIMG_VFAT} ${SDIMG_LINK_VFAT}
-        fi
+    # Deploy vfat partition (for u-boot case only)
+    if [ "${RPI_USE_U_BOOT}" = "1" ]; then
+        cp ${WORKDIR}/boot.img ${IMGDEPLOYDIR}/${SDIMG_VFAT}
+        ln -sf ${SDIMG_VFAT} ${SDIMG_LINK_VFAT}
+    fi
 
-	# Burn Partitions
-	dd if=${WORKDIR}/boot.img of=${SDIMG} conv=notrunc seek=1 bs=$(expr ${IMAGE_ROOTFS_ALIGNMENT} \* 1024)
-	# If SDIMG_ROOTFS_TYPE is a .xz file use xzcat
-	if echo "${SDIMG_ROOTFS_TYPE}" | egrep -q "*\.xz"
-	then
-		xzcat ${SDIMG_ROOTFS} | dd of=${SDIMG} conv=notrunc seek=1 bs=$(expr 1024 \* ${BOOT_SPACE_ALIGNED} + ${IMAGE_ROOTFS_ALIGNMENT} \* 1024)
-	else
-		dd if=${SDIMG_ROOTFS} of=${SDIMG} conv=notrunc seek=1 bs=$(expr 1024 \* ${BOOT_SPACE_ALIGNED} + ${IMAGE_ROOTFS_ALIGNMENT} \* 1024)
-	fi
+    # Burn Partitions
+    dd if=${WORKDIR}/boot.img of=${SDIMG} conv=notrunc seek=1 bs=$(expr ${IMAGE_ROOTFS_ALIGNMENT} \* 1024)
+    # If SDIMG_ROOTFS_TYPE is a .xz file use xzcat
+    if echo "${SDIMG_ROOTFS_TYPE}" | egrep -q "*\.xz"
+    then
+        xzcat ${SDIMG_ROOTFS} | dd of=${SDIMG} conv=notrunc seek=1 bs=$(expr 1024 \* ${BOOT_SPACE_ALIGNED} + ${IMAGE_ROOTFS_ALIGNMENT} \* 1024)
+    else
+        dd if=${SDIMG_ROOTFS} of=${SDIMG} conv=notrunc seek=1 bs=$(expr 1024 \* ${BOOT_SPACE_ALIGNED} + ${IMAGE_ROOTFS_ALIGNMENT} \* 1024)
+    fi
 
-	# Optionally apply compression
-	case "${SDIMG_COMPRESSION}" in
-	"gzip")
-		gzip -k9 "${SDIMG}"
-		;;
-	"bzip2")
-		bzip2 -k9 "${SDIMG}"
-		;;
-	"xz")
-		xz -k "${SDIMG}"
-		;;
-	esac
+    # Optionally apply compression
+    case "${SDIMG_COMPRESSION}" in
+    "gzip")
+        gzip -k9 "${SDIMG}"
+        ;;
+    "bzip2")
+        bzip2 -k9 "${SDIMG}"
+        ;;
+    "xz")
+        xz -k "${SDIMG}"
+        ;;
+    esac
 }
 
 ROOTFS_POSTPROCESS_COMMAND += " rpi_generate_sysctl_config ; "
 
 rpi_generate_sysctl_config() {
-	# systemd sysctl config
-	test -d ${IMAGE_ROOTFS}${sysconfdir}/sysctl.d && \
-		echo "vm.min_free_kbytes = 8192" > ${IMAGE_ROOTFS}${sysconfdir}/sysctl.d/rpi-vm.conf
+    # systemd sysctl config
+    test -d ${IMAGE_ROOTFS}${sysconfdir}/sysctl.d && \
+        echo "vm.min_free_kbytes = 8192" > ${IMAGE_ROOTFS}${sysconfdir}/sysctl.d/rpi-vm.conf
 
-	# sysv sysctl config
-	IMAGE_SYSCTL_CONF="${IMAGE_ROOTFS}${sysconfdir}/sysctl.conf"
-	test -e ${IMAGE_ROOTFS}${sysconfdir}/sysctl.conf && \
-		sed -e "/vm.min_free_kbytes/d" -i ${IMAGE_SYSCTL_CONF}
-	echo "" >> ${IMAGE_SYSCTL_CONF} && echo "vm.min_free_kbytes = 8192" >> ${IMAGE_SYSCTL_CONF}
+    # sysv sysctl config
+    IMAGE_SYSCTL_CONF="${IMAGE_ROOTFS}${sysconfdir}/sysctl.conf"
+    test -e ${IMAGE_ROOTFS}${sysconfdir}/sysctl.conf && \
+        sed -e "/vm.min_free_kbytes/d" -i ${IMAGE_SYSCTL_CONF}
+    echo "" >> ${IMAGE_SYSCTL_CONF} && echo "vm.min_free_kbytes = 8192" >> ${IMAGE_SYSCTL_CONF}
 }


### PR DESCRIPTION
These are bits from older PR:
https://github.com/agherzan/meta-raspberrypi/pull/159
without the dependency on oe-core changes which weren't merged yet.

The files in deploy/raspberrypi3 are the same:

$ diff -rq */deploy/images/*/
Only in old/deploy/images/raspberrypi3/: rpi-hwup-image-raspberrypi3-20180702120324.testdata.json
Only in old/deploy/images/raspberrypi3/: rpi-hwup-image-raspberrypi3-20180702141536.rootfs.ext3
Only in old/deploy/images/raspberrypi3/: rpi-hwup-image-raspberrypi3-20180702141536.rootfs.manifest
Only in old/deploy/images/raspberrypi3/: rpi-hwup-image-raspberrypi3-20180702141536.rootfs.rpi-sdimg
Only in old/deploy/images/raspberrypi3/: rpi-hwup-image-raspberrypi3-20180702141536.testdata.json
Only in old/deploy/images/raspberrypi3/: rpi-hwup-image-raspberrypi3-20180702141536.vfat
Only in new/deploy/images/raspberrypi3/: rpi-hwup-image-raspberrypi3-20180702151020.rootfs.ext3
Only in new/deploy/images/raspberrypi3/: rpi-hwup-image-raspberrypi3-20180702151020.rootfs.manifest
Only in new/deploy/images/raspberrypi3/: rpi-hwup-image-raspberrypi3-20180702151020.rootfs.rpi-sdimg
Only in new/deploy/images/raspberrypi3/: rpi-hwup-image-raspberrypi3-20180702151020.testdata.json
Only in new/deploy/images/raspberrypi3/: rpi-hwup-image-raspberrypi3-20180702151020.vfat
Files new/deploy/images/raspberrypi3/rpi-hwup-image-raspberrypi3.ext3 and old/deploy/images/raspberrypi3/rpi-hwup-image-raspberrypi3.ext3 differ
Files new/deploy/images/raspberrypi3/rpi-hwup-image-raspberrypi3.rpi-sdimg and old/deploy/images/raspberrypi3/rpi-hwup-image-raspberrypi3.rpi-sdimg differ
Files new/deploy/images/raspberrypi3/rpi-hwup-image-raspberrypi3.testdata.json and old/deploy/images/raspberrypi3/rpi-hwup-image-raspberrypi3.testdata.json differ
Files new/deploy/images/raspberrypi3/rpi-hwup-image-raspberrypi3.vfat and old/deploy/images/raspberrypi3/rpi-hwup-image-raspberrypi3.vfat differ
