### PR TITLE
rpi-config: Use vc4-kms-v3d for raspberrypi3-64 as well

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -23,7 +23,6 @@ PITFT28r="${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "1", "0", d)}"
 PITFT35r="${@bb.utils.contains("MACHINE_FEATURES", "pitft35r", "1", "0", d)}"
 
 VC4GRAPHICS="${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"
-VC4DTBO_raspberrypi3-64 ?= "vc4-fkms-v3d"
 VC4DTBO ?= "vc4-kms-v3d"
 
 inherit deploy nopackages


### PR DESCRIPTION
vc4-fkms-v3d needs dispmanx, its DRM VC4 V3D driver on top of the dispmanx
display stack, this does not work with 4.14 kernel and since we always
use vc4graphics on 64bit, just keep using vc4-kms-v3d dtbo which should
enable right graphics

Tested with core-image-sato, running glxgears with 55.5fps in
raspberrypi3-64

Signed-off-by: Khem Raj <raj.khem@gmail.com>

