### PR TITLE
rpi-default-providers.inc: default provider for virtual/kernel_poky-tiny

### DIFF
--- a/conf/machine/include/rpi-default-providers.inc
+++ b/conf/machine/include/rpi-default-providers.inc
@@ -1,6 +1,7 @@
 # RaspberryPi BSP default providers
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-raspberrypi"
+PREFERRED_PROVIDER_virtual/kernel_poky-tiny ?= "linux-raspberrypi"
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 PREFERRED_PROVIDER_virtual/egl ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "mesa", "userland", d)}"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "mesa", "userland", d)}"


### PR DESCRIPTION
For the distro poky-tiny a provider for virtual/kernel_poky-tiny
is needed instead of virtual/kernel.
This was missing in rpi-default-providers.inc

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
