### PR TITLE
omxplayer: remove hardcoded tune and arch from Makefile

### DIFF
--- a/recipes-multimedia/omxplayer/omxplayer/0007-Remove-Makefile-hardcoded-arch-tune.patch
+++ b/recipes-multimedia/omxplayer/omxplayer/0007-Remove-Makefile-hardcoded-arch-tune.patch
@@ -1,0 +1,8 @@
+--- a/Makefile	2019-06-20 15:04:53.390282996 +0200
++++ b/Makefile	2019-06-20 15:03:45.538763872 +0200
+@@ -1,4 +1,4 @@
+-CFLAGS=-pipe -mfloat-abi=hard -mcpu=arm1176jzf-s -fomit-frame-pointer -mabi=aapcs-linux -mtune=arm1176jzf-s -mfpu=vfp -Wno-psabi -mno-apcs-stack-check -g -mstructure-size-boundary=32 -mno-sched-prolog
++CFLAGS+= -fomit-frame-pointer -mabi=aapcs-linux -Wno-psabi -mno-apcs-stack-check -g -mstructure-size-boundary=32 -mno-sched-prolog
+ CFLAGS+=-std=c++0x -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -DTARGET_LINUX -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -DHAVE_CMAKE_CONFIG -D__VIDEOCORE4__ -U_FORTIFY_SOURCE -Wall -DHAVE_OMXLIB -DUSE_EXTERNAL_FFMPEG  -DHAVE_LIBAVCODEC_AVCODEC_H -DHAVE_LIBAVUTIL_OPT_H -DHAVE_LIBAVUTIL_MEM_H -DHAVE_LIBAVUTIL_AVUTIL_H -DHAVE_LIBAVFORMAT_AVFORMAT_H -DHAVE_LIBAVFILTER_AVFILTER_H -DHAVE_LIBSWRESAMPLE_SWRESAMPLE_H -DOMX -DOMX_SKIP64BIT -ftree-vectorize -DUSE_EXTERNAL_OMX -DTARGET_RASPBERRY_PI -DUSE_EXTERNAL_LIBBCM_HOST
+ 
+ LDFLAGS=-L$(SDKSTAGE)/opt/vc/lib/

--- a/recipes-multimedia/omxplayer/omxplayer_git.bb
+++ b/recipes-multimedia/omxplayer/omxplayer_git.bb
@@ -33,6 +33,7 @@ SRC_URI = "git://github.com/popcornmix/omxplayer.git;protocol=git;branch=master 
            file://0006-Prevent-ffmpeg-configure-compile-race-condition.patch \
            file://0001-Specify-cc-cxx-and-ld-variables-from-environment.patch \
            file://cross-crompile-ffmpeg.patch \
+           file://0007-Remove-Makefile-hardcoded-arch-tune.patch \
            "
 
 SRC_URI_append = "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", " file://0001-Fix-build-with-vc4-driver.patch ", "", d)}"


### PR DESCRIPTION
Fixes: #428

Signed-off-by: Martin Schuessler <tossprobe@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
Removed the hardcoded arch and tune settings from Makefile 
**- How I did it**
Patching the Makefile