### PR TITLE
userland: Upgrade to latest

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -27,6 +27,8 @@ BBFILES += "${@' '.join('${LAYERDIR}/dynamic-layers/%s/recipes*/*/*.bb' % layer 
 BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
+    networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bb \
+    networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bb \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bbappend \
 "

--- a/dynamic-layers/networking-layer/recipes-support/drbd/drbd_%.bbappend
+++ b/dynamic-layers/networking-layer/recipes-support/drbd/drbd_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+COMPATIBLE_MACHINE_rpi = "(null)"

--- a/recipes-graphics/userland/files/0001-Allow-applications-to-set-next-resource-handle.patch
+++ b/recipes-graphics/userland/files/0001-Allow-applications-to-set-next-resource-handle.patch
@@ -1,7 +1,7 @@
-From e94675aa943c114ff801167c69bdd2d366d01665 Mon Sep 17 00:00:00 2001
+From ccb7f6f1a2bc491a24c0402616a2d24b85e3933a Mon Sep 17 00:00:00 2001
 From: Dom Cobley <dc4@broadcom.com>
 Date: Tue, 9 Jul 2013 09:26:26 -0400
-Subject: [PATCH 01/18] Allow applications to set next resource handle
+Subject: [PATCH 01/19] Allow applications to set next resource handle
 
 This patch adds provisions in userland to
 let apps callers set the next rendereing dispmanx resource.
@@ -204,5 +204,5 @@ index 8a5734c..51b3580 100644
  
  FN(void, eglIntGetColorData_impl, (EGL_SURFACE_ID_T s, KHRN_IMAGE_FORMAT_T format, uint32_t width, uint32_t height, int32_t stride, uint32_t y_offset, void *data))
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0002-wayland-Add-support-for-the-Wayland-winsys.patch
+++ b/recipes-graphics/userland/files/0002-wayland-Add-support-for-the-Wayland-winsys.patch
@@ -1,7 +1,7 @@
-From ad6f485d9eb809b67398ce0948844dd30ea1c8e3 Mon Sep 17 00:00:00 2001
+From 7432d49ddca97b34e402d0108221d34ec69bcd66 Mon Sep 17 00:00:00 2001
 From: Tomeu Vizoso <tomeu.vizoso@collabora.com>
 Date: Tue, 1 Oct 2013 13:19:20 +0200
-Subject: [PATCH 02/18] wayland: Add support for the Wayland winsys
+Subject: [PATCH 02/19] wayland: Add support for the Wayland winsys
 
 * Adds EGL_WL_bind_wayland_display extension
 * Adds wayland-egl library
@@ -1551,12 +1551,12 @@ index 0000000..8bafc15
 +Libs: -L${libdir} -lwayland-egl
 +Cflags: -I${includedir}
 diff --git a/interface/vmcs_host/CMakeLists.txt b/interface/vmcs_host/CMakeLists.txt
-index fde18da..6718215 100755
+index a157db1..55b6ace 100755
 --- a/interface/vmcs_host/CMakeLists.txt
 +++ b/interface/vmcs_host/CMakeLists.txt
-@@ -9,13 +9,24 @@ add_definitions(-fno-strict-aliasing)
- 
- include_directories(${VMCS_TARGET}/vcfiled)
+@@ -7,13 +7,24 @@
+ # vc_vchi_gencmd.c has a type-punning problem in vc_gencmd_read_response
+ add_definitions(-fno-strict-aliasing)
  
 -add_library(vchostif
 -            ${VMCS_TARGET}/vcfilesys.c ${VMCS_TARGET}/vcmisc.c
@@ -1894,5 +1894,5 @@ index 0000000..ad90d30
 +    set(${_sources} ${${_sources}} PARENT_SCOPE)
 +endfunction()
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0003-wayland-Add-Wayland-example.patch
+++ b/recipes-graphics/userland/files/0003-wayland-Add-Wayland-example.patch
@@ -1,7 +1,7 @@
-From 642110bbc9ebcb9ad497f4f1c1ccbc5a9afda753 Mon Sep 17 00:00:00 2001
+From 481a9aeba3f84371668fdf8a1380a3cb23bfc502 Mon Sep 17 00:00:00 2001
 From: Tomeu Vizoso <tomeu.vizoso@collabora.com>
 Date: Tue, 1 Oct 2013 13:19:20 +0200
-Subject: [PATCH 03/18] wayland: Add Wayland example
+Subject: [PATCH 03/19] wayland: Add Wayland example
 
 ---
  .../linux/apps/hello_pi/CMakeLists.txt        |   1 +
@@ -19,10 +19,10 @@ Subject: [PATCH 03/18] wayland: Add Wayland example
  create mode 100644 host_applications/linux/apps/hello_pi/hello_wayland/triangle.c
 
 diff --git a/host_applications/linux/apps/hello_pi/CMakeLists.txt b/host_applications/linux/apps/hello_pi/CMakeLists.txt
-index f2c6aef..0df78f7 100644
+index b28a94a..2849fad 100644
 --- a/host_applications/linux/apps/hello_pi/CMakeLists.txt
 +++ b/host_applications/linux/apps/hello_pi/CMakeLists.txt
-@@ -21,6 +21,7 @@ add_subdirectory(hello_encode)
+@@ -25,6 +25,7 @@ add_subdirectory(hello_encode)
  add_subdirectory(hello_jpeg)
  add_subdirectory(hello_videocube)
  add_subdirectory(hello_teapot)
@@ -862,5 +862,5 @@ index 8225dd5..0be6ce7 100755
 -
 +make -C hello_wayland
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0004-wayland-egl-Add-bcm_host-to-dependencies.patch
+++ b/recipes-graphics/userland/files/0004-wayland-egl-Add-bcm_host-to-dependencies.patch
@@ -1,7 +1,7 @@
-From 33374e6b19a28d52a0089aa7b9af9b698fb98a86 Mon Sep 17 00:00:00 2001
+From 4463e2732a09dbb721d0614e7147cbfaa9059930 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Mon, 10 Aug 2015 02:38:27 -0700
-Subject: [PATCH 04/18] wayland-egl: Add bcm_host to dependencies
+Subject: [PATCH 04/19] wayland-egl: Add bcm_host to dependencies
 
 It uses headers like vcos_platform_types.h but does not
 depend on module which should add the required include paths
@@ -24,5 +24,5 @@ index 8bafc15..fd259c9 100644
  Libs: -L${libdir} -lwayland-egl
  Cflags: -I${includedir}
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0005-interface-remove-faulty-assert-to-make-weston-happy-.patch
+++ b/recipes-graphics/userland/files/0005-interface-remove-faulty-assert-to-make-weston-happy-.patch
@@ -1,7 +1,7 @@
-From e2d13265a34519364bd7d27d54a860967b320504 Mon Sep 17 00:00:00 2001
+From 571c417c055a57cfd42c30a7a8279332397bad83 Mon Sep 17 00:00:00 2001
 From: "Yann E. MORIN" <yann.morin.1998@free.fr>
 Date: Sat, 24 Jan 2015 22:07:19 +0100
-Subject: [PATCH 05/18] interface: remove faulty assert() to make weston happy
+Subject: [PATCH 05/19] interface: remove faulty assert() to make weston happy
  at runtime
 
 This was removed after a discussion on IRC with the weston guys
@@ -25,5 +25,5 @@ index eab146e..29e0dee 100755
              }
           } else {
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0006-zero-out-wl-buffers-in-egl_surface_free.patch
+++ b/recipes-graphics/userland/files/0006-zero-out-wl-buffers-in-egl_surface_free.patch
@@ -1,7 +1,7 @@
-From 0c64a21bd90b9dea9916dcdc7c8c23b93518ccb8 Mon Sep 17 00:00:00 2001
+From 393e90beb9f5e535b5ce5d9eba4bc74907a96afe Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sat, 6 Feb 2016 11:10:47 -0800
-Subject: [PATCH 06/18] zero-out wl buffers in egl_surface_free
+Subject: [PATCH 06/19] zero-out wl buffers in egl_surface_free
 
 origins from buildroot
 
@@ -29,5 +29,5 @@ index 42350bf..1f923d9 100644
  #endif
     }
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0007-initialize-front-back-wayland-buffers.patch
+++ b/recipes-graphics/userland/files/0007-initialize-front-back-wayland-buffers.patch
@@ -1,7 +1,7 @@
-From 4e0f83d815461d501fef788236dab356c9b60ea5 Mon Sep 17 00:00:00 2001
+From 3e7e309de25d546a4836c59523060f286aadd87d Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sat, 6 Feb 2016 11:11:41 -0800
-Subject: [PATCH 07/18] initialize front back wayland buffers
+Subject: [PATCH 07/19] initialize front back wayland buffers
 
 origins from metrological wayland support
 
@@ -30,5 +30,5 @@ index 1f923d9..9a9582c 100644
     }
  #endif
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0008-Remove-RPC_FLUSH.patch
+++ b/recipes-graphics/userland/files/0008-Remove-RPC_FLUSH.patch
@@ -1,7 +1,7 @@
-From 67384449b85e65661558b9ebe059792cdd737fc7 Mon Sep 17 00:00:00 2001
+From a08887086cf4418fa0999a340c574b66a5ab4412 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sat, 6 Feb 2016 11:09:18 -0800
-Subject: [PATCH 08/18] Remove RPC_FLUSH
+Subject: [PATCH 08/19] Remove RPC_FLUSH
 
 Origins from buildroot
 
@@ -23,5 +23,5 @@ index f9b7287..b04ffef 100644
        }
  #endif
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0009-fix-cmake-dependency-race.patch
+++ b/recipes-graphics/userland/files/0009-fix-cmake-dependency-race.patch
@@ -1,7 +1,7 @@
-From a4a31696bddb72f3bf58f6b5303816fd31081566 Mon Sep 17 00:00:00 2001
+From e14d2bfff42be64361a873e73674ce1205af3ee5 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sat, 6 Feb 2016 13:12:47 -0800
-Subject: [PATCH 09/18] fix cmake dependency race
+Subject: [PATCH 09/19] fix cmake dependency race
 
 Fixes errors like
 
@@ -42,10 +42,10 @@ index 1d81ca3..d6cd415 100644
     add_library (vcos SHARED ${SOURCES})
     target_link_libraries (vcos pthread dl rt)
 diff --git a/interface/vmcs_host/CMakeLists.txt b/interface/vmcs_host/CMakeLists.txt
-index 6718215..c415176 100755
+index 55b6ace..ae52495 100755
 --- a/interface/vmcs_host/CMakeLists.txt
 +++ b/interface/vmcs_host/CMakeLists.txt
-@@ -17,14 +17,6 @@ set(VCHOSTIF_SOURCE
+@@ -15,14 +15,6 @@ set(VCHOSTIF_SOURCE
  #            ${VMCS_TARGET}/vmcs_main.c
  #  vc_vchi_haud.c
  
@@ -74,5 +74,5 @@ index f0bae30..8c44c58 100644
  	struct wl_resource *resource;
  	struct wl_dispmanx *dispmanx;
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0010-Fix-for-framerate-with-nested-composition.patch
+++ b/recipes-graphics/userland/files/0010-Fix-for-framerate-with-nested-composition.patch
@@ -1,7 +1,7 @@
-From c7acd48a9044e24d64ef453ff35202d6a697eb5d Mon Sep 17 00:00:00 2001
+From ea3f7c3822efd33cec96a79eb9a345544b942d9e Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Tue, 29 Mar 2016 20:38:30 -0700
-Subject: [PATCH 10/18] Fix for framerate with nested composition
+Subject: [PATCH 10/19] Fix for framerate with nested composition
 
 frame rate appears irregular and lower than expected when using nested composition.
 
@@ -56,5 +56,5 @@ index 03fe67b..13a110c 100644
  #ifdef ANDROID
                 CLIENT_UNLOCK();
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0011-build-shared-library-for-vchostif.patch
+++ b/recipes-graphics/userland/files/0011-build-shared-library-for-vchostif.patch
@@ -1,7 +1,7 @@
-From a49fbbc6abc3d57d45011a3410d3b8f04349e424 Mon Sep 17 00:00:00 2001
+From 407ab0ed315b4c7b49d1a1dd3777d5af8e0b7e66 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sat, 2 Apr 2016 10:37:24 -0700
-Subject: [PATCH 11/18] build shared library for vchostif
+Subject: [PATCH 11/19] build shared library for vchostif
 
 Fixes #149
 
@@ -11,10 +11,10 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/interface/vmcs_host/CMakeLists.txt b/interface/vmcs_host/CMakeLists.txt
-index c415176..d0cca1a 100755
+index ae52495..369758b 100755
 --- a/interface/vmcs_host/CMakeLists.txt
 +++ b/interface/vmcs_host/CMakeLists.txt
-@@ -17,7 +17,7 @@ set(VCHOSTIF_SOURCE
+@@ -15,7 +15,7 @@ set(VCHOSTIF_SOURCE
  #            ${VMCS_TARGET}/vmcs_main.c
  #  vc_vchi_haud.c
  
@@ -24,5 +24,5 @@ index c415176..d0cca1a 100755
  #add_library(bufman            vc_vchi_bufman.c            )
  
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0012-implement-buffer-wrapping-interface-for-dispmanx.patch
+++ b/recipes-graphics/userland/files/0012-implement-buffer-wrapping-interface-for-dispmanx.patch
@@ -1,7 +1,7 @@
-From 70c5c684fbfbc8ebd890b0aafb2bb5c13d6cfb11 Mon Sep 17 00:00:00 2001
+From 48a946e24c3e7172f1044f5815e9cfed96982830 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sat, 2 Apr 2016 10:54:59 -0700
-Subject: [PATCH 12/18] implement buffer wrapping interface for dispmanx
+Subject: [PATCH 12/19] implement buffer wrapping interface for dispmanx
 
 Courtesy: Zan Dobersek
 
@@ -88,5 +88,5 @@ index c18626d..11ed1ef 100644
  
  </protocol>
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0013-Implement-triple-buffering-for-wayland.patch
+++ b/recipes-graphics/userland/files/0013-Implement-triple-buffering-for-wayland.patch
@@ -1,7 +1,7 @@
-From 789d16a9d5aa57b201e9d6be9427671f48fec5e4 Mon Sep 17 00:00:00 2001
+From 31e61d1a1d26442be9c90c479e2b14589acedb0e Mon Sep 17 00:00:00 2001
 From: Jeff Wannamaker <jeff_wannamaker@cable.comcast.com>
 Date: Thu, 19 Jan 2017 18:56:07 +0000
-Subject: [PATCH 13/18] Implement triple buffering for wayland
+Subject: [PATCH 13/19] Implement triple buffering for wayland
 
 Change from double to triple buffering for wayland.
 This enables higher frame rates without tearing artifacts
@@ -86,5 +86,5 @@ index e328b77..58a3184 100644
        back_wl_buffer
  
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0014-GLES2-gl2ext.h-Define-GL_R8_EXT-and-GL_RG8_EXT.patch
+++ b/recipes-graphics/userland/files/0014-GLES2-gl2ext.h-Define-GL_R8_EXT-and-GL_RG8_EXT.patch
@@ -1,7 +1,7 @@
-From 49604e158b8171033bc8a9db5d8893887fb98557 Mon Sep 17 00:00:00 2001
+From 961cd03f4db37041ae068cd8535f11cf739e42c0 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 10 May 2017 06:39:34 +0000
-Subject: [PATCH 14/18] GLES2/gl2ext.h: Define GL_R8_EXT and GL_RG8_EXT
+Subject: [PATCH 14/19] GLES2/gl2ext.h: Define GL_R8_EXT and GL_RG8_EXT
 
 weston code uses these defines
 Upstream-Status: Pending
@@ -31,5 +31,5 @@ index 4eacf7f..b1acc9f 100644
  #ifndef GL_EXT_texture_type_2_10_10_10_REV
  #define GL_UNSIGNED_INT_2_10_10_10_REV_EXT                      0x8368
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0015-EGL-glplatform.h-define-EGL_CAST.patch
+++ b/recipes-graphics/userland/files/0015-EGL-glplatform.h-define-EGL_CAST.patch
@@ -1,7 +1,7 @@
-From 90f6ebc04c688720f45c7009d12d524d33f51781 Mon Sep 17 00:00:00 2001
+From 9568135c3e4c23e9056135a13cee58c37456aaac Mon Sep 17 00:00:00 2001
 From: Andrea Galbusera <gizero@gmail.com>
 Date: Fri, 14 Jul 2017 09:52:54 +0200
-Subject: [PATCH 15/18] EGL/glplatform.h: define EGL_CAST
+Subject: [PATCH 15/19] EGL/glplatform.h: define EGL_CAST
 
 C++ / C typecast macros for special EGL handle values: used by libepoxy code
 The definition comes from the updated version of this header in mesa.
@@ -28,5 +28,5 @@ index 1f7c930..c39d425 100644
 +
  #endif /* __eglplatform_h */
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0016-Allow-multiple-wayland-compositor-state-data-per-pro.patch
+++ b/recipes-graphics/userland/files/0016-Allow-multiple-wayland-compositor-state-data-per-pro.patch
@@ -1,7 +1,7 @@
-From b8a1516fd1d8c8a5f2400a7fb7bd6b9e05d33a55 Mon Sep 17 00:00:00 2001
+From 493b013cb702b821fdeaef7021ae25dea88900c6 Mon Sep 17 00:00:00 2001
 From: Jeff Wannamaker <jeff_wannamaker@cable.comcast.com>
 Date: Sat, 27 Jan 2018 12:28:31 -0500
-Subject: [PATCH 16/18] Allow multiple wayland compositor state data per
+Subject: [PATCH 16/19] Allow multiple wayland compositor state data per
  process
 
 When eglBindWaylandDisplayWL is called store the wl_global
@@ -141,5 +141,5 @@ index 9ef89cd..abd5ab3 100644
     CLIENT_UNLOCK();
  
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0017-khronos-backport-typedef-for-EGL_EXT_image_dma_buf_i.patch
+++ b/recipes-graphics/userland/files/0017-khronos-backport-typedef-for-EGL_EXT_image_dma_buf_i.patch
@@ -1,7 +1,7 @@
-From d65939b5bdc6cfddb68803e87efffac13182ae46 Mon Sep 17 00:00:00 2001
+From cc25f8abd4498004a276a4ee40e37681fa42422a Mon Sep 17 00:00:00 2001
 From: Hugo Hromic <hhromic@gmail.com>
 Date: Sun, 13 May 2018 10:49:04 +0100
-Subject: [PATCH 17/18] khronos: backport typedef for
+Subject: [PATCH 17/19] khronos: backport typedef for
  EGL_EXT_image_dma_buf_import
 
 The `gstreamer1.0-plugins-base` package version `1.14` uses `EGL_EXT_image_dma_buf_import`, which
@@ -34,5 +34,5 @@ index d7e5ba7..dcc90ce 100755
  #ifndef EGL_WL_bind_wayland_display
  #define EGL_WL_bind_wayland_display 1
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0018-Add-EGL_IMG_context_priority-related-defines.patch
+++ b/recipes-graphics/userland/files/0018-Add-EGL_IMG_context_priority-related-defines.patch
@@ -1,7 +1,7 @@
-From e5fcfe7af2c7f75b66356680bb641f4f6555d0c5 Mon Sep 17 00:00:00 2001
+From e091388b4382d90494b5842e9f591043a45b2b21 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sun, 15 Jul 2018 00:48:38 -0700
-Subject: [PATCH 18/18] Add EGL_IMG_context_priority related defines
+Subject: [PATCH 18/19] Add EGL_IMG_context_priority related defines
 
 These defines are needed for compiling weston 4.x
 taken from Khronos headers
@@ -31,5 +31,5 @@ index dcc90ce..6842bf9 100755
  #define EGL_KHR_vg_parent_image 1
  #define EGL_VG_PARENT_IMAGE_KHR			0x30BA	/* eglCreateImageKHR target */
 -- 
-2.21.0
+2.22.0
 

--- a/recipes-graphics/userland/files/0019-libfdt-Undefine-__wordsize-if-already-defined.patch
+++ b/recipes-graphics/userland/files/0019-libfdt-Undefine-__wordsize-if-already-defined.patch
@@ -1,0 +1,31 @@
+From 5229430874b5275547babdbef1e322922317456d Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 25 Jul 2019 23:30:27 -0700
+Subject: [PATCH 19/19] libfdt: Undefine __wordsize if already defined
+
+glibc 2.30+ defines __wordsize, which is same so its easier to compile
+for multiple versions of glibc even ones which does not have this define
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ opensrc/helpers/libfdt/libfdt_env.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/opensrc/helpers/libfdt/libfdt_env.h b/opensrc/helpers/libfdt/libfdt_env.h
+index 1c966b8..fc25ca6 100644
+--- a/opensrc/helpers/libfdt/libfdt_env.h
++++ b/opensrc/helpers/libfdt/libfdt_env.h
+@@ -56,6 +56,10 @@
+ #include <stdint.h>
+ #include <string.h>
+ 
++#ifdef __bitwise
++#undef __bitwise
++#endif
++
+ #ifdef __CHECKER__
+ #define __force __attribute__((force))
+ #define __bitwise __attribute__((bitwise))
+-- 
+2.22.0
+

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -12,11 +12,11 @@ COMPATIBLE_MACHINE = "^rpi$"
 
 SRCBRANCH = "master"
 SRCFORK = "raspberrypi"
-SRCREV = "517cdc30da167d81a485e7a994e02cec2390a269"
+SRCREV = "17d2fdc1abd370e09ba7074753294c7976dd6b0d"
 
 # Use the date of the above commit as the package version. Update this when
 # SRCREV is changed.
-PV = "20190501"
+PV = "20190724"
 
 SRC_URI = "\
     git://github.com/${SRCFORK}/userland.git;protocol=git;branch=${SRCBRANCH} \
@@ -38,6 +38,7 @@ SRC_URI = "\
     file://0016-Allow-multiple-wayland-compositor-state-data-per-pro.patch \
     file://0017-khronos-backport-typedef-for-EGL_EXT_image_dma_buf_i.patch \
     file://0018-Add-EGL_IMG_context_priority-related-defines.patch \
+    file://0019-libfdt-Undefine-__wordsize-if-already-defined.patch \
 "
 S = "${WORKDIR}/git"
 
@@ -64,7 +65,6 @@ do_install_append () {
 		sed -i 's/include "vcos_futex_mutex.h"/include "pthreads\/vcos_futex_mutex.h"/g' ${f}
 		sed -i 's/include "vcos_platform_types.h"/include "pthreads\/vcos_platform_types.h"/g' ${f}
 	done
-        install -D -m 0755 ${D}${prefix}${sysconfdir}/init.d/vcfiled ${D}${sysconfdir}/init.d/vcfiled
         rm -rf ${D}${prefix}${sysconfdir}
 	if [ "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}" = "1" ]; then
 		rm -rf ${D}${libdir}/libEGL*

--- a/recipes-sato/webkitgtk/webkitgtk_%.bbappend
+++ b/recipes-sato/webkitgtk/webkitgtk_%.bbappend
@@ -1,1 +1,0 @@
-EXTRA_OECMAKE_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', ' -DUSE_GSTREAMER_GL=OFF ', '', d)}"


### PR DESCRIPTION
Fix build with glibc 2.30
Forward patches to 20190724 release

Signed-off-by: Khem Raj <raj.khem@gmail.com>

