### PR TITLE
linux-raspberrypi: Build dtbs with dtbs make target for rpi4-64

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -122,9 +122,11 @@ do_configure_prepend() {
     rm -f ${B}/.config.patched
 }
 
-do_compile_append_raspberrypi3-64() {
-    cc_extra=$(get_cc_option)
-    oe_runmake dtbs CC="${KERNEL_CC} $cc_extra " LD="${KERNEL_LD}" ${KERNEL_EXTRA_ARGS}
+do_compile_append() {
+    if [ "${SITEINFO_BITS}" = "64" ]; then
+        cc_extra=$(get_cc_option)
+        oe_runmake dtbs CC="${KERNEL_CC} $cc_extra " LD="${KERNEL_LD}" ${KERNEL_EXTRA_ARGS}
+    fi
 }
 
 do_deploy_append() {


### PR DESCRIPTION
We already do this for rpi3-64 and we will need it for rpi4-64 as well.
See 6c4de0b5fe44b8e661f1391ee8540a7f04d75315 for more details.

Signed-off-by: Andrei Gherzan <andrei@gherzan.ro>

CC @diegosueiro
