### PR TITLE
linux_raspberrypi_4.19: Update to 4.19.32

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -1,9 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
-LINUX_VERSION ?= "4.19.30"
+LINUX_VERSION ?= "4.19.32"
 LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 
-SRCREV = "3c468fc8191d276e3e9efd976a0ff71271f3fc51"
+SRCREV = "d65a0f76d3adcf86a6f5c614c68edb3aeb3b8590"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_BRANCH} \
     "


### PR DESCRIPTION
The rpi-4.19.y branch has been rebased and the commit specified for
4.19.30 no longer exists upstream.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>
