### PR TITLE
add RPi 0W to UART doc section

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -219,7 +219,7 @@ needs a fixed core frequency and enable_uart wil set it to the minimum. Certain
 operations - 60fps h264 decode, high quality deinterlace - which aren't
 performed on the ARM may be affected, and we wouldn't want to do that to users
 who don't want to use the serial port. Users who want serial console support on
-RaspberryPi3 will have to explicitly set in local.conf:
+RaspberryPi 0 Wifi or 3 will have to explicitly set in local.conf:
 
     ENABLE_UART = "1"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
This makes it clear that ENABLE_UART can be used both for the **RPi 0W** or 3.
**- How I did it**
Just updated the "Enable UART" section of `docs/extra-build-config.md`