### PR TITLE
omxplayer: Update and add fixes for OpenSSL 1.1.x and thumb2

### DIFF
--- a/recipes-core/packagegroups/packagegroup-rpi-test.bb
+++ b/recipes-core/packagegroups/packagegroup-rpi-test.bb
@@ -6,8 +6,7 @@ inherit packagegroup
 
 COMPATIBLE_MACHINE = "^rpi$"
 
-OMXPLAYER_rpi = "omxplayer"
-OMXPLAYER_rpi_aarch64 = ""
+OMXPLAYER  = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'omxplayer', d)}"
 
 RDEPENDS_${PN} = "\
     ${OMXPLAYER} \

--- a/recipes-multimedia/omxplayer/omxplayer/0001-Specify-cc-cxx-and-ld-variables-from-environment.patch
+++ b/recipes-multimedia/omxplayer/omxplayer/0001-Specify-cc-cxx-and-ld-variables-from-environment.patch
@@ -1,0 +1,43 @@
+From 9b4b7f8726171e97f12c587d50e54bab0dc42da5 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 12 Sep 2018 22:18:07 -0700
+Subject: [PATCH] Specify --cc, --cxx and --ld variables from environment
+
+This helps in compiling with non-gcc compilers
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ Makefile.ffmpeg | 22 ++++++++++++++--------
+ 1 file changed, 14 insertions(+), 8 deletions(-)
+
+Index: git/Makefile.ffmpeg
+===================================================================
+--- git.orig/Makefile.ffmpeg
++++ git/Makefile.ffmpeg
+@@ -23,13 +23,16 @@ configure:
+ 	CFLAGS="$(CFLAGS) ${INCLUDES}" \
+ 	LDFLAGS="" \
+   ./configure \
++			--ld="${CCLD}" \
++			--cc="${CC}" \
++			--cxx="${CXX}" \
+ 			--extra-cflags="$(FFMPEG_EXTRA_CFLAGS)" \
+ 			--extra-ldflags="$(FFMPEG_EXTRA_LDFLAGS)" \
+ 			--enable-cross-compile \
+ 			--enable-shared \
+ 			--disable-static \
+ 			--arch=arm \
+-			--cpu=arm1176jzf-s \
++			--cpu=$(CPU) \
+ 			--target-os=linux \
+ 			--disable-hwaccels \
+ 			--enable-parsers \
+@@ -44,7 +47,7 @@ configure:
+ 			--enable-gpl \
+ 			--enable-version3 \
+ 			--enable-protocols \
+-			--enable-libsmbclient \
++			--disable-libsmbclient \
+ 			--enable-libssh \
+ 			--enable-nonfree \
+ 			--enable-openssl \

--- a/recipes-multimedia/omxplayer/omxplayer/0001-openssl-Support-version-1.1.0.patch
+++ b/recipes-multimedia/omxplayer/omxplayer/0001-openssl-Support-version-1.1.0.patch
@@ -1,0 +1,233 @@
+From 3e085f3e5ff4b45672ccb43b4556ddf86f805c1f Mon Sep 17 00:00:00 2001
+From: Matt Oliver <protogonoi@gmail.com>
+Date: Wed, 12 Sep 2018 22:47:20 -0700
+Subject: [PATCH] openssl: Support version 1.1.0
+
+Fixes #5675
+
+Upstream-Status: Backport
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ configure                 |   3 +-
+ libavformat/tls_openssl.c | 163 +++++++++++++++++++++++---------------
+ 2 files changed, 102 insertions(+), 64 deletions(-)
+
+diff --git a/configure b/configure
+index 592df195ac..cc5c8e70fc 100755
+--- a/configure
++++ b/configure
+@@ -5788,7 +5788,8 @@ enabled omx               && { check_header OMX_Core.h ||
+                                     add_cflags -isystem/opt/vc/include/IL ; }
+                                 check_header OMX_Core.h ; } ||
+                                die "ERROR: OpenMAX IL headers not found"; }
+-enabled openssl           && { use_pkg_config openssl openssl/ssl.h SSL_library_init ||
++enabled openssl           && { use_pkg_config openssl openssl/ssl.h OPENSSL_init_ssl ||
++                               use_pkg_config openssl openssl/ssl.h SSL_library_init ||
+                                check_lib openssl/ssl.h SSL_library_init -lssl -lcrypto ||
+                                check_lib openssl/ssl.h SSL_library_init -lssl32 -leay32 ||
+                                check_lib openssl/ssl.h SSL_library_init -lssl -lcrypto -lws2_32 -lgdi32 ||
+diff --git a/libavformat/tls_openssl.c b/libavformat/tls_openssl.c
+index 46eb3e68c7..c551ac74e2 100644
+--- a/libavformat/tls_openssl.c
++++ b/libavformat/tls_openssl.c
+@@ -43,6 +43,9 @@ typedef struct TLSContext {
+     TLSShared tls_shared;
+     SSL_CTX *ctx;
+     SSL *ssl;
++#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
++    BIO_METHOD* url_bio_method;
++#endif
+ } TLSContext;
+ 
+ #if HAVE_THREADS
+@@ -63,6 +66,87 @@ static unsigned long openssl_thread_id(void)
+ #endif
+ #endif
+ 
++static int url_bio_create(BIO *b)
++{
++#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
++    BIO_set_init(b, 1);
++    BIO_set_data(b, NULL);
++    BIO_set_flags(b, 0);
++#else
++    b->init = 1;
++    b->ptr = NULL;
++    b->flags = 0;
++#endif
++    return 1;
++}
++
++static int url_bio_destroy(BIO *b)
++{
++    return 1;
++}
++
++#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
++#define GET_BIO_DATA(x) BIO_get_data(x);
++#else
++#define GET_BIO_DATA(x) (x)->ptr;
++#endif
++
++static int url_bio_bread(BIO *b, char *buf, int len)
++{
++    URLContext *h;
++    int ret;
++    h = GET_BIO_DATA(b);
++    ret = ffurl_read(h, buf, len);
++    if (ret >= 0)
++        return ret;
++    BIO_clear_retry_flags(b);
++    if (ret == AVERROR_EXIT)
++        return 0;
++    return -1;
++}
++
++static int url_bio_bwrite(BIO *b, const char *buf, int len)
++{
++    URLContext *h;
++    int ret;
++    h = GET_BIO_DATA(b);
++    ret = ffurl_write(h, buf, len);
++    if (ret >= 0)
++        return ret;
++    BIO_clear_retry_flags(b);
++    if (ret == AVERROR_EXIT)
++        return 0;
++    return -1;
++}
++
++static long url_bio_ctrl(BIO *b, int cmd, long num, void *ptr)
++{
++    if (cmd == BIO_CTRL_FLUSH) {
++        BIO_clear_retry_flags(b);
++        return 1;
++    }
++    return 0;
++}
++
++static int url_bio_bputs(BIO *b, const char *str)
++{
++    return url_bio_bwrite(b, str, strlen(str));
++}
++
++#if OPENSSL_VERSION_NUMBER < 0x1010000fL
++static BIO_METHOD url_bio_method = {
++    .type = BIO_TYPE_SOURCE_SINK,
++    .name = "urlprotocol bio",
++    .bwrite = url_bio_bwrite,
++    .bread = url_bio_bread,
++    .bputs = url_bio_bputs,
++    .bgets = NULL,
++    .ctrl = url_bio_ctrl,
++    .create = url_bio_create,
++    .destroy = url_bio_destroy,
++};
++#endif
++
+ int ff_openssl_init(void)
+ {
+     avpriv_lock_avformat();
+@@ -128,73 +212,14 @@ static int tls_close(URLContext *h)
+         SSL_CTX_free(c->ctx);
+     if (c->tls_shared.tcp)
+         ffurl_close(c->tls_shared.tcp);
++#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
++    if (c->url_bio_method)
++        BIO_meth_free(c->url_bio_method);
++#endif
+     ff_openssl_deinit();
+     return 0;
+ }
+ 
+-static int url_bio_create(BIO *b)
+-{
+-    b->init = 1;
+-    b->ptr = NULL;
+-    b->flags = 0;
+-    return 1;
+-}
+-
+-static int url_bio_destroy(BIO *b)
+-{
+-    return 1;
+-}
+-
+-static int url_bio_bread(BIO *b, char *buf, int len)
+-{
+-    URLContext *h = b->ptr;
+-    int ret = ffurl_read(h, buf, len);
+-    if (ret >= 0)
+-        return ret;
+-    BIO_clear_retry_flags(b);
+-    if (ret == AVERROR_EXIT)
+-        return 0;
+-    return -1;
+-}
+-
+-static int url_bio_bwrite(BIO *b, const char *buf, int len)
+-{
+-    URLContext *h = b->ptr;
+-    int ret = ffurl_write(h, buf, len);
+-    if (ret >= 0)
+-        return ret;
+-    BIO_clear_retry_flags(b);
+-    if (ret == AVERROR_EXIT)
+-        return 0;
+-    return -1;
+-}
+-
+-static long url_bio_ctrl(BIO *b, int cmd, long num, void *ptr)
+-{
+-    if (cmd == BIO_CTRL_FLUSH) {
+-        BIO_clear_retry_flags(b);
+-        return 1;
+-    }
+-    return 0;
+-}
+-
+-static int url_bio_bputs(BIO *b, const char *str)
+-{
+-    return url_bio_bwrite(b, str, strlen(str));
+-}
+-
+-static BIO_METHOD url_bio_method = {
+-    .type = BIO_TYPE_SOURCE_SINK,
+-    .name = "urlprotocol bio",
+-    .bwrite = url_bio_bwrite,
+-    .bread = url_bio_bread,
+-    .bputs = url_bio_bputs,
+-    .bgets = NULL,
+-    .ctrl = url_bio_ctrl,
+-    .create = url_bio_create,
+-    .destroy = url_bio_destroy,
+-};
+-
+ static int tls_open(URLContext *h, const char *uri, int flags, AVDictionary **options)
+ {
+     TLSContext *p = h->priv_data;
+@@ -240,8 +265,20 @@ static int tls_open(URLContext *h, const char *uri, int flags, AVDictionary **op
+         ret = AVERROR(EIO);
+         goto fail;
+     }
++#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
++    p->url_bio_method = BIO_meth_new(BIO_TYPE_SOURCE_SINK, "urlprotocol bio");
++    BIO_meth_set_write(p->url_bio_method, url_bio_bwrite);
++    BIO_meth_set_read(p->url_bio_method, url_bio_bread);
++    BIO_meth_set_puts(p->url_bio_method, url_bio_bputs);
++    BIO_meth_set_ctrl(p->url_bio_method, url_bio_ctrl);
++    BIO_meth_set_create(p->url_bio_method, url_bio_create);
++    BIO_meth_set_destroy(p->url_bio_method, url_bio_destroy);
++    bio = BIO_new(p->url_bio_method);
++    BIO_set_data(bio, c->tcp);
++#else
+     bio = BIO_new(&url_bio_method);
+     bio->ptr = c->tcp;
++#endif
+     SSL_set_bio(p->ssl, bio, bio);
+     if (!c->listen && !c->numerichost)
+         SSL_set_tlsext_host_name(p->ssl, c->host);
+-- 
+2.19.0
+

--- a/recipes-multimedia/omxplayer/omxplayer/0001-rtmpdh-Stop-using-OpenSSL-provided-DH-functions-to-s.patch
+++ b/recipes-multimedia/omxplayer/omxplayer/0001-rtmpdh-Stop-using-OpenSSL-provided-DH-functions-to-s.patch
@@ -1,0 +1,223 @@
+From db251a3d71020ef15094158ccd69d2c32ddd194d Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 12 Sep 2018 23:55:42 -0700
+Subject: [PATCH] rtmpdh: Stop using OpenSSL-provided DH functions to support
+ 1.1.0
+
+DH (struct dh_st) was made private in the 1.1 series, instead
+DH is now done the same way as with gcrypt / libgmp.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ libavformat/rtmpdh.c | 95 +++++++++++++++++++++-----------------------
+ libavformat/rtmpdh.h | 14 +++----
+ 2 files changed, 52 insertions(+), 57 deletions(-)
+
+diff --git a/libavformat/rtmpdh.c b/libavformat/rtmpdh.c
+index 1876fd44f9..8eb088237b 100644
+--- a/libavformat/rtmpdh.c
++++ b/libavformat/rtmpdh.c
+@@ -54,7 +54,6 @@
+     "F71C35FDAD44CFD2D74F9208BE258FF324943328F67329C0" \
+     "FFFFFFFFFFFFFFFF"
+ 
+-#if CONFIG_GMP || CONFIG_GCRYPT
+ #if CONFIG_GMP
+ #define bn_new(bn)                      \
+     do {                                \
+@@ -93,7 +92,6 @@
+         else                                        \
+             ret = 1;                                \
+     } while (0)
+-#define bn_modexp(bn, y, q, p)      mpz_powm(bn, y, q, p)
+ #define bn_random(bn, num_bits)                       \
+     do {                                              \
+         int bits = num_bits;                          \
+@@ -104,6 +102,11 @@
+         }                                             \
+         mpz_fdiv_r_2exp(bn, bn, num_bits);            \
+     } while (0)
++static int bn_modexp(FFBigNum bn, FFBigNum y, FFBigNum q, FFBigNum p)
++{
++    mpz_powm(bn, y, q, p);
++    return 0;
++}
+ #elif CONFIG_GCRYPT
+ #define bn_new(bn)                                              \
+     do {                                                        \
+@@ -125,13 +128,42 @@
+ #define bn_bn2bin(bn, buf, len)     gcry_mpi_print(GCRYMPI_FMT_USG, buf, len, NULL, bn)
+ #define bn_bin2bn(bn, buf, len)     gcry_mpi_scan(&bn, GCRYMPI_FMT_USG, buf, len, NULL)
+ #define bn_hex2bn(bn, buf, ret)     ret = (gcry_mpi_scan(&bn, GCRYMPI_FMT_HEX, buf, 0, 0) == 0)
+-#define bn_modexp(bn, y, q, p)      gcry_mpi_powm(bn, y, q, p)
+ #define bn_random(bn, num_bits)     gcry_mpi_randomize(bn, num_bits, GCRY_WEAK_RANDOM)
++static int bn_modexp(FFBigNum bn, FFBigNum y, FFBigNum q, FFBigNum p)
++{
++    gcry_mpi_powm(bn, y, q, p);
++    return 0;
++}
++#elif CONFIG_OPENSSL
++#define bn_new(bn)                  bn = BN_new()
++#define bn_free(bn)                 BN_free(bn)
++#define bn_set_word(bn, w)          BN_set_word(bn, w)
++#define bn_cmp(a, b)                BN_cmp(a, b)
++#define bn_copy(to, from)           BN_copy(to, from)
++#define bn_sub_word(bn, w)          BN_sub_word(bn, w)
++#define bn_cmp_1(bn)                BN_cmp(bn, BN_value_one())
++#define bn_num_bytes(bn)            BN_num_bytes(bn)
++#define bn_bn2bin(bn, buf, len)     BN_bn2bin(bn, buf)
++#define bn_bin2bn(bn, buf, len)     bn = BN_bin2bn(buf, len, 0)
++#define bn_hex2bn(bn, buf, ret)     ret = BN_hex2bn(&bn, buf)
++#define bn_random(bn, num_bits)     BN_rand(bn, num_bits, 0, 0)
++static int bn_modexp(FFBigNum bn, FFBigNum y, FFBigNum q, FFBigNum p)
++{
++    BN_CTX *ctx = BN_CTX_new();
++    if (!ctx)
++        return AVERROR(ENOMEM);
++    if (!BN_mod_exp(bn, y, q, p, ctx)) {
++        BN_CTX_free(ctx);
++        return AVERROR(EINVAL);
++    }
++    BN_CTX_free(ctx);
++    return 0;
++}
+ #endif
+ 
+ #define MAX_BYTES 18000
+ 
+-#define dh_new()                    av_malloc(sizeof(FF_DH))
++#define dh_new()                    av_mallocz(sizeof(FF_DH))
+ 
+ static FFBigNum dh_generate_key(FF_DH *dh)
+ {
+@@ -152,7 +184,8 @@ static FFBigNum dh_generate_key(FF_DH *dh)
+         return NULL;
+     }
+ 
+-    bn_modexp(dh->pub_key, dh->g, dh->priv_key, dh->p);
++    if (bn_modexp(dh->pub_key, dh->g, dh->priv_key, dh->p) < 0)
++        return NULL;
+ 
+     return dh->pub_key;
+ }
+@@ -161,12 +194,16 @@ static int dh_compute_key(FF_DH *dh, FFBigNum pub_key_bn,
+                           uint32_t secret_key_len, uint8_t *secret_key)
+ {
+     FFBigNum k;
++    int ret;
+ 
+     bn_new(k);
+     if (!k)
+         return -1;
+ 
+-    bn_modexp(k, pub_key_bn, dh->priv_key, dh->p);
++    if ((ret = bn_modexp(k, pub_key_bn, dh->priv_key, dh->p)) < 0) {
++        bn_free(k);
++        return ret;
++    }
+     bn_bn2bin(k, secret_key, secret_key_len);
+     bn_free(k);
+ 
+@@ -184,48 +221,6 @@ void ff_dh_free(FF_DH *dh)
+     bn_free(dh->priv_key);
+     av_free(dh);
+ }
+-#elif CONFIG_OPENSSL
+-#define bn_new(bn)                  bn = BN_new()
+-#define bn_free(bn)                 BN_free(bn)
+-#define bn_set_word(bn, w)          BN_set_word(bn, w)
+-#define bn_cmp(a, b)                BN_cmp(a, b)
+-#define bn_copy(to, from)           BN_copy(to, from)
+-#define bn_sub_word(bn, w)          BN_sub_word(bn, w)
+-#define bn_cmp_1(bn)                BN_cmp(bn, BN_value_one())
+-#define bn_num_bytes(bn)            BN_num_bytes(bn)
+-#define bn_bn2bin(bn, buf, len)     BN_bn2bin(bn, buf)
+-#define bn_bin2bn(bn, buf, len)     bn = BN_bin2bn(buf, len, 0)
+-#define bn_hex2bn(bn, buf, ret)     ret = BN_hex2bn(&bn, buf)
+-#define bn_modexp(bn, y, q, p)               \
+-    do {                                     \
+-        BN_CTX *ctx = BN_CTX_new();          \
+-        if (!ctx)                            \
+-            return AVERROR(ENOMEM);          \
+-        if (!BN_mod_exp(bn, y, q, p, ctx)) { \
+-            BN_CTX_free(ctx);                \
+-            return AVERROR(EINVAL);          \
+-        }                                    \
+-        BN_CTX_free(ctx);                    \
+-    } while (0)
+-
+-#define dh_new()                                DH_new()
+-#define dh_generate_key(dh)                     DH_generate_key(dh)
+-
+-static int dh_compute_key(FF_DH *dh, FFBigNum pub_key_bn,
+-                          uint32_t secret_key_len, uint8_t *secret_key)
+-{
+-    if (secret_key_len < DH_size(dh))
+-        return AVERROR(EINVAL);
+-    return DH_compute_key(secret_key, pub_key_bn, dh);
+-}
+-
+-void ff_dh_free(FF_DH *dh)
+-{
+-    if (!dh)
+-        return;
+-    DH_free(dh);
+-}
+-#endif
+ 
+ static int dh_is_valid_public_key(FFBigNum y, FFBigNum p, FFBigNum q)
+ {
+@@ -254,8 +249,10 @@ static int dh_is_valid_public_key(FFBigNum y, FFBigNum p, FFBigNum q)
+      * random data.
+      */
+     /* y must fulfill y^q mod p = 1 */
+-    bn_modexp(bn, y, q, p);
++    if ((ret = bn_modexp(bn, y, q, p)) < 0)
++        goto fail;
+ 
++    ret = AVERROR(EINVAL);
+     if (bn_cmp_1(bn))
+         goto fail;
+ 
+diff --git a/libavformat/rtmpdh.h b/libavformat/rtmpdh.h
+index 2b250f595d..188aad7a45 100644
+--- a/libavformat/rtmpdh.h
++++ b/libavformat/rtmpdh.h
+@@ -26,7 +26,6 @@
+ 
+ #include "config.h"
+ 
+-#if CONFIG_GMP || CONFIG_GCRYPT
+ #if CONFIG_GMP
+ #include <gmp.h>
+ 
+@@ -35,6 +34,12 @@ typedef mpz_ptr FFBigNum;
+ #include <gcrypt.h>
+ 
+ typedef gcry_mpi_t FFBigNum;
++
++#elif CONFIG_OPENSSL
++#include <openssl/bn.h>
++#include <openssl/dh.h>
++
++typedef BIGNUM *FFBigNum;
+ #endif
+ 
+ typedef struct FF_DH {
+@@ -45,13 +50,6 @@ typedef struct FF_DH {
+     long length;
+ } FF_DH;
+ 
+-#elif CONFIG_OPENSSL
+-#include <openssl/bn.h>
+-#include <openssl/dh.h>
+-
+-typedef BIGNUM *FFBigNum;
+-typedef DH FF_DH;
+-#endif
+ 
+ /**
+  * Initialize a Diffie-Hellmann context.
+-- 
+2.19.0
+

--- a/recipes-multimedia/omxplayer/omxplayer/0001-swresample-arm-avoid-conditional-branch-to-PLT-in-TH.patch
+++ b/recipes-multimedia/omxplayer/omxplayer/0001-swresample-arm-avoid-conditional-branch-to-PLT-in-TH.patch
@@ -1,0 +1,75 @@
+From 6616f39fec0aa6270a707c8d0eb0f78c4b616eb9 Mon Sep 17 00:00:00 2001
+From: Rahul Chaudhry <rahulchaudhry@chromium.org>
+Date: Wed, 18 Apr 2018 16:40:28 -0700
+Subject: [PATCH] swresample/arm: avoid conditional branch to PLT in THUMB-2.
+
+On Wed, Apr 18, 2018 at 3:46 PM, Michael Niedermayer
+<michael@niedermayer.cc> wrote:
+> please make sure this works on apple based arm (unless you know it works)
+> (ive tested qemu linux based)
+>
+> Also please add a commit message
+
+If by 'apple based arm' you mean llvm/clang assembler, then yes, I've verified
+that the assembly works with armv7a-cros-linux-gnueabi-clang (version 7.0.0).
+
+Updated patch with new commit message is attached.
+
+Thanks,
+Rahul
+>From 2e3318acf266b519e98b680102a07196d6ddbf93 Mon Sep 17 00:00:00 2001
+From: Rahul Chaudhry <rahulchaudhry@chromium.org>
+Date: Wed, 18 Apr 2018 16:29:39 -0700
+Subject: [PATCH] swresample/arm: remove unintentional relocation.
+
+Branch to global symbol results in reference to PLT, and when compiling
+for THUMB-2 - in a R_ARM_THM_JUMP19 relocation. Some linkers don't
+support this relocation (ld.gold), while others can end up truncating
+the relocation to fit (ld.bfd).
+
+Convert this branch through PLT into a direct branch that the assembler
+can resolve locally.
+
+See https://github.com/android-ndk/ndk/issues/337 for background.
+
+The current workaround is to disable neon during gstreamer build,
+which is not optimal and can be reverted after this patch:
+https://github.com/freedesktop/gstreamer-cerbero/commit/41556c415739fbc3a72c7eaee7e70a565b719b2f
+---
+ libswresample/arm/audio_convert_neon.S | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/libswresample/arm/audio_convert_neon.S b/libswresample/arm/audio_convert_neon.S
+index 1f88316dde..7729514701 100644
+--- a/libswresample/arm/audio_convert_neon.S
++++ b/libswresample/arm/audio_convert_neon.S
+@@ -22,6 +22,7 @@
+ #include "libavutil/arm/asm.S"
+ 
+ function swri_oldapi_conv_flt_to_s16_neon, export=1
++_swri_oldapi_conv_flt_to_s16_neon:
+         subs            r2,  r2,  #8
+         vld1.32         {q0},     [r1,:128]!
+         vcvt.s32.f32    q8,  q0,  #31
+@@ -66,6 +67,7 @@ function swri_oldapi_conv_flt_to_s16_neon, export=1
+ endfunc
+ 
+ function swri_oldapi_conv_fltp_to_s16_2ch_neon, export=1
++_swri_oldapi_conv_fltp_to_s16_2ch_neon:
+         ldm             r1,  {r1, r3}
+         subs            r2,  r2,  #8
+         vld1.32         {q0},     [r1,:128]!
+@@ -133,8 +135,8 @@ function swri_oldapi_conv_fltp_to_s16_nch_neon, export=1
+         cmp             r3,  #2
+         itt             lt
+         ldrlt           r1,  [r1]
+-        blt             X(swri_oldapi_conv_flt_to_s16_neon)
+-        beq             X(swri_oldapi_conv_fltp_to_s16_2ch_neon)
++        blt             _swri_oldapi_conv_flt_to_s16_neon
++        beq             _swri_oldapi_conv_fltp_to_s16_2ch_neon
+ 
+         push            {r4-r8, lr}
+         cmp             r3,  #4
+-- 
+2.19.0
+

--- a/recipes-multimedia/omxplayer/omxplayer_git.bb
+++ b/recipes-multimedia/omxplayer/omxplayer_git.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 DEPENDS = "libpcre libav virtual/egl boost freetype dbus openssl libssh libomxil coreutils-native curl-native"
 PR = "r4"
 
-SRCREV_default = "b8ff59dccd9307f10dad71bec2525a95bd6c603b"
+SRCREV_default = "7f3faf6cadac913013248de759462bcff92f0102"
 
 # omxplayer builds its own copy of ffmpeg from source instead of using the
 # system's ffmpeg library. This isn't ideal but it's ok for now. We do however
@@ -31,12 +31,23 @@ SRC_URI = "git://github.com/popcornmix/omxplayer.git;protocol=git;branch=master 
            file://use-native-pkg-config.patch \
            file://0005-Don-t-require-internet-connection-during-build.patch \
            file://0006-Prevent-ffmpeg-configure-compile-race-condition.patch \
+           file://0001-Specify-cc-cxx-and-ld-variables-from-environment.patch \
+           file://0001-openssl-Support-version-1.1.0.patch;patchdir=ffmpeg \
+           file://0001-swresample-arm-avoid-conditional-branch-to-PLT-in-TH.patch;patchdir=ffmpeg \
+           file://0001-rtmpdh-Stop-using-OpenSSL-provided-DH-functions-to-s.patch;patchdir=ffmpeg \
            "
 S = "${WORKDIR}/git"
 
 COMPATIBLE_MACHINE ?= "null"
-COMPATIBLE_MACHINE_rpi_aarch64 = "null"
-COMPATIBLE_MACHINE_rpi = "(.*)"
+COMPATIBLE_HOST_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'null', '(.*)', d)}"
+
+def cpu(d):
+    for arg in (d.getVar('TUNE_CCARGS') or '').split():
+        if arg.startswith('-mcpu='):
+            return arg[6:]
+    return 'generic'
+
+export CPU = "${@cpu(d)}"
 
 inherit autotools-brokensep pkgconfig
 


### PR DESCRIPTION
* Update to latest from upstream
* Backport OpenSSL 1.1.x related patches for ffmpeg
* Pass --cpu based on machine, instead of hardcoding it to arm1176jzf-s
* Make --cc, --cxx and --ld be used from environment, helps building
  with clang
* It requires userland graphics driver to build to encode that in
  COMPATIBLE_HOST

Signed-off-by: Khem Raj <raj.khem@gmail.com>


