### PR TITLE
Build X11/eglfs images with userland graphics

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,7 +1,8 @@
 PACKAGECONFIG_GL_rpi = "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'gl', \
                         bb.utils.contains('DISTRO_FEATURES',     'opengl', 'eglfs gles2', \
                                                                        '', d), d)}"
-PACKAGECONFIG_GL_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', ' gbm kms', '', d)}"
+PACKAGECONFIG_GL_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', ' kms', '', d)}"
+PACKAGECONFIG_GL_append_rpi = " gbm"
 PACKAGECONFIG_FONTS_rpi = "fontconfig"
 PACKAGECONFIG_append_rpi = " libinput examples tslib xkb xkbcommon-evdev"
 PACKAGECONFIG_remove_rpi = "tests"
@@ -15,3 +16,4 @@ do_configure_prepend_rpi() {
     fi
 }
 RDEPENDS_${PN}_append_rpi = " userland"
+DEPENDS_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' userland', d)}"

--- a/recipes-graphics/cairo/cairo_%.bbappend
+++ b/recipes-graphics/cairo/cairo_%.bbappend
@@ -1,0 +1,3 @@
+PACKAGECONFIG_GLESV2 = " ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'glesv2', d)}"
+
+PACKAGECONFIG_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' egl ${PACKAGECONFIG_GLESV2}', d)}"

--- a/recipes-graphics/mesa/mesa-gl_%.bbappend
+++ b/recipes-graphics/mesa/mesa-gl_%.bbappend
@@ -2,12 +2,5 @@ PACKAGECONFIG_append_rpi = " gbm"
 PROVIDES_append_rpi = " virtual/libgbm"
 
 do_install_append_rpi() {
-    if [ "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}" = "0" ]; then
-        rm -rf ${D}${libdir}/libEGL*
-        rm -rf ${D}${libdir}/libGLES*
-        rm -rf ${D}${libdir}/libwayland-*
-        rm -rf ${D}${libdir}/pkgconfig/egl.pc ${D}${libdir}/pkgconfig/glesv2.pc \
-            ${D}${libdir}/pkgconfig/wayland-egl.pc
-        rm -rf ${D}${includedir}/EGL ${D}${includedir}/GLES* ${D}${includedir}/KHR
-    fi
+    rm -rf ${D}${includedir}/KHR/khrplatform.h
 }

--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -1,9 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
-LINUX_VERSION ?= "4.19.23"
+LINUX_VERSION ?= "4.19.25"
 LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 
-SRCREV = "e2d2941326922b63d722ebc46520c3a2287b675f"
+SRCREV = "7f26b4456f70f9909c19936d550cf7c5dc47e1a5"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_BRANCH} \
     "


### PR DESCRIPTION
Newer changes in OE-Core means we need to do some adjustments to get userland graphics going again. This patchset addresses that. Please note that it will also need

http://lists.openembedded.org/pipermail/openembedded-core/2019-February/279490.html