### PR TITLE
omxplayer: Bump revision

### DIFF
--- a/recipes-multimedia/omxplayer/omxplayer/0004-Add-FFMPEG_EXTRA_CFLAGS-and-FFMPEG_EXTRA_LDFLAGS.patch
+++ b/recipes-multimedia/omxplayer/omxplayer/0004-Add-FFMPEG_EXTRA_CFLAGS-and-FFMPEG_EXTRA_LDFLAGS.patch
@@ -20,7 +20,7 @@ Index: git/Makefile.ffmpeg
 @@ -1,5 +1,7 @@
  CFLAGS=-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -DTARGET_LINUX -fPIC -DPIC -D_REENTRANT -D_HAVE_SBRK -D_LARGEFILE64_SOURCE -DHAVE_CMAKE_CONFIG -DHAVE_VMCS_CONFIG -D_REENTRANT -DUSE_VCHIQ_ARM -DVCHI_BULK_ALIGN=1 -DVCHI_BULK_GRANULARITY=1 -DEGL_SERVER_DISPMANX -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D__VIDEOCORE4__ -DGRAPHICS_X_VG=1 -U_FORTIFY_SOURCE -Wall -DHAVE_OMXLIB -DUSE_EXTERNAL_FFMPEG  -DHAVE_LIBAVCODEC_AVCODEC_H -DHAVE_LIBAVUTIL_MEM_H -DHAVE_LIBAVUTIL_AVUTIL_H -DHAVE_LIBAVFORMAT_AVFORMAT_H -DHAVE_LIBAVFILTER_AVFILTER_H -DOMX -DOMX_SKIP64BIT
  
-+FFMPEG_EXTRA_CFLAGS?=-mfpu=vfp -mfloat-abi=$(FLOAT) -mno-apcs-stack-check -mstructure-size-boundary=32 -mno-sched-prolog
++FFMPEG_EXTRA_CFLAGS?=-mfpu=vfp -mfloat-abi=$(FLOAT)
 +
  WORK=$(PWD)
  
@@ -29,7 +29,7 @@ Index: git/Makefile.ffmpeg
  	CFLAGS="$(CFLAGS) ${INCLUDES}" \
  	LDFLAGS="" \
    ./configure \
--			--extra-cflags="-mfpu=vfp -mfloat-abi=hard -mno-apcs-stack-check -mstructure-size-boundary=32 -mno-sched-prolog" \
+-			--extra-cflags="-mfpu=vfp -mfloat-abi=hard" \
 +			--extra-cflags="$(FFMPEG_EXTRA_CFLAGS)" \
 +			--extra-ldflags="$(FFMPEG_EXTRA_LDFLAGS)" \
  			--enable-shared \

--- a/recipes-multimedia/omxplayer/omxplayer/0007-Remove-Makefile-hardcoded-arch-tune.patch
+++ b/recipes-multimedia/omxplayer/omxplayer/0007-Remove-Makefile-hardcoded-arch-tune.patch
@@ -1,8 +1,8 @@
 --- a/Makefile	2019-06-20 15:04:53.390282996 +0200
 +++ b/Makefile	2019-06-20 15:03:45.538763872 +0200
 @@ -1,4 +1,4 @@
--CFLAGS=-pipe -mfloat-abi=hard -mcpu=arm1176jzf-s -fomit-frame-pointer -mabi=aapcs-linux -mtune=arm1176jzf-s -mfpu=vfp -Wno-psabi -mno-apcs-stack-check -g -mstructure-size-boundary=32 -mno-sched-prolog
-+CFLAGS+= -fomit-frame-pointer -mabi=aapcs-linux -Wno-psabi -mno-apcs-stack-check -g -mstructure-size-boundary=32 -mno-sched-prolog
+-CFLAGS=-pipe -mfloat-abi=hard -mcpu=arm1176jzf-s -fomit-frame-pointer -mabi=aapcs-linux -mtune=arm1176jzf-s -mfpu=vfp -Wno-psabi -g
++CFLAGS+= -fomit-frame-pointer -mabi=aapcs-linux -Wno-psabi -g
  CFLAGS+=-std=c++0x -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -DTARGET_LINUX -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -DHAVE_CMAKE_CONFIG -D__VIDEOCORE4__ -U_FORTIFY_SOURCE -Wall -DHAVE_OMXLIB -DUSE_EXTERNAL_FFMPEG  -DHAVE_LIBAVCODEC_AVCODEC_H -DHAVE_LIBAVUTIL_OPT_H -DHAVE_LIBAVUTIL_MEM_H -DHAVE_LIBAVUTIL_AVUTIL_H -DHAVE_LIBAVFORMAT_AVFORMAT_H -DHAVE_LIBAVFILTER_AVFILTER_H -DHAVE_LIBSWRESAMPLE_SWRESAMPLE_H -DOMX -DOMX_SKIP64BIT -ftree-vectorize -DUSE_EXTERNAL_OMX -DTARGET_RASPBERRY_PI -DUSE_EXTERNAL_LIBBCM_HOST
  
  LDFLAGS=-L$(SDKSTAGE)/opt/vc/lib/

--- a/recipes-multimedia/omxplayer/omxplayer_git.bb
+++ b/recipes-multimedia/omxplayer/omxplayer_git.bb
@@ -5,13 +5,13 @@ HOMEPAGE = "https://github.com/popcornmix/omxplayer"
 SECTION = "console/utils"
 
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
+LIC_FILES_CHKSUM = "file://COPYING;md5=00a27da7ac0f9bcd17320ec29ef4bbf6"
 
 DEPENDS = "libpcre libav virtual/egl boost freetype dbus openssl libssh libomxil coreutils-native curl-native userland"
 
-PR = "r4"
+PR = "r5"
 
-SRCREV_default = "b4bbef8fac5e8c2ddafa895f98456ba715b39c6b"
+SRCREV_default = "f543a0d0e707ab56415f17b0ca6d397394ee8b63"
 
 # omxplayer builds its own copy of ffmpeg from source instead of using the
 # system's ffmpeg library. This isn't ideal but it's ok for now. We do however


### PR DESCRIPTION
Updated SRCREV to `f543a0d0e707ab56415f17b0ca6d397394ee8b63` to fix playback errors on RPi 4 (https://github.com/popcornmix/omxplayer/issues/733).