### PR TITLE
linux-firmware: remove duplicate ${PN}-bcm43455 package

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -31,10 +31,17 @@ do_install_append_rpi() {
 # NB: Must prepend, else these become empty and their content is left in
 # the roll-up package which precedes them.
 PACKAGES_prepend_rpi = "\
-    ${PN}-bcm43455 \
     ${PN}-bcm43430a1-hcd \
     ${PN}-bcm4345c0-hcd \
 "
+
+# ${PN}-bcm43455 package and brcmfmac43455-sdio from linux-firmware
+# is already included in the oe-core recipe, so don't add it to PACKAGES
+# again, the version from raspbian-nf seems a bit newer:
+# $ strings ./1_0.0+gitAUTOINC+d114732723+86e88fbf03+e28cd7ee86-r0/git/brcm/brcmfmac43455-sdio.bin | grep Ver
+# Version: 7.45.18.0 CRC: d7226371 Date: Sun 2015-03-01 07:31:57 PST Ucode Ver: 1026.2 FWID: 01-6a2c8ad4
+# $ strings ./1_0.0+gitAUTOINC+d114732723+86e88fbf03+e28cd7ee86-r0/raspbian-nf/brcm/brcmfmac43455-sdio.bin | grep Ver
+# Version: 7.45.154 (r684107 CY) CRC: b1f79383 Date: Tue 2018-02-27 03:18:17 PST Ucode Ver: 1043.2105 FWID 01-4fbe0b04
 
 # For additional Broadcom
 LICENSE_${PN}-bcm43455 = "Firmware-broadcom_bcm43xx"


### PR DESCRIPTION
This is the rest of https://github.com/agherzan/meta-raspberrypi/pull/295 it also depends on oe-core changes which aren't in master yet, but as of today they are in master-next.
http://lists.openembedded.org/pipermail/openembedded-core/2018-July/153164.html
http://lists.openembedded.org/pipermail/openembedded-core/2018-July/153167.html

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>

