### PR TITLE
Introduce DISABLE_VC4GRAPHICS

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -70,7 +70,7 @@ KERNEL_IMAGETYPE_DIRECT ??= "zImage"
 KERNEL_IMAGETYPE ?= "${@bb.utils.contains('RPI_USE_U_BOOT', '1', \
         '${KERNEL_IMAGETYPE_UBOOT}', '${KERNEL_IMAGETYPE_DIRECT}', d)}"
 
-MACHINE_FEATURES += "apm usbhost keyboard vfat ext2 screen touchscreen alsa bluetooth wifi sdio vc4graphics"
+MACHINE_FEATURES += "apm usbhost keyboard vfat ext2 screen touchscreen alsa bluetooth wifi sdio ${@bb.utils.contains('DISABLE_VC4GRAPHICS', '1', '', 'vc4graphics', d)}"
 
 # Raspberry Pi has no hardware clock
 MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"

--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -23,7 +23,6 @@ RPI_KERNEL_DEVICETREE = " \
 SERIAL_CONSOLES ?= "115200;ttyS0"
 
 UBOOT_MACHINE = "rpi_3_config"
-MACHINE_FEATURES_append = " vc4graphics"
 
 # When u-boot is enabled we need to use the "Image" format and the "booti"
 # command to load the kernel

--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -20,7 +20,6 @@ SDIMG_KERNELIMAGE ?= "kernel8.img"
 SERIAL_CONSOLES ?= "115200;ttyS0"
 
 UBOOT_MACHINE = "rpi_4_config"
-MACHINE_FEATURES_append = " vc4graphics"
 
 VC4DTBO ?= "vc4-fkms-v3d"
 

--- a/conf/machine/raspberrypi4.conf
+++ b/conf/machine/raspberrypi4.conf
@@ -16,6 +16,5 @@ SDIMG_KERNELIMAGE ?= "kernel7l.img"
 UBOOT_MACHINE = "rpi_4_32b_config"
 SERIAL_CONSOLES ?= "115200;ttyS0"
 
-MACHINE_FEATURES_append = " vc4graphics"
 VC4DTBO ?= "vc4-fkms-v3d"
 ARMSTUB ?= "armstub7.bin"

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -31,6 +31,10 @@ Accommodate the values above to your own needs (ex: ext3 / ext4).
 
 See: <https://www.raspberrypi.org/documentation/configuration/config-txt/memory.md>
 
+## VC4
+
+By default, each machine uses `vc4` for graphics. This will in turn sets mesa as provider for `gl` libraries. `DISABLE_VC4GRAPHICS` can be set to `1` to disable this behaviour falling back to using `userland`. Be aware that `userland` has not support for 64-bit arch. If you disable `vc4` on a 64-bit Raspberry Pi machine, expect build breakage.
+
 ## Add purchased license codecs
 
 To add you own licenses use variables `KEY_DECODE_MPG2` and `KEY_DECODE_WVC1` in


### PR DESCRIPTION
By default, each machine uses `vc4` for graphics. This will in turn sets mesa as provider for `gl` libraries. `DISABLE_VC4GRAPHICS` can be set to `1` to disable this behaviour falling back to using `userland`. Be aware that `userland` has not support for 64-bit arch. If you disable `vc4` on a 64-bit Raspberry Pi machine, expect build breakage. 