### PR TITLE
userland: rprovide debiannamed libraries

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -12,7 +12,6 @@ do_configure_prepend_rpi() {
     # Add the appropriate EGLFS_DEVICE_INTEGRATION
     if [ "${@d.getVar('OE_QTBASE_EGLFS_DEVICE_INTEGRATION')}" != "" ]; then
         echo "EGLFS_DEVICE_INTEGRATION = ${OE_QTBASE_EGLFS_DEVICE_INTEGRATION}" > ${S}/mkspecs/oe-device-extra.pri
-        echo "QT_QPA_DEFAULT_PLATFORM = eglfs" >> ${S}/mkspecs/oe-device-extra.pri
     fi
 }
 RDEPENDS_${PN}_append_rpi = " userland"

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENCE;md5=0448d6488ef8cc380632b1569ee6d196"
 
 PROVIDES += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "", "virtual/libgles2 virtual/egl", d)}"
 
-RPROVIDES_${PN} += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "", "libgles2 egl libegl", d)}"
+RPROVIDES_${PN} += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "", "libgles2 egl libegl libegl1 libgl1 libglesv2-2", d)}"
 COMPATIBLE_MACHINE = "^rpi$"
 
 SRCBRANCH = "master"
@@ -91,4 +91,4 @@ FILES_${PN}-dbg += "${libdir}/plugins/.debug"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 RDEPENDS_${PN} += "bash"
-RDEPENDS_${PN} += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "libegl", "", d)}"
+RDEPENDS_${PN} += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "libegl1", "", d)}"


### PR DESCRIPTION
These names are mapped to mesa equivalent rproviders
when using vc4 rdep should be on libegl1 which is then
mapped to libegl-mesa since thats what provides libegl1
when using mesa. The libegl is not a global name for this
library

Fixes

ERROR: userland-20181120-r0 do_package_qa: QA Issue: /usr/lib/libWFC.so
contained in package userland requires libEGL.so.1, but no providers
found in RDEPENDS_userland? [file-rdeps]

Signed-off-by: Khem Raj <raj.khem@gmail.com>

