### PR TITLE
raspberrypi3-64.conf: Use more appropriate tune

### DIFF
--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -11,7 +11,7 @@ MACHINE_EXTRA_RRECOMMENDS += "\
     bluez-firmware-rpidistro-bcm4345c0-hcd \
 "
 
-require conf/machine/include/arm/arch-armv8.inc
+require conf/machine/include/tune-cortexa53.inc
 include conf/machine/include/rpi-base.inc
 
 RPI_KERNEL_DEVICETREE = " \


### PR DESCRIPTION
rpi3 is based on cortex-a53 implementation which is armv8+crc+simd
now that OE-Core has the appropriate tunes, switch to using the new
tune file, bonus, is that chromium will be more optimized now

Signed-off-by: Khem Raj <raj.khem@gmail.com>

