### PR TITLE
mesa: Build swrast gallium driver along with vc4

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -3,5 +3,5 @@
 # as default. To state out clearly that Raspi needs dri3 and to avoid surprises
 # in case oe-core changes this default, we set dri3 explicitly.
 PACKAGECONFIG_append_rpi = " gallium ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11 dri3', '', d)}"
-GALLIUMDRIVERS_rpi = "vc4"
+GALLIUMDRIVERS_append_rpi = ",vc4"
 DRIDRIVERS_rpi = ""

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/rpi/xorg.conf.d/10-noglamor.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/rpi/xorg.conf.d/10-noglamor.conf
@@ -1,6 +1,0 @@
-# 
-Section "Device"
-	Identifier "modeset"
-	Driver "modesetting"
-	Option "AccelMethod" "None"
-EndSection

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
@@ -3,18 +3,13 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append_rpi = " \
     file://xorg.conf.d/98-pitft.conf \
     file://xorg.conf.d/99-calibration.conf \
-    file://xorg.conf.d/10-noglamor.conf \
 "
 do_install_append_rpi () {
     PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
-    VC4="${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"
     if [ "${PITFT}" = "1" ]; then
         install -d ${D}/${sysconfdir}/X11/xorg.conf.d/
         install -m 0644 ${WORKDIR}/xorg.conf.d/98-pitft.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
         install -m 0644 ${WORKDIR}/xorg.conf.d/99-calibration.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
-    fi
-    if [ "${VC4}" = "1" ]; then
-        install -Dm 0644 ${WORKDIR}/xorg.conf.d/10-noglamor.conf ${D}/${sysconfdir}/X11/xorg.conf.d/10-noglamor.conf
     fi
 }
 


### PR DESCRIPTION
when running -ctestimage target, it fails because of errors it finds in
Xorg logs

| Log:
/mnt/a/yoe/build/tmp/work/raspberrypi3-yoe-linux-gnueabi/core-image-sato/1.0-r0/target_logs/Xorg.0.log
| -----------------------
| Central error: [    14.760] (EE) AIGLX error: dlopen of /usr/lib/dri/swrast_dri.so failed (/usr/lib/dri/swrast_dri.so: cannot open shared object file: No such file or directory)

Therefore we enable swrast gallium drivers to make xorg happy

Signed-off-by: Khem Raj <raj.khem@gmail.com>