### PR TITLE
linux-raspberrypi: Upgrade to 4.19.57

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -1,13 +1,16 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
-LINUX_VERSION ?= "4.19.56"
+LINUX_VERSION ?= "4.19.57"
 LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 
-SRCREV = "fba6ea6a8f6e2eaf814475812aec64de3f4912c9"
+SRCREV = "55b89745a4782db50e86291bd1adee8fb44b84ad"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_BRANCH} \
     "
 SRC_URI_append_raspberrypi4-64 = " file://rpi4-64-kernel-misc.cfg"
+
 require linux-raspberrypi.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+
+KERNEL_EXTRA_ARGS_append_rpi = " DTC_FLAGS='-@ -H epapr'"


### PR DESCRIPTION
Fixes vc4 graphics issues seen with 4.19.56
Add -@ to device tree flags so we can debug/dump the
dtb with symbols, helps in debugging the overlays

Signed-off-by: Khem Raj <raj.khem@gmail.com>


