### PR TITLE
Remove sbin directory that's not part of the firmware anymore

### DIFF
--- a/recipes-graphics/vc-graphics/vc-graphics.inc
+++ b/recipes-graphics/vc-graphics/vc-graphics.inc
@@ -25,9 +25,6 @@ do_install () {
   install -d ${D}${bindir}
   cp -R bin/* ${D}${bindir}
 
-  install -d ${D}${sbindir}
-  cp -R sbin/* ${D}${sbindir}
-
   install -d ${D}${libdir}
   # note: -H option to deref symlinked .so
   cp -R -H lib/* ${D}${libdir}
@@ -49,7 +46,6 @@ INITSCRIPT_NAME = "vchiq.sh"
 INITSCRIPT_PARAMS = "start 03 S ."
 
 FILES_${PN} = "${bindir}/* \
-               ${sbindir}/* \
                ${libdir}/lib*.so \
                ${sysconfdir}/init.d \
                ${libdir}/plugins"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

The current firmware archive doesn't contain a sbin directory anymore, so it failed for me when trying to install `vcdbg`. I fixed this.

**- How I did it**

Just removed the lines affecting sbin.