### PR TITLE
Update kernel 4.14 series recipe to 4.14.114

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.14.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.14.bb
@@ -1,6 +1,6 @@
-LINUX_VERSION ?= "4.14.112"
+LINUX_VERSION ?= "4.14.114"
 
-SRCREV = "6b5c4a2508403839af29ef44059d04acbe0ee204"
+SRCREV = "7688b39276ff9952df381d79de63b258e73971ce"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y \
     file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \


### PR DESCRIPTION
Kernel 4.19.y and above was patched to rename the Raspberry Pi Zero W dts file. Unfortunately, this modification was not propagated to previous versions of the kernel, especially on the 4.14.y series which is still supported in this layer.
This modification leads to kernel 4.14.y build failure because the correct .dts file is not found.
This patch backports the mainline series patch downstream on 4.14.y series.

I am also creating a pull request on rpi-4.14.y so that this file can be deleted when the patch is accepted.

Signed-off-by: Francesco Giancane <francescogiancane8@gmail.com>