### PR TITLE
raspi-gpio: bump to revision 2eaa8b8

### DIFF
--- a/recipes-devtools/raspi-gpio/raspi-gpio_git.bb
+++ b/recipes-devtools/raspi-gpio/raspi-gpio_git.bb
@@ -8,7 +8,7 @@ COMPATIBLE_MACHINE = "^rpi$"
 
 inherit autotools
 
-SRCREV = "2df7b8684e2e36b080cda315d78d5ba16f8f18b0"
+SRCREV = "2eaa8b8755a550e34d07c898b90b0d9b3d66fd81"
 SRC_URI = "git://github.com/RPi-Distro/raspi-gpio.git;protocol=https;branch=master \
           "
 


### PR DESCRIPTION
This includes the following changes:

2eaa8b8 Initialise hwbase so that access without /dev/gpiomem works again
f36777c Whitespace tidyup (and re-ran astyle). No functional changes.
80fa7d0 Add support for 2711
bf7f4c8 Reformat with astyle (cosmetic change)
aa55bbd Autoreconf for Buster
5e453d0 raspi-gpio: Fix handling of "funcs" mode

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>