### PR TITLE
mesa-gl: Let userland provide libEGL and GLESv2 when vc4 graphics is …

### DIFF
--- a/recipes-graphics/mesa/mesa-gl_%.bbappend
+++ b/recipes-graphics/mesa/mesa-gl_%.bbappend
@@ -1,1 +1,12 @@
 PACKAGECONFIG_append_rpi = " gbm"
+
+do_install_append_rpi() {
+    if [ "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}" = "0" ]; then
+        rm -rf ${D}${libdir}/libEGL*
+        rm -rf ${D}${libdir}/libGLES*
+        rm -rf ${D}${libdir}/libwayland-*
+        rm -rf ${D}${libdir}/pkgconfig/egl.pc ${D}${libdir}/pkgconfig/glesv2.pc \
+            ${D}${libdir}/pkgconfig/wayland-egl.pc
+        rm -rf ${D}${includedir}/EGL ${D}${includedir}/GLES* ${D}${includedir}/KHR
+    fi
+}

--- a/recipes-graphics/mesa/mesa-gl_%.bbappend
+++ b/recipes-graphics/mesa/mesa-gl_%.bbappend
@@ -1,4 +1,5 @@
 PACKAGECONFIG_append_rpi = " gbm"
+PROVIDES_append_rpi = " virtual/libgbm"
 
 do_install_append_rpi() {
     if [ "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}" = "0" ]; then


### PR DESCRIPTION
…not used

When vc4graphics is not used then useland graphics provides these
libraries

Signed-off-by: Khem Raj <raj.khem@gmail.com>

