### PR TITLE
raspberrypi-firmware: upgrade to latest to fix vc4-fkms

### DIFF
--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,10 +1,10 @@
-RPIFW_DATE ?= "20190718"
-SRCREV ?= "d36bde339b067bf13b610fd9741d6351c1dafc38"
+RPIFW_DATE ?= "20190823"
+SRCREV ?= "7163480fff007dc98978899b556dcf06f8a462c8"
 RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[md5sum] = "273fe147e3edc92ce38a0ff6bf49e3b9"
-SRC_URI[sha256sum] = "f266df66ce92e7726e894c0c870f0d8e7257434f102ba77bd60640970b689aa3"
+SRC_URI[md5sum] = "b10044aa637ed170eef2ca6c1dcc8aba"
+SRC_URI[sha256sum] = "012bc542157d03d19c52dfb2ff9e828905d1991a8b33420f1a2e3730040c167f"
 
 PV = "${RPIFW_DATE}"


### PR DESCRIPTION
* with 4.19.66 kernel the vc4-fkms no longer works, because it doesn't
  get any usable modes from firmware

* this behavior was introduced probably in one of following changes:
  https://github.com/raspberrypi/firmware/commit/38e81f25e639d19fc0ce6e67fd39998c340a15d5
  https://github.com/raspberrypi/linux/pull/3082
  https://github.com/raspberrypi/linux/pull/3110
  https://github.com/raspberrypi/firmware/commit/66bafab005569e3eb92ec54cd3efeee3da338738

* without this fix:
root@rpijama:~# cat /proc/device-tree/soc/firmwarekms@7e600000/status
okay

root@rpijama:~# modeprint vc4
Starting test
Resources

count_connectors : 1
count_encoders   : 1
count_crtcs      : 1
count_fbs        : 0

Connector: HDMI-A-1
        id             : 51
        encoder id     : 0
        conn           : connected
        size           : 0x0 (mm)
        count_modes    : 0
        count_props    : 9
        props          : 1 2 5 6 52 53 54 55 56
        count_encoders : 1
        encoders       : 50

Encoder: TMDS
        id     :50
        crtc_id   :0
        type   :2
        possible_crtcs  :0x1
        possible_clones :0x0

Crtc
        id             : 49
        x              : 0
        y              : 0
        width          : 0
        height         : 0
        mode           : 0xfec884
        gamma size     : 0

Ok

* with this fix:

martin@jama ~ $ sshc root@rpijama
Warning: Permanently added 'rpijama,192.168.169.37' (ECDSA) to the list of known hosts.
root@rpijama:~# modeprint vc4
Starting test
Resources

count_connectors : 1
count_encoders   : 1
count_crtcs      : 1
count_fbs        : 0

Connector: HDMI-A-1
        id             : 51
        encoder id     : 50
        conn           : connected
        size           : 1600x900 (mm)
        count_modes    : 22
        count_props    : 9
        props          : 1 2 5 6 52 53 54 55 56
        count_encoders : 1
        encoders       : 50
Mode: "1920x1080" 1920x1080 60
Mode: "1920x1080" 1920x1080 60
Mode: "1920x1080" 1920x1080 50
Mode: "1920x1080" 1920x1080 30
Mode: "1920x1080" 1920x1080 30
Mode: "1920x1080" 1920x1080 25
Mode: "1920x1080" 1920x1080 24
Mode: "1920x1080" 1920x1080 24
Mode: "1280x1024" 1280x1024 60
Mode: "1360x768" 1360x768 60
Mode: "1152x864" 1152x864 60
Mode: "1280x720" 1280x720 60
Mode: "1280x720" 1280x720 60
Mode: "1280x720" 1280x720 50
Mode: "1024x768" 1024x768 60
Mode: "800x600" 800x600 60
Mode: "720x576" 720x576 50
Mode: "720x480" 720x480 60
Mode: "720x480" 720x480 60
Mode: "640x480" 640x480 60
Mode: "640x480" 640x480 60
Mode: "720x400" 720x400 70

Encoder: TMDS
        id     :50
        crtc_id   :49
        type   :2
        possible_crtcs  :0x1
        possible_clones :0x0

Crtc
        id             : 49
        x              : 0
        y              : 0
        width          : 1920
        height         : 1080
        mode           : 0x1fcde54
        gamma size     : 0

Ok

* tested on raspberrypi3 B
  weston works fine
  qtbase-examples tested with:
  /usr/share/examples/opengl/cube/cube -platform eglfs

* the same issue is now in warrior, after someone tests on raspberrypi4
  it would be good to backport this to warrior as well

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
