### PR TITLE
raspberrypi-linux: removed protocoll setting from SRC_URI

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.19.inc
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.inc
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
 SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_BRANCH} \
+    git://github.com/raspberrypi/linux.git;branch=${LINUX_RPI_BRANCH} \
     "
 SRC_URI_append_raspberrypi4-64 = " file://rpi4-64-kernel-misc.cfg"
 


### PR DESCRIPTION
Default protocoll for git will be used. Default setting is in the most case https.

Signed-off-by: Timm Eversmeyer saeugetier@gmail.com

fixes #465 
