### PR TITLE
xorg-xserver: Adapt bbappend to latest OE-core

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
@@ -1,9 +1,1 @@
-OPENGL_PKGCFG = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'dri3 xshmfence glamor', '', d)}"
-
-# slightly modified to oe-core's default: add ${OPENGL_PKGCFG}
-PACKAGECONFIG_rpi ?= " \
-    dri2 udev ${XORG_CRYPTO} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'dri glx ${OPENGL_PKGCFG}', '', d)} \
-    ${@bb.utils.contains("DISTRO_FEATURES", "wayland", "xwayland", "", d)} \
-    ${@bb.utils.contains("DISTRO_FEATURES", "systemd", "systemd", "", d)} \
-"
+OPENGL_PKGCONFIGS_rpi = "dri glx ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'dri3 xshmfence glamor', '', d)}"


### PR DESCRIPTION
There is no need to override complete packageconfig but just the openGL
part, this ensures that any common change in oe-core reflects for rpi as
well and does not cause the packageconfigs to go stale

Signed-off-by: Khem Raj <raj.khem@gmail.com>

