### PR TITLE
sdcard_image-rpi.bbclass: drop KERNEL_INITRAMFS variable

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -75,6 +75,7 @@ SDIMG = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.rpi-sdimg"
 FATPAYLOAD ?= ""
 
 # SD card vfat partition image name
+SDIMG_VFAT_DEPLOY ?= "${RPI_USE_U_BOOT}"
 SDIMG_VFAT = "${IMAGE_NAME}.vfat"
 SDIMG_LINK_VFAT = "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.vfat"
 
@@ -161,8 +162,8 @@ IMAGE_CMD_rpi-sdimg () {
     echo "${IMAGE_NAME}" > ${WORKDIR}/image-version-info
     mcopy -i ${WORKDIR}/boot.img -v ${WORKDIR}/image-version-info ::
 
-    # Deploy vfat partition (for u-boot case only)
-    if [ "${RPI_USE_U_BOOT}" = "1" ]; then
+    # Deploy vfat partition
+    if [ "${SDIMG_VFAT_DEPLOY}" = "1" ]; then
         cp ${WORKDIR}/boot.img ${IMGDEPLOYDIR}/${SDIMG_VFAT}
         ln -sf ${SDIMG_VFAT} ${SDIMG_LINK_VFAT}
     fi

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -167,9 +167,6 @@ To build an initramfs image:
   - `INITRAMFS_IMAGE = "<a name for your initramfs image>"`
   - `INITRAMFS_IMAGE_BUNDLE = "1"`
 
-* Set the meta-rasberrypi variable (in raspberrypi.conf for example)
-  - `KERNEL_INITRAMFS = "-initramfs"`
-
 ## Enable SPI bus
 
 When using device tree kernels, set this variable to enable the SPI bus:

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -33,8 +33,6 @@ CMDLINE_append += ' ${@oe.utils.conditional("DISABLE_RPI_BOOT_LOGO", "1", "logo.
 CMDLINE_DEBUG ?= ""
 CMDLINE_append = " ${CMDLINE_DEBUG}"
 
-KERNEL_INITRAMFS ?= '${@oe.utils.conditional("INITRAMFS_IMAGE_BUNDLE", "1", "1", "", d)}'
-
 KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "stmpe-ts", "", d)}"
 
 # A LOADADDR is needed when building a uImage format kernel. This value is not
@@ -99,7 +97,7 @@ do_configure_prepend() {
     # Localversion
     kernel_configure_variable LOCALVERSION "\"\""
 
-    if [ ! -z "${KERNEL_INITRAMFS}" ]; then
+    if [ "${INITRAMFS_IMAGE_BUNDLE}" = "1" ]; then
         kernel_configure_variable OVERLAY_FS y
         kernel_configure_variable SQUASHFS y
         kernel_configure_variable UBIFS_FS y
@@ -107,7 +105,7 @@ do_configure_prepend() {
 
     # Activate the configuration options for VC4
     VC4GRAPHICS="${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"
-    if [ ${VC4GRAPHICS} = "1" ]; then
+    if [ "${VC4GRAPHICS}" = "1" ]; then
         kernel_configure_variable I2C_BCM2835 y
         kernel_configure_variable DRM y
         kernel_configure_variable DRM_FBDEV_EMULATION y


### PR DESCRIPTION
* use INITRAMFS_SYMLINK_NAME from new kernel-artifact-names.bbclass
  instead of KERNEL_INITRAMFS
* the documentation says that KERNEL_INITRAMFS should be used to
  define extension of initramfs, but in linux-raspberrypi.inc it's
  defined only to 1 or empty based on INITRAMFS_IMAGE_BUNDLE variable
  and I don't see any code in meta-raspberry or oe-core which would
  use KERNEL_INITRAMFS to actualy name the initramfs artifact to create:
  ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin
  used in classes/sdcard_image-rpi.bbclass
* also fix the assumption that there is -${MACHINE} suffix in:
  ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin
  because that's defined as KERNEL_IMAGE_SYMLINK_NAME and some DISTROs
  might use different value
* this depends on oe-core changes which were merged today:
http://git.openembedded.org/openembedded-core/commit/?id=7d0ef0eaa1bfe97015a774c26f5791622e7e8b12
* this is the last piece of previous pull-request:
  https://github.com/agherzan/meta-raspberrypi/pull/159

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
