### PR TITLE
Fixes: #169

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -190,7 +190,7 @@ do_deploy() {
     fi
 
     # Append extra config if the user has provided any
-    echo "${RPI_EXTRA_CONFIG}" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    printf "${RPI_EXTRA_CONFIG}\n" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
 }
 
 do_deploy_append_raspberrypi3-64() {


### PR DESCRIPTION
Enabled escape sequence because on some systems bash doesn't escape sequences by default. 