### PR TITLE
Check some config values (ex: ENABLE_I2C) against "1" instead of stri…

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -41,7 +41,7 @@ do_deploy() {
     if [ -n "${DISABLE_OVERSCAN}" ]; then
         sed -i '/#disable_overscan=/ c\disable_overscan=${DISABLE_OVERSCAN}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
-    if [ -n "${DISABLE_SPLASH}" ]; then
+    if [ "${DISABLE_SPLASH}" = "1" ]; then
         sed -i '/#disable_splash=/ c\disable_splash=${DISABLE_SPLASH}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
@@ -111,25 +111,25 @@ do_deploy() {
     fi
 
     # Video camera support
-    if [ -n "${VIDEO_CAMERA}" ]; then
+    if [ "${VIDEO_CAMERA}" = "1" ]; then
         echo "# Enable video camera" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "start_x=1" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
     # Offline compositing support
-    if [ -n "${DISPMANX_OFFLINE}" ]; then
+    if [ "${DISPMANX_OFFLINE}" = "1" ]; then
         echo "# Enable offline compositing" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dispmanx_offline=1" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
     # SPI bus support
-    if [ -n "${ENABLE_SPI_BUS}" ] || [ "${PITFT}" = "1" ]; then
+    if [ "${ENABLE_SPI_BUS}" = "1" ] || [ "${PITFT}" = "1" ]; then
         echo "# Enable SPI bus" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dtparam=spi=on" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
     # I2C support
-    if [ -n "${ENABLE_I2C}" ] || [ "${PITFT}" = "1" ]; then
+    if [ "${ENABLE_I2C}" = "1" ] || [ "${PITFT}" = "1" ]; then
         echo "# Enable I2C" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dtparam=i2c1=on" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dtparam=i2c_arm=on" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt


### PR DESCRIPTION

**- What I did**

I changed the check for some variables in the rpi-config_git.bb.

When we read the docs, we have the feelings that theses variables are boolean ones. So I was setting, for example in my distro.conf file the variable ' ENABLE_I2C = "1" ' to enable I2C. Then I wanted to disable it by simply setting 'ENABLE_I2C' to "0" but it wasn't working. So I noticed that, for example, ' ENABLE_UART ' was checked with ' = "1" ' condition and some other "boolean" was checked against ' -n ' like for ENABLE_I2C.

This commit tries to have an uniform behavior for all variables that are shown in the doc under the format ' VARIABLE = "1" ' to enable them and the reader can think they are kind of 'boolean' values.

