### PR TITLE
Remove support of the deprecated SDIMG_COMPRESSION variable

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -64,13 +64,6 @@ do_image_rpi_sdimg[recrdeps] = "do_build"
 # SD card image name
 SDIMG = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.rpi-sdimg"
 
-# Compression method to apply to SDIMG after it has been created. Supported
-# compression formats are "gzip", "bzip2" or "xz". The original .rpi-sdimg file
-# is kept and a new compressed file is created if one of these compression
-# formats is chosen. If SDIMG_COMPRESSION is set to any other value it is
-# silently ignored.
-#SDIMG_COMPRESSION ?= ""
-
 # Additional files and/or directories to be copied into the vfat partition from the IMAGE_ROOTFS.
 FATPAYLOAD ?= ""
 
@@ -177,19 +170,6 @@ IMAGE_CMD_rpi-sdimg () {
     else
         dd if=${SDIMG_ROOTFS} of=${SDIMG} conv=notrunc seek=1 bs=$(expr 1024 \* ${BOOT_SPACE_ALIGNED} + ${IMAGE_ROOTFS_ALIGNMENT} \* 1024)
     fi
-
-    # Optionally apply compression
-    case "${SDIMG_COMPRESSION}" in
-    "gzip")
-        gzip -k9 "${SDIMG}"
-        ;;
-    "bzip2")
-        bzip2 -k9 "${SDIMG}"
-        ;;
-    "xz")
-        xz -k "${SDIMG}"
-        ;;
-    esac
 }
 
 ROOTFS_POSTPROCESS_COMMAND += " rpi_generate_sysctl_config ; "

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -13,9 +13,6 @@ specific to it. For the rest please check:
 2. Overwrite SDIMG_ROOTFS_TYPE in local.conf
     * `SDIMG_ROOTFS_TYPE = "ext3.xz"`
 
-3. Overwrite SDIMG_COMPRESSION in local.conf
-    * `SDIMG_COMPRESSION = "xz"`
-
 Accommodate the values above to your own needs (ex: ext3 / ext4).
 
 ## GPU memory


### PR DESCRIPTION
SDIMG_COMPRESSION is not used too much, and it has limitations for
multi-threaded compression process. Instead, meta/classes/image_types.bbclass
does the trick in a generic and supported way, thus it was suggested
to remove SDIMG_COMPRESSION variable and related codepaths altogether
to avoid confusion in the future. IMAGE_FSTYPES variable should be used
instead.

Signed-off-by: Iurii Lunev <koolkhel@mail.ru>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

I removed SDIMG_COMPRESSION definition and usage so no references to that variable exist anymore.

**- How I did it**

By removing :-) See the earlier PR here for reasoning: https://github.com/agherzan/meta-raspberrypi/pull/210