### PR TITLE
fixes #465: using https protocol instead of git

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -5,7 +5,7 @@ LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 
 SRCREV = "d5dc848c982dff2e020f294e384447efe6ea6617"
 SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_BRANCH} \
+    git://github.com/raspberrypi/linux.git;protocol=https;branch=${LINUX_RPI_BRANCH} \
     "
 SRC_URI_append_raspberrypi4-64 = " file://rpi4-64-kernel-misc.cfg"
 


### PR DESCRIPTION
raspberrypi-linux: changed repository source from git to https

Signed-off-by: Timm Eversmeyer saeugetier@gmail.com