### PR TITLE
sdcard_image-rpi.bbclass: use -v for all mcopy calls and add bbfatal …

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -113,51 +113,51 @@ IMAGE_CMD_rpi-sdimg () {
     BOOT_BLOCKS=$(LC_ALL=C parted -s ${SDIMG} unit b print | awk '/ 1 / { print substr($4, 1, length($4 -1)) / 512 /2 }')
     rm -f ${WORKDIR}/boot.img
     mkfs.vfat -F32 -n "${BOOTDD_VOLUME_ID}" -S 512 -C ${WORKDIR}/boot.img $BOOT_BLOCKS
-    mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/* ::/
+    mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/* ::/ || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/* into boot.img"
     if [ "${@bb.utils.contains("MACHINE_FEATURES", "armstub", "1", "0", d)}" = "1" ]; then
-        mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/armstubs/${ARMSTUB} ::/
+        mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/armstubs/${ARMSTUB} ::/ || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/armstubs/${ARMSTUB} into boot.img"
     fi
     if test -n "${DTS}"; then
         # Copy board device trees to root folder
         for dtbf in ${@split_overlays(d, True)}; do
             dtb=`basename $dtbf`
-            mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::$dtb
+            mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::$dtb || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/$dtb into boot.img"
         done
 
         # Copy device tree overlays to dedicated folder
         mmd -i ${WORKDIR}/boot.img overlays
         for dtbf in ${@split_overlays(d, False)}; do
             dtb=`basename $dtbf`
-            mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::overlays/$dtb
+            mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/$dtb ::overlays/$dtb || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/$dtb into boot.img"
         done
     fi
     if [ "${RPI_USE_U_BOOT}" = "1" ]; then
-        mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/u-boot.bin ::${SDIMG_KERNELIMAGE}
-        mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/boot.scr ::boot.scr
+        mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/u-boot.bin ::${SDIMG_KERNELIMAGE} || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/u-boot.bin into boot.img"
+        mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/boot.scr ::boot.scr || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/boot.scr into boot.img"
         if [ ! -z "${INITRAMFS_IMAGE}" -a "${INITRAMFS_IMAGE_BUNDLE}" = "1" ]; then
-            mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${INITRAMFS_LINK_NAME}.bin ::${KERNEL_IMAGETYPE}
+            mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${INITRAMFS_LINK_NAME}.bin ::${KERNEL_IMAGETYPE} || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${INITRAMFS_LINK_NAME}.bin into boot.img"
         else
-            mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE} ::${KERNEL_IMAGETYPE}
+            mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE} ::${KERNEL_IMAGETYPE} || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE} into boot.img"
         fi
     else
         if [ ! -z "${INITRAMFS_IMAGE}" -a "${INITRAMFS_IMAGE_BUNDLE}" = "1" ]; then
-            mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${INITRAMFS_LINK_NAME}.bin ::${SDIMG_KERNELIMAGE}
+            mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${INITRAMFS_LINK_NAME}.bin ::${SDIMG_KERNELIMAGE} || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${INITRAMFS_LINK_NAME}.bin into boot.img"
         else
-            mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE} ::${SDIMG_KERNELIMAGE}
+            mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE} ::${SDIMG_KERNELIMAGE} || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE} into boot.img"
         fi
     fi
 
     if [ -n "${FATPAYLOAD}" ] ; then
         echo "Copying payload into VFAT"
         for entry in ${FATPAYLOAD} ; do
-            # add the || true to stop aborting on vfat issues like not supporting .~lock files
-            mcopy -i ${WORKDIR}/boot.img -s -v ${IMAGE_ROOTFS}$entry :: || true
+            # use bbwarn instead of bbfatal to stop aborting on vfat issues like not supporting .~lock files
+            mcopy -v -i ${WORKDIR}/boot.img -s ${IMAGE_ROOTFS}$entry :: || bbwarn "mcopy cannot copy ${IMAGE_ROOTFS}$entry into boot.img"
         done
     fi
 
     # Add stamp file
     echo "${IMAGE_NAME}" > ${WORKDIR}/image-version-info
-    mcopy -i ${WORKDIR}/boot.img -v ${WORKDIR}/image-version-info ::
+    mcopy -v -i ${WORKDIR}/boot.img ${WORKDIR}/image-version-info :: || bbfatal "mcopy cannot copy ${WORKDIR}/image-version-info into boot.img"
 
     # Deploy vfat partition
     if [ "${SDIMG_VFAT_DEPLOY}" = "1" ]; then


### PR DESCRIPTION
…in case mcopy fails

* I have this in our layer for some time:
  RPI_KERNEL_DEVICETREE_OVERLAYS_append = " overlays/vc4-fkms-v3d.dtbo"
  because we're using vc4graphics also on raspberrypi3 and it was
  working fine until recently.

* now the default rpi-base.inc in warrior and master branch includes the same since:
  https://github.com/agherzan/meta-raspberrypi/commit/37aa050d5a44eb797540ef50408c2ca8e3da6fa0
  and do_image_rpi_sdimg started failing with a bit useless log:
  ...
  Partition Table: msdos
  Disk Flags:

  Number  Start   End     Size    Type     File system  Flags
   1      4194kB  46.1MB  41.9MB  primary               boot, lba
   2      46.1MB  1145MB  1099MB  primary

  mkfs.fat: warning - lowercase labels might not work properly with DOS or
  Windows
  mkfs.fat 4.1 (2017-01-24)
  WARNING: exit code 1 from a shell command.

* after adding -v to mcopy calls I got slightly better log:
  ...
  Copying w1-gpio-pullup.dtbo
  Copying w1-gpio.dtbo
  WARNING: exit code 1 from a shell command.

* the issue is that mcopy behavior in non-interactive shell is to fail
  when the target file already exists (sometimes it seems to cause mcopy
  to hang forever), but when you execute the run.do_image_rpi_sdimg
  script manually in interactive shell it will nicely show this prompt
  on stderr:
  $ dtb=vc4-fkms-v3d.dtbo recipe-sysroot-native/usr/bin/mcopy  -i boot.img -s BUILD/deploy/images/raspberrypi3/$dtb ::overlays/$dtb
    Long file name "vc4-fkms-v3d.dtbo" already exists.
    a)utorename A)utorename-all r)ename R)ename-all o)verwrite O)verwrite-all
    s)kip S)kip-all q)uit (aArRoOsSq): o

* with the bbfatal the log is finally a bit more useful:
  ...
  Copying w1-gpio-pullup.dtbo
  Copying w1-gpio.dtbo
  ERROR: mcopy cannot copy TOPDIR/BUILD/deploy/images/raspberrypi3/vc4-fkms-v3d.dtbo into boot.img
  WARNING: exit code 1 from a shell command.

* the only exception is FATPAYLOAD where it was ignoring mcopy with || true
  before, I've added bbwarn, because even issues like mentioned there
  "vfat issues like not supporting .~lock files" are probably worth
  reporting as warning (why would people add .~lock to FATPAYLOAD if
  it cannot be copied into boot.img)

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>