### PR TITLE
mesa: Enable vc4, v3d, kmsro gallium drivers

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-kernel/linux/bpftool.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-kernel/linux/bpftool.bbappend
@@ -1,3 +1,0 @@
-# remove it when we upgrade to kernel > 4.14
-#
-COMPATIBLE_HOST_rpi = "null"

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -2,6 +2,5 @@
 # With oe-core commit 8509e2e1a87578882b71948ccef3b50ccf1228b3 dri3 is set
 # as default. To state out clearly that Raspi needs dri3 and to avoid surprises
 # in case oe-core changes this default, we set dri3 explicitly.
-PACKAGECONFIG_append_rpi = " gallium ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11 dri3', '', d)}"
-GALLIUMDRIVERS_append_rpi = ",vc4,v3d,kmsro"
-DRIDRIVERS_rpi = ""
+PACKAGECONFIG_append_rpi = " gallium vc4 v3d kmsro ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11 dri3', '', d)}"
+DRIDRIVERS_class-target_rpi = ""


### PR DESCRIPTION
This enables new v3d driver which needs kmsro as dependency

This will start working fully after oe-core change [1] is merged

[1] http://lists.openembedded.org/pipermail/openembedded-core/2019-August/285763.html