### PR TITLE
linux-raspberrypi.inc: no longer set CONFIG_LOCALVERSION to empty string

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -22,6 +22,8 @@ KBUILD_DEFCONFIG_raspberrypi3-64 ?= "bcmrpi3_defconfig"
 KBUILD_DEFCONFIG_raspberrypi4 ?= "bcm2711_defconfig"
 KBUILD_DEFCONFIG_raspberrypi4-64 ?= "bcm2711_defconfig"
 
+LINUX_VERSION_EXTENSION ?= ""
+
 # CMDLINE for raspberrypi
 SERIAL = "${@oe.utils.conditional("ENABLE_UART", "1", "console=serial0,115200", "", d)}"
 CMDLINE ?= "dwc_otg.lpm_enable=0 ${SERIAL} root=/dev/mmcblk0p2 rootfstype=ext4 rootwait"
@@ -97,9 +99,6 @@ do_configure_prepend() {
 
     mv -f ${B}/.config ${B}/.config.patched
     CONF_SED_SCRIPT=""
-
-    # Localversion
-    kernel_configure_variable LOCALVERSION "\"\""
 
     if [ "${INITRAMFS_IMAGE_BUNDLE}" = "1" ]; then
         kernel_configure_variable OVERLAY_FS y


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

#533 

Can I hope to also see this in the Warrior branch?