### PR TITLE
Fix u-boot support for rpi4

### DIFF
--- a/recipes-bsp/u-boot/u-boot-2019.10.inc
+++ b/recipes-bsp/u-boot/u-boot-2019.10.inc
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot-2019.10:"
+
+SRC_URI_append_rpi = " \
+    file://0001-libfdt-fdt_address_cells-and-fdt_size_cells.patch \
+    file://0002-libfdt-return-correct-value-if-size-cells-property-i.patch \
+    file://0003-libfdt-Allow-size-cells-of-0.patch \
+    file://0004-dm-Fix-default-address-cells-return-value.patch \
+"

--- a/recipes-bsp/u-boot/u-boot-2019.10/0001-libfdt-fdt_address_cells-and-fdt_size_cells.patch
+++ b/recipes-bsp/u-boot/u-boot-2019.10/0001-libfdt-fdt_address_cells-and-fdt_size_cells.patch
@@ -1,0 +1,105 @@
+From 8d0867e28073b652f275ae94d470feed368e23ee Mon Sep 17 00:00:00 2001
+From: Matthias Brugger <mbrugger@suse.com>
+Date: Thu, 5 Sep 2019 10:48:46 +0200
+Subject: [PATCH 1/4] libfdt: fdt_address_cells() and fdt_size_cells()
+
+Add internal fdt_cells() to avoid copy and paste. Fix typo in
+fdt_size_cells() documentation comment.
+
+This is based in upstream commit:
+c12b2b0 ("libfdt: fdt_address_cells() and fdt_size_cells()")
+but misses the test cases, as we don't implement them in U-Boot.
+
+Signed-off-by: Matthias Brugger <mbrugger@suse.com>
+Reviewed-by: Simon Glass <sjg@chromium.org>
+
+Upstream-Status: Backport [git://gitlab.denx.de/u-boot/u-boot]
+Signed-off-by: Laurent Bonnans <laurent.bonnans@here.com>
+---
+ scripts/dtc/libfdt/fdt_addresses.c | 35 +++++++++++-------------------
+ scripts/dtc/libfdt/libfdt.h        |  2 +-
+ 2 files changed, 14 insertions(+), 23 deletions(-)
+
+diff --git a/scripts/dtc/libfdt/fdt_addresses.c b/scripts/dtc/libfdt/fdt_addresses.c
+index eff4dbcc72..49537b578d 100644
+--- a/scripts/dtc/libfdt/fdt_addresses.c
++++ b/scripts/dtc/libfdt/fdt_addresses.c
+@@ -1,6 +1,7 @@
+ /*
+  * libfdt - Flat Device Tree manipulation
+  * Copyright (C) 2014 David Gibson <david@gibson.dropbear.id.au>
++ * Copyright (C) 2018 embedded brains GmbH
+  *
+  * libfdt is dual licensed: you can use it either under the terms of
+  * the GPL, or the BSD license, at your option.
+@@ -55,42 +56,32 @@
+ 
+ #include "libfdt_internal.h"
+ 
+-int fdt_address_cells(const void *fdt, int nodeoffset)
++static int fdt_cells(const void *fdt, int nodeoffset, const char *name)
+ {
+-	const fdt32_t *ac;
++	const fdt32_t *c;
+ 	int val;
+ 	int len;
+ 
+-	ac = fdt_getprop(fdt, nodeoffset, "#address-cells", &len);
+-	if (!ac)
++	c = fdt_getprop(fdt, nodeoffset, name, &len);
++	if (!c)
+ 		return 2;
+ 
+-	if (len != sizeof(*ac))
++	if (len != sizeof(*c))
+ 		return -FDT_ERR_BADNCELLS;
+ 
+-	val = fdt32_to_cpu(*ac);
++	val = fdt32_to_cpu(*c);
+ 	if ((val <= 0) || (val > FDT_MAX_NCELLS))
+ 		return -FDT_ERR_BADNCELLS;
+ 
+ 	return val;
+ }
+ 
+-int fdt_size_cells(const void *fdt, int nodeoffset)
++int fdt_address_cells(const void *fdt, int nodeoffset)
+ {
+-	const fdt32_t *sc;
+-	int val;
+-	int len;
+-
+-	sc = fdt_getprop(fdt, nodeoffset, "#size-cells", &len);
+-	if (!sc)
+-		return 2;
+-
+-	if (len != sizeof(*sc))
+-		return -FDT_ERR_BADNCELLS;
+-
+-	val = fdt32_to_cpu(*sc);
+-	if ((val < 0) || (val > FDT_MAX_NCELLS))
+-		return -FDT_ERR_BADNCELLS;
++	return fdt_cells(fdt, nodeoffset, "#address-cells");
++}
+ 
+-	return val;
++int fdt_size_cells(const void *fdt, int nodeoffset)
++{
++	return fdt_cells(fdt, nodeoffset, "#size-cells");
+ }
+diff --git a/scripts/dtc/libfdt/libfdt.h b/scripts/dtc/libfdt/libfdt.h
+index cf86ddba88..66f01fec53 100644
+--- a/scripts/dtc/libfdt/libfdt.h
++++ b/scripts/dtc/libfdt/libfdt.h
+@@ -1109,7 +1109,7 @@ int fdt_address_cells(const void *fdt, int nodeoffset);
+  *
+  * returns:
+  *	0 <= n < FDT_MAX_NCELLS, on success
+- *      2, if the node has no #address-cells property
++ *      2, if the node has no #size-cells property
+  *      -FDT_ERR_BADNCELLS, if the node has a badly formatted or invalid
+  *		#size-cells property
+  *	-FDT_ERR_BADMAGIC,
+-- 
+2.24.0
+

--- a/recipes-bsp/u-boot/u-boot-2019.10/0002-libfdt-return-correct-value-if-size-cells-property-i.patch
+++ b/recipes-bsp/u-boot/u-boot-2019.10/0002-libfdt-return-correct-value-if-size-cells-property-i.patch
@@ -1,0 +1,79 @@
+From b7a17b1035cbbbf747e036be3470b4983cd3dce0 Mon Sep 17 00:00:00 2001
+From: Matthias Brugger <mbrugger@suse.com>
+Date: Thu, 5 Sep 2019 10:48:47 +0200
+Subject: [PATCH 2/4] libfdt: return correct value if #size-cells property is
+ not present
+
+According to the device tree specification, the default value for
+was not present.
+
+This patch also makes fdt_address_cells() and fdt_size_cells() conform
+to the behaviour documented in libfdt.h. The defaults are only returned
+if fdt_getprop() returns -FDT_ERR_NOTFOUND, otherwise the actual error
+is returned.
+
+This is based on upstream commit:
+aa7254d ("libfdt: return correct value if #size-cells property is not present")
+but misses the test case part, as we don't implement them in U-Boot.
+
+Signed-off-by: Matthias Brugger <mbrugger@suse.com>
+
+Upstream-Status: Backport [git://gitlab.denx.de/u-boot/u-boot]
+Signed-off-by: Laurent Bonnans <laurent.bonnans@here.com>
+---
+ scripts/dtc/libfdt/fdt_addresses.c | 16 +++++++++++++---
+ scripts/dtc/libfdt/libfdt.h        |  2 +-
+ 2 files changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/scripts/dtc/libfdt/fdt_addresses.c b/scripts/dtc/libfdt/fdt_addresses.c
+index 49537b578d..f13a87dfa0 100644
+--- a/scripts/dtc/libfdt/fdt_addresses.c
++++ b/scripts/dtc/libfdt/fdt_addresses.c
+@@ -64,7 +64,7 @@ static int fdt_cells(const void *fdt, int nodeoffset, const char *name)
+ 
+ 	c = fdt_getprop(fdt, nodeoffset, name, &len);
+ 	if (!c)
+-		return 2;
++		return len;
+ 
+ 	if (len != sizeof(*c))
+ 		return -FDT_ERR_BADNCELLS;
+@@ -78,10 +78,20 @@ static int fdt_cells(const void *fdt, int nodeoffset, const char *name)
+ 
+ int fdt_address_cells(const void *fdt, int nodeoffset)
+ {
+-	return fdt_cells(fdt, nodeoffset, "#address-cells");
++	int val;
++
++	val = fdt_cells(fdt, nodeoffset, "#address-cells");
++	if (val == -FDT_ERR_NOTFOUND)
++		return 2;
++	return val;
+ }
+ 
+ int fdt_size_cells(const void *fdt, int nodeoffset)
+ {
+-	return fdt_cells(fdt, nodeoffset, "#size-cells");
++	int val;
++
++	val = fdt_cells(fdt, nodeoffset, "#size-cells");
++	if (val == -FDT_ERR_NOTFOUND)
++		return 1;
++	return val;
+ }
+diff --git a/scripts/dtc/libfdt/libfdt.h b/scripts/dtc/libfdt/libfdt.h
+index 66f01fec53..5c778b115b 100644
+--- a/scripts/dtc/libfdt/libfdt.h
++++ b/scripts/dtc/libfdt/libfdt.h
+@@ -1109,7 +1109,7 @@ int fdt_address_cells(const void *fdt, int nodeoffset);
+  *
+  * returns:
+  *	0 <= n < FDT_MAX_NCELLS, on success
+- *      2, if the node has no #size-cells property
++ *      1, if the node has no #size-cells property
+  *      -FDT_ERR_BADNCELLS, if the node has a badly formatted or invalid
+  *		#size-cells property
+  *	-FDT_ERR_BADMAGIC,
+-- 
+2.24.0
+

--- a/recipes-bsp/u-boot/u-boot-2019.10/0003-libfdt-Allow-size-cells-of-0.patch
+++ b/recipes-bsp/u-boot/u-boot-2019.10/0003-libfdt-Allow-size-cells-of-0.patch
@@ -1,0 +1,67 @@
+From c31cb8e5ff9a07429f5babe91168a1939e2d9dac Mon Sep 17 00:00:00 2001
+From: Matthias Brugger <mbrugger@suse.com>
+Date: Thu, 5 Sep 2019 10:48:48 +0200
+Subject: [PATCH 3/4] libfdt: Allow #size-cells of 0
+
+The commit "libfdt: fdt_address_cells() and fdt_size_cells()" introduced
+a bug as it consolidated code between the helpers for getting
+be 0, and is frequently found so in practice for /cpus.  IEEE1275 only
+requires implementations to handle 1..4 for #address-cells, although one
+could make a case for #address-cells == #size-cells == 0 being used to
+represent a bridge with a single port.
+
+While we're there, it's not totally obvious that the existing implicit
+cast of a u32 to int will give the correct results according to strict C,
+although it does work in practice.  Straighten that up to cast only after
+we've made our range checks.
+
+This is based on upstream commit:
+b8d6eca ("libfdt: Allow #size-cells of 0")
+but misses the test cases,as we don't implement them in U-Boot.
+
+Signed-off-by: Matthias Brugger <mbrugger@suse.com>
+
+Upstream-Status: Backport [git://gitlab.denx.de/u-boot/u-boot]
+Signed-off-by: Laurent Bonnans <laurent.bonnans@here.com>
+---
+ scripts/dtc/libfdt/fdt_addresses.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/dtc/libfdt/fdt_addresses.c b/scripts/dtc/libfdt/fdt_addresses.c
+index f13a87dfa0..788c143113 100644
+--- a/scripts/dtc/libfdt/fdt_addresses.c
++++ b/scripts/dtc/libfdt/fdt_addresses.c
+@@ -59,7 +59,7 @@
+ static int fdt_cells(const void *fdt, int nodeoffset, const char *name)
+ {
+ 	const fdt32_t *c;
+-	int val;
++	uint32_t val;
+ 	int len;
+ 
+ 	c = fdt_getprop(fdt, nodeoffset, name, &len);
+@@ -70,10 +70,10 @@ static int fdt_cells(const void *fdt, int nodeoffset, const char *name)
+ 		return -FDT_ERR_BADNCELLS;
+ 
+ 	val = fdt32_to_cpu(*c);
+-	if ((val <= 0) || (val > FDT_MAX_NCELLS))
++	if (val > FDT_MAX_NCELLS)
+ 		return -FDT_ERR_BADNCELLS;
+ 
+-	return val;
++	return (int)val;
+ }
+ 
+ int fdt_address_cells(const void *fdt, int nodeoffset)
+@@ -81,6 +81,8 @@ int fdt_address_cells(const void *fdt, int nodeoffset)
+ 	int val;
+ 
+ 	val = fdt_cells(fdt, nodeoffset, "#address-cells");
++	if (val == 0)
++		return -FDT_ERR_BADNCELLS;
+ 	if (val == -FDT_ERR_NOTFOUND)
+ 		return 2;
+ 	return val;
+-- 
+2.24.0
+

--- a/recipes-bsp/u-boot/u-boot-2019.10/0004-dm-Fix-default-address-cells-return-value.patch
+++ b/recipes-bsp/u-boot/u-boot-2019.10/0004-dm-Fix-default-address-cells-return-value.patch
@@ -1,0 +1,33 @@
+From 352736e5f59789a17c80acff4fbe6ee9ca1b49c4 Mon Sep 17 00:00:00 2001
+From: Matthias Brugger <mbrugger@suse.com>
+Date: Thu, 5 Sep 2019 10:48:49 +0200
+Subject: [PATCH 4/4] dm: Fix default address cells return value
+
+Default address cells value on the livetree access function
+returns the wrong value. Fix this so that the value returned
+corresponds to the device tree specification.
+
+Signed-off-by: Matthias Brugger <mbrugger@suse.com>
+
+Upstream-Status: Backport [git://gitlab.denx.de/u-boot/u-boot]
+Signed-off-by: Laurent Bonnans <laurent.bonnans@here.com>
+---
+ include/dm/of.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/dm/of.h b/include/dm/of.h
+index 461e25aa19..6bef73b441 100644
+--- a/include/dm/of.h
++++ b/include/dm/of.h
+@@ -111,7 +111,7 @@ static inline const char *of_node_full_name(const struct device_node *np)
+ 
+ /* Default #address and #size cells */
+ #if !defined(OF_ROOT_NODE_ADDR_CELLS_DEFAULT)
+-#define OF_ROOT_NODE_ADDR_CELLS_DEFAULT 1
++#define OF_ROOT_NODE_ADDR_CELLS_DEFAULT 2
+ #define OF_ROOT_NODE_SIZE_CELLS_DEFAULT 1
+ #endif
+ 
+-- 
+2.24.0
+

--- a/recipes-bsp/u-boot/u-boot-fw-utils_2019.10.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils_2019.10.bbappend
@@ -1,0 +1,1 @@
+require u-boot-${PV}.inc

--- a/recipes-bsp/u-boot/u-boot_2019.10.bbappend
+++ b/recipes-bsp/u-boot/u-boot_2019.10.bbappend
@@ -1,0 +1,1 @@
+require u-boot-${PV}.inc


### PR DESCRIPTION
u-boot stopped working on rpi4 starting from the following commit
included in 2019.10: https://gitlab.denx.de/u-boot/u-boot/commit/9de5b89e4c898ec770878eb4848588c635a37bac

According to the mailing list, it has been since fixed on u-boot master: https://www.mail-archive.com/u-boot@lists.denx.de/msg346771.html

After testing, it seems to be accurate!