### PR TITLE
sdcard_image-rpi.bbclass: Use IMAGE_NAME_SUFFIX variable in SDIMG

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -64,7 +64,7 @@ do_image_rpi_sdimg[depends] = " \
 do_image_rpi_sdimg[recrdeps] = "do_build"
 
 # SD card image name
-SDIMG = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.rpi-sdimg"
+SDIMG = "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.rpi-sdimg"
 
 # Additional files and/or directories to be copied into the vfat partition from the IMAGE_ROOTFS.
 FATPAYLOAD ?= ""


### PR DESCRIPTION
Use the IMAGE_NAME_SUFFIX variable to build the SDIMG name. Some layers,
notably meta-mender, change the IMAGE_NAME_SUFFIX variable to something
other that ".rootfs", causing build failures.

Signed-off-by: Francois Retief <fgretief@gmail.com>