### PR TITLE
linux-raspberrypi: Update 4.14.y kernel

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.14.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.14.bb
@@ -1,6 +1,6 @@
-LINUX_VERSION ?= "4.14.98"
+LINUX_VERSION ?= "4.14.112"
 
-SRCREV = "5d63a4595d32a8505590d5fea5c4ec1ca79fd49d"
+SRCREV = "6b5c4a2508403839af29ef44059d04acbe0ee204"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y \
     file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \


### PR DESCRIPTION
Backport the upgrade to 4.12.112 from warrior to fix building lttng-modules-2.10.9 recently backported to oe-core thud.

Without this upgrade lttng-modules build fails with:
lttng-modules/2.10.9-r0/lttng-modules-2.10.9/probes/../blacklist/kprobes.h:19:4: error: #error "Your kernel is known to have buggy optimized kprobes implementation. Fixed by commit 0ac569bf6a7983c0c5747d6df8db9dc05bc92b6c \"ARM: 8834/1: Fix: kprobes: optimized kprobes illegal instruction\" in Linux. Disable CONFIG_OPTPROBES or upgrade your kernel."
\#  error "Your kernel is known to have buggy optimized kprobes implementation. Fixed by commit 0ac569bf6a7983c0c5747d6df8db9dc05bc92b6c \"ARM: 8834/1: Fix: kprobes: optimized kprobes illegal instruction\" in Linux. Disable CONFIG_OPTPROBES or upgrade your kernel."