### PR TITLE
raspberrypi3-64.conf: Include cm3 dtb

### DIFF
--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -17,6 +17,7 @@ include conf/machine/include/rpi-base.inc
 KERNEL_DEVICETREE = " \
     broadcom/bcm2710-rpi-3-b.dtb \
     broadcom/bcm2710-rpi-3-b-plus.dtb \
+    broadcom/bcm2710-rpi-cm3.dtb \
     broadcom/bcm2837-rpi-3-b.dtb \
     \
     overlays/hifiberry-amp.dtbo \


### PR DESCRIPTION
Add the CM3 dtb in the boot partition so we can boot this board as well with
this machine.

Signed-off-by: Andrei Gherzan <andrei@gherzan.com>