### PR TITLE
raspberrypi-cm3.conf: Inherit raspberrypi3 not raspberrypi2

### DIFF
--- a/conf/machine/raspberrypi-cm3.conf
+++ b/conf/machine/raspberrypi-cm3.conf
@@ -2,5 +2,5 @@
 #@NAME: RaspberryPi Compute Module 3 (CM3)
 #@DESCRIPTION: Machine configuration for the RaspberryPi Compute Module 3 (CM3)
 
-MACHINEOVERRIDES = "raspberrypi2:${MACHINE}"
-include conf/machine/raspberrypi2.conf
+MACHINEOVERRIDES = "raspberrypi3:${MACHINE}"
+include conf/machine/raspberrypi3.conf


### PR DESCRIPTION
The CM3 module is based Raspberry Pi 3 not 2.

Added also to rocko as a lot of people is using it and need to carry this locally somehow. @agherzan  It is necessary to port to other branches? 

Signed-off-by: Andrei Gherzan <andrei@gherzan.com>


