### PR TITLE
linux-raspberrypi-rt: bump to revision e2e9cec

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-rt_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-rt_4.19.bb
@@ -1,6 +1,6 @@
 LINUX_VERSION ?= "4.19.71"
 LINUX_RPI_BRANCH ?= "rpi-4.19.y-rt"
 
-SRCREV = "1532ea50263c8fd70f769b55e60fbc6a0c5778a0"
+SRCREV = "e2e9cec6fb061ba58304fd391ef76747f2963557"
 
 require linux-raspberrypi_4.19.inc


### PR DESCRIPTION
This version includes a fix for the USB part.

Fixes:

[    2.988098] CPU: 3 PID: 79 Comm: irq/56-dwc_otg_ Not tainted 4.19.71-rt24 #1
[    2.988102] Hardware name: BCM2835
[    2.988134] [<801120a8>] (unwind_backtrace) from [<8010d260>] (show_stack+0x20/0x24)
[    2.988151] [<8010d260>] (show_stack) from [<8085340c>] (dump_stack+0xbc/0x100)
[    2.988167] [<8085340c>] (dump_stack) from [<80121160>] (__warn.part.0+0xcc/0xe8)
[    2.988182] [<80121160>] (__warn.part.0) from [<80121314>] (warn_slowpath_null+0x54/0x5c)
[    2.988197] [<80121314>] (warn_slowpath_null) from [<8014f120>] (migrate_disable+0x220/0x

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>