### PR TITLE
linux-raspberrypi: add linux-raspberrypi-rt 4.14

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-rt_4.14.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-rt_4.14.bb
@@ -1,0 +1,9 @@
+LINUX_VERSION ?= "4.14.81"
+
+SRCREV = "acf578d07d57480674d5361df9171fe9528765cb"
+SRC_URI = " \
+    git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y-rt \
+    file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \
+    "
+
+require linux-raspberrypi.inc


### PR DESCRIPTION
select the rt kernel by adding in local.conf:

PREFERRED_PROVIDER_virtual/kernel = "linux-raspberrypi-rt"

Signed-off-by: Phong Tran <tranmanphong@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
append a new recipe for selection the linux rt
kernel source here: https://github.com/raspberrypi/linux/tree/rpi-4.14.y-rt

**- How I did it**
Build and boot with MACHINE = "raspberrypi3-64" (core-image-base)

Ref: #368 