### PR TITLE
omxplayer: disable thumb instruction set

### DIFF
--- a/recipes-multimedia/omxplayer/omxplayer_git.bb
+++ b/recipes-multimedia/omxplayer/omxplayer_git.bb
@@ -80,6 +80,8 @@ export INCLUDES = "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", " -D_
                   "
 export DIST = "${D}"
 
+ARM_INSTRUCTION_SET = "arm"
+
 do_compile() {
     # Needed for compiler test in ffmpeg's configure
     mkdir -p tmp


### PR DESCRIPTION
Fixes: #428

Signed-off-by: Martin Schuessler <tossprobe@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
Disabling thumb instruction set for this package

**- How I did it**
Forcing the package to compile without thumb instruction set