### PR TITLE
CAN: Add Pican2 support

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -26,6 +26,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/iqaudio-dac.dtbo \
     overlays/iqaudio-dacplus.dtbo \
     overlays/lirc-rpi.dtbo \
+    overlays/mcp2515-can0.dtbo \
     overlays/pi3-disable-bt.dtbo \
     overlays/pi3-miniuart-bt.dtbo \
     overlays/pitft22.dtbo \

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -246,6 +246,15 @@ When using device tree kernels, set this variable to enable the 802.15.4 hat:
 
 See: <https://openlabs.co/OSHW/Raspberry-Pi-802.15.4-radio>
 
+## Enable CAN with Pican2
+
+In order to use Pican2 CAN module, set the following variables:
+
+	ENABLE_SPI_BUS = "1"
+	ENABLE_CAN = "1"
+
+See: <http://skpang.co.uk/catalog/pican2-canbus-board-for-raspberry-pi-23-p-1475.html>
+
 ## Manual additions to config.txt
 
 The `RPI_EXTRA_CONFIG` variable can be used to manually add additional lines to

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -183,6 +183,12 @@ do_deploy() {
         echo "dtoverlay=at86rf233,speed=3000000" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
+    # ENABLE CAN
+    if [ "${ENABLE_CAN}" = "1" ]; then
+        echo "# Enable CAN" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=25" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+
     # Append extra config if the user has provided any
     echo "${RPI_EXTRA_CONFIG}" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
 }

--- a/recipes-core/udev/udev-rules-rpi.bb
+++ b/recipes-core/udev/udev-rules-rpi.bb
@@ -2,7 +2,10 @@ DESCRIPTION = "udev rules for Raspberry Pi Boards"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRC_URI = " file://99-com.rules"
+SRC_URI = " \
+	file://99-com.rules \
+	file://can.rules \
+	"
 
 S = "${WORKDIR}"
 
@@ -11,4 +14,5 @@ INHIBIT_DEFAULT_DEPS = "1"
 do_install () {
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${WORKDIR}/99-com.rules ${D}${sysconfdir}/udev/rules.d/
+    install -m 0644 ${WORKDIR}/can.rules ${D}${sysconfdir}/udev/rules.d/
 }

--- a/recipes-core/udev/udev-rules-rpi/can.rules
+++ b/recipes-core/udev/udev-rules-rpi/can.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", DEVPATH=="/devices/platform/soc/3f204000.spi/spi_master/spi0/spi0.0/net/can0", RUN+="/sbin/ip link set can0 up type can bitrate 500000"


### PR DESCRIPTION
In order to make Pican 2 work, we :
- add mcp2515.dto to the overlay list
- add a variable to enable it in local.conf
- create a udev rule to mount interface

http://skpang.co.uk/catalog/pican2-canbus-board-for-raspberry-pi-23-p-1475.html

Signed-off-by: Fabien Lahoudere <fabien.lahoudere@collabora.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
