### PR TITLE
rpi-cm3 includes rpi3, not rpi2

### DIFF
--- a/docs/layer-contents.md
+++ b/docs/layer-contents.md
@@ -9,7 +9,7 @@
 * raspberrypi3
 * raspberrypi3-64 (64 bit kernel & userspace)
 * raspberrypi-cm (dummy alias for raspberrypi)
-* raspberrypi-cm3 (dummy alias for raspberrypi2)
+* raspberrypi-cm3 (dummy alias for raspberrypi3)
 
 Note: The raspberrypi3 machines include support for Raspberry Pi 3B+.
 


### PR DESCRIPTION
docs: Fix raspberrypi-cm3 alias information

Signed-off-by Moritz Augsburger <moritz.augsburger@gmail.com>