### PR TITLE
pi-bluetooth: Runtime depends on udev-rules-rpi

### DIFF
--- a/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.12.bb
+++ b/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.12.bb
@@ -43,3 +43,7 @@ FILES_${PN} = "\
     ${sysconfdir} \
     ${systemd_unitdir}/system \
 "
+
+RDEPENDS_${PN} += " \
+    udev-rules-rpi \
+"


### PR DESCRIPTION
Add udev-rules-rpi as a runtime dependency. It brings udev rules
for creating /dev/serial1. This way hciuart.service, provided by
pi-bluetooth, will be successfully started because it depends
on dev-serial1.device. As a result the Bluetooth module will
be properly attached via UART HCI to BlueZ stack.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
