### PR TITLE
bluez-firmware-rpidistro: update bluez-firmware

### DIFF
--- a/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
+++ b/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
@@ -24,7 +24,7 @@ LIC_FILES_CHKSUM = "\
 NO_GENERIC_LICENSE[Firmware-cypress-rpidistro] = "LICENCE.cypress-rpidistro"
 
 SRC_URI = "git://github.com/RPi-Distro/bluez-firmware"
-SRCREV = "ade2bae1aaaebede09abb8fb546f767a0e4c7804"
+SRCREV = "96eefffcccc725425fd83be5e0704a5c32b79e54"
 PV = "0.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Latest bluez-firmware release updates BCM4345C0.hcd to
003.001.025.0156.0280, restoring LE scan capability.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>