### PR TITLE
linux-raspberrypi-rt: update to latest commit for 4.14 series

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-rt_4.14.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-rt_4.14.bb
@@ -1,6 +1,6 @@
-LINUX_VERSION ?= "4.14.81"
+LINUX_VERSION ?= "4.14.91"
 
-SRCREV = "acf578d07d57480674d5361df9171fe9528765cb"
+SRCREV = "0b520d5f1f580d36a742a9457a5673fa1578fff3"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y-rt \
     file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \


### PR DESCRIPTION
Update linux kernel 4.14 series recipe for building with latest -rt
branch.
This fixes #474.