### PR TITLE
Drop tslib from packageconfig.

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -4,7 +4,7 @@ PACKAGECONFIG_GL_rpi = "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'g
 PACKAGECONFIG_GL_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', ' kms', '', d)}"
 PACKAGECONFIG_GL_append_rpi = " gbm"
 PACKAGECONFIG_FONTS_rpi = "fontconfig"
-PACKAGECONFIG_append_rpi = " libinput examples tslib xkb xkbcommon"
+PACKAGECONFIG_append_rpi = " libinput examples xkb xkbcommon"
 PACKAGECONFIG_remove_rpi = "tests"
 
 OE_QTBASE_EGLFS_DEVICE_INTEGRATION_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'eglfs_brcm', d)}"


### PR DESCRIPTION
yocto zeus has no tslib support anymore, so the build fails with:
ERROR: Nothing PROVIDES 'tslib' (but meta-qt5/recipes-qt/qt5/qtbase_git.bb DEPENDS on or otherwise requires it). Close matches:
  taglib
ERROR: Required build target 'qtbase' has no buildable providers.
Missing or unbuildable dependency chain was: ['qtbase', 'tslib']


