### PR TITLE
qtbase: fix xkbcommon-evdev packageconfig for 5.12

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -3,7 +3,7 @@ PACKAGECONFIG_GL_rpi = "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'g
                                                                        '', d), d)}"
 #PACKAGECONFIG_GL_rpi = "${@bb.utils.any_distro_features('x11 wayland', '', 'eglfs', d)}"
 PACKAGECONFIG_FONTS_rpi = "fontconfig"
-PACKAGECONFIG_append_rpi = " libinput examples tslib xkb xkbcommon-evdev"
+PACKAGECONFIG_append_rpi = " libinput examples tslib xkb xkbcommon"
 PACKAGECONFIG_remove_rpi = "tests"
 
 OE_QTBASE_EGLFS_DEVICE_INTEGRATION_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'eglfs_kms', 'eglfs_brcm', d)}"


### PR DESCRIPTION
Patch that made `meta-qt5` use this feature has been reverted for `5.12`,
which is used by `thud` layer of `meta-qt5` with commit `33c578729e721ac80e`.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>