### PR TITLE
meta-raspberrypi: sdcard_image-rpi, Minor bug in use of FATPAYLOAD variable

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -143,7 +143,7 @@ IMAGE_CMD_rpi-sdimg () {
         fi
     fi
 
-    if [ -n ${FATPAYLOAD} ] ; then
+    if [ -n "${FATPAYLOAD}" ] ; then
         echo "Copying payload into VFAT"
         for entry in ${FATPAYLOAD} ; do
             # add the || true to stop aborting on vfat issues like not supporting .~lock files


### PR DESCRIPTION
FATPAYLOAD has been put into double quotation marks. Otherwise, when its value is compound  (like "filename_1   filename_2   filename_3") it generates parsing error.


Signed-off-by: Nataliya Korovkina <malus.brandywine@gmail.com>