### PR TITLE
packagegroup-rpi-test: Depend on wireless-regdb instead of crda

### DIFF
--- a/recipes-core/packagegroups/packagegroup-rpi-test.bb
+++ b/recipes-core/packagegroups/packagegroup-rpi-test.bb
@@ -19,7 +19,7 @@ RDEPENDS_${PN} = "\
     python-sense-hat \
     connman \
     connman-client \
-    crda \
+    wireless-regdb \
     bluez5 \
 "
 


### PR DESCRIPTION
this should bring in crda if needed

Fixes issue #456

Signed-off-by: Khem Raj <raj.khem@gmail.com>
