### PR TITLE
qtbase_%.bbappend: update PACKAGECONFIG name for xkbcommon

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -4,7 +4,7 @@ PACKAGECONFIG_GL_rpi = "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'g
 PACKAGECONFIG_GL_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', ' kms', '', d)}"
 PACKAGECONFIG_GL_append_rpi = " gbm"
 PACKAGECONFIG_FONTS_rpi = "fontconfig"
-PACKAGECONFIG_append_rpi = " libinput examples tslib xkb xkbcommon-evdev"
+PACKAGECONFIG_append_rpi = " libinput examples tslib xkb xkbcommon"
 PACKAGECONFIG_remove_rpi = "tests"
 
 OE_QTBASE_EGLFS_DEVICE_INTEGRATION_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'eglfs_brcm', d)}"


### PR DESCRIPTION
As per [Qt 5.12.2 commit update](https://github.com/meta-qt5/meta-qt5/commit/28d4bfdf74ba9d66ad749fc7208ca8dc147a3927), xkbcommon-evdev PACKAGECONFIG option has been renamed to xkbcommon.

This commit fixes BitBake QA:
WARNING: qtbase-5.12.2+gitAUTOINC+856fb1ab44-r0 do_configure: QA Issue: qtbase: invalid PACKAGECONFIG: xkbcommon-evdev [invalid-packageconfig]

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**Note for maintainers**
I do not think those rpi appends are necessary anymore. The very same configuration is now automatically enforced in meta-qt5 by default. (Look above).

Before merging, I would like to discuss whether the appends are still required.

Thanks