### PR TITLE
linux_raspberrypi_4.19: Update to 4.19.34

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -1,9 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
-LINUX_VERSION ?= "4.19.32"
+LINUX_VERSION ?= "4.19.34"
 LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 
-SRCREV = "d65a0f76d3adcf86a6f5c614c68edb3aeb3b8590"
+SRCREV = "ab8652c03fa081b27de7e28a74c2536cb2aa3e5b"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_BRANCH} \
     "


### PR DESCRIPTION
* The branch rpi-4.19.y (and rpi-4.18.y) was recently force pushed and
  current d65a0f76d3adcf86a6f5c614c68edb3aeb3b8590 nor previous
  3c468fc8191d276e3e9efd976a0ff71271f3fc51 aren't included in any
  branch, from my local checkout update:

  e24b1f6c0c79..5f4b16e4a8d6 rpi-4.14.y -> up/rpi-4.14.y
  e54efc381a97..22bb67b8e2e8 rpi-4.14.y-rt -> up/rpi-4.14.y-rt
  3a1a31d70660...d58c595b013f rpi-4.18.y -> up/rpi-4.18.y (forced update)
  48dfbb408fdd...ab8652c03fa0 rpi-4.19.y -> up/rpi-4.19.y (forced update)
  [new branch] rpi-4.20.y -> up/rpi-4.20.y
  [new branch] rpi-5.0.y -> up/rpi-5.0.y
