### PR TITLE
psplash: Raise alternatives priority to 200

### DIFF
--- a/recipes-core/psplash/psplash_%.bbappend
+++ b/recipes-core/psplash/psplash_%.bbappend
@@ -1,4 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SPLASH_IMAGES_append_rpi = " file://psplash-raspberrypi-img.h;outsuffix=raspberrypi"
-ALTERNATIVE_PRIORITY_psplash-raspberrypi[psplash] = "10"
-
+ALTERNATIVE_PRIORITY_psplash-raspberrypi[psplash] = "200"


### PR DESCRIPTION
Alternatives priority of psplash in poky is now 100,
so we need something higher (fixes #381).

Signed-off-by: Gianluigi Tiesi <sherpya@netfarm.it>
(cherry picked from commit 7059c374512f1c1c0df9ecab0703d11438bdf78b)