### PR TITLE
bcm2835-bootfiles: tighten up dep on rpi-config

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -55,6 +55,7 @@ do_image_rpi_sdimg[depends] = " \
     dosfstools-native:do_populate_sysroot \
     virtual/kernel:do_deploy \
     ${IMAGE_BOOTLOADER}:do_deploy \
+    rpi-config:do_deploy \
     ${@bb.utils.contains('MACHINE_FEATURES', 'armstub', 'armstubs:do_deploy', '' ,d)} \
     ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
     ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'rpi-u-boot-scr:do_deploy', '',d)} \

--- a/recipes-bsp/bootfiles/bcm2835-bootfiles.bb
+++ b/recipes-bsp/bootfiles/bcm2835-bootfiles.bb
@@ -34,6 +34,8 @@ do_deploy() {
     touch ${DEPLOYDIR}/${PN}/${PN}-${PV}.stamp
 }
 
+do_deploy[depends] += "rpi-config:do_deploy"
+
 addtask deploy before do_build after do_install
 do_deploy[dirs] += "${DEPLOYDIR}/${PN}"
 


### PR DESCRIPTION
Intuitively, bcm2835-bootfiles:do_deploy should depend on rpi-config:do_deploy.

This indirectly resolves a missing dep between rpi-config:do_deploy and
do_image_rpi_sdimg (on an image recipe inheriting from sdcard_image-rpi.bbclass).
This manifested as changes to rpi-config (e.g. setting or unsetting
ENABLE_* variables) not triggering a rebuild of the SD card image.

Signed-off-by: Chris Laplante <mostthingsweb@gmail.com>