### PR TITLE
userland: Use original name libegl-mesa in rdeps

### DIFF
--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -91,4 +91,4 @@ FILES_${PN}-dbg += "${libdir}/plugins/.debug"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 RDEPENDS_${PN} += "bash"
-RDEPENDS_${PN} += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "libegl1", "", d)}"
+RDEPENDS_${PN} += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "libegl-mesa", "", d)}"


### PR DESCRIPTION
This avoids a missing rdep errors seen sometimes when switching
compilers or graphic driver providers

ERROR: userland-20181120-r0 do_package_qa: QA Issue: /usr/lib/libWFC.so contained in package userland requires li bEGL.so.1, but no providers found in RDEPENDS_userland? [file-rdeps]

Signed-off-by: Khem Raj <raj.khem@gmail.com>

