### PR TITLE
linux-raspberrypi: update 4.9 recipe to current HEAD

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.9.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.9.bb
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
 LINUX_VERSION ?= "4.9.80"
 
-SRCREV = "ffd7bf4085b09447e5db96edd74e524f118ca3fe"
+SRCREV = "7f9c648dad6473469b4133898fa6bb8d818ecff9"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;branch=rpi-4.9.y \
     file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \


### PR DESCRIPTION
Contains the following changes:

    7f9c648dad64 drm/vc4: Move IRQ enable to PM path

which fixes an unbalanced IRQ enable warning, which was rapported
in #286

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>
Signed-off-by: Gunnar Andersson <gandersson@genivi.org>
Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>