### PR TITLE
Drop memory limitation for RPi4-64

### DIFF
--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -31,4 +31,4 @@ KERNEL_IMAGETYPE_UBOOT ?= "Image"
 KERNEL_IMAGETYPE_DIRECT ?= "Image"
 KERNEL_BOOTCMD ?= "booti"
 
-RPI_EXTRA_CONFIG ?= "\n# RPi4 64bit has some limitation - see https://github.com/raspberrypi/linux/commit/cdb78ce891f6c6367a69c0a46b5779a58164bd4b\ntotal_mem=1024\narm_64bit=1"
+RPI_EXTRA_CONFIG ?= "\n# Force arm in 64bit mode. See: https://github.com/raspberrypi/firmware/issues/1193.\narm_64bit=1"

--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -3,7 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 LINUX_VERSION ?= "4.19.58"
 LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 
-SRCREV = "8222f38b1ceadd0642d49812fd34a3a6cb00e264"
+SRCREV = "d5dc848c982dff2e020f294e384447efe6ea6617"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_BRANCH} \
     "


### PR DESCRIPTION
**- What I did**
Updated kernel to include the https://github.com/raspberrypi/linux/pull/3080 and removed the limitation.
