### PR TITLE
linux-raspberrypi_4.19.bb: Update to 4.19.27

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -1,9 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
-LINUX_VERSION ?= "4.19.25"
+LINUX_VERSION ?= "4.19.27"
 LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 
-SRCREV = "7f26b4456f70f9909c19936d550cf7c5dc47e1a5"
+SRCREV = "c0e09b3420442df016ee7906985535d644481e4b"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_BRANCH} \
     "


### PR DESCRIPTION
Changed to kernel 4.19.27, pointing to the current HEAD at "c0e09b3420442df016ee7906985535d644481e4b"
