### PR TITLE
[warrior backport] raspberrypi4-64.conf: Limit RAM to 3G

### DIFF
--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -31,6 +31,6 @@ KERNEL_IMAGETYPE_UBOOT ?= "Image"
 KERNEL_IMAGETYPE_DIRECT ?= "Image"
 KERNEL_BOOTCMD ?= "booti"
 
-RPI_EXTRA_CONFIG ?= "\n# Force arm in 64bit mode. See: https://github.com/raspberrypi/firmware/issues/1193.\narm_64bit=1"
+RPI_EXTRA_CONFIG ?= "\n# Force arm in 64bit mode. See: https://github.com/raspberrypi/firmware/issues/1193.\narm_64bit=1\n\n# Limit RAM to 3G. See: https://github.com/raspberrypi/linux/issues/3093\ntotal_mem=3072"
 
 ARMSTUB ?= "armstub8-gic.bin"


### PR DESCRIPTION
The PCI controller on the Raspberry Pi 4 acts as a DMA controller and can
only address the first 3Gb[1] of the memory space. On 32bit this was
addressed by implementing bouncing buffers[2] but this currently has no
support for arm64. In order to have working USB, as a workaround, we
limit the ram to 3G.

Fixes #446

[1] https://github.com/raspberrypi/linux/issues/3093
[2] https://github.com/raspberrypi/linux/blob/rpi-4.19.y/drivers/pci/controller/pcie-brcmstb-bounce.c

Signed-off-by: Andrei Gherzan <andrei@gherzan.ro>
