### PR TITLE
qtbase: Get eglfs/kms working with vc4graphics

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,12 +1,12 @@
 PACKAGECONFIG_GL_rpi = "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'gl', \
-                        bb.utils.contains('DISTRO_FEATURES',     'opengl', 'eglfs gles2 linuxfb', \
+                        bb.utils.contains('DISTRO_FEATURES',     'opengl', 'eglfs gles2', \
                                                                        '', d), d)}"
-#PACKAGECONFIG_GL_rpi = "${@bb.utils.any_distro_features('x11 wayland', '', 'eglfs', d)}"
+PACKAGECONFIG_GL_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', ' gbm kms', '', d)}"
 PACKAGECONFIG_FONTS_rpi = "fontconfig"
 PACKAGECONFIG_append_rpi = " libinput examples tslib xkb xkbcommon-evdev"
 PACKAGECONFIG_remove_rpi = "tests"
 
-OE_QTBASE_EGLFS_DEVICE_INTEGRATION_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'eglfs_kms', 'eglfs_brcm', d)}"
+OE_QTBASE_EGLFS_DEVICE_INTEGRATION_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'eglfs_brcm', d)}"
 
 do_configure_prepend_rpi() {
     # Add the appropriate EGLFS_DEVICE_INTEGRATION


### PR DESCRIPTION
- Drop enabling linuxfb, now we can get eglfs going
- Enable kms and gbm feature when using vc4graphics driver
- No need to set OE_QTBASE_EGLFS_DEVICE_INTEGRATION when using vc4graphics

Signed-off-by: Khem Raj <raj.khem@gmail.com>

