### PR TITLE
rpi-gpio: bump to version 0.7.0

### DIFF
--- a/recipes-devtools/python/rpi-gpio/0001-Remove-nested-functions.patch
+++ b/recipes-devtools/python/rpi-gpio/0001-Remove-nested-functions.patch
@@ -30,6 +30,8 @@ silence this warning
     uint32_t peri_base;
 
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+[Pierre-Jean: update for version 0.7.0]
+Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>
 ---
 Upstream-Status: Submitted
 
@@ -37,37 +39,6 @@ Upstream-Status: Submitted
  source/py_gpio.c | 135 ++++++++++++++++++++++++++++---------------------------
  2 files changed, 71 insertions(+), 70 deletions(-)
 
-diff --git a/source/c_gpio.c b/source/c_gpio.c
-index c96a2b0..b69880f 100644
---- a/source/c_gpio.c
-+++ b/source/c_gpio.c
-@@ -61,7 +61,7 @@ int setup(void)
- {
-     int mem_fd;
-     uint8_t *gpio_mem;
--    uint32_t peri_base;
-+    uint32_t peri_base = 0;
-     uint32_t gpio_base;
-     unsigned char buf[4];
-     FILE *fp;
-@@ -73,7 +73,7 @@ int setup(void)
-     if ((mem_fd = open("/dev/gpiomem", O_RDWR|O_SYNC)) > 0)
-     {
-         gpio_map = (uint32_t *)mmap(NULL, BLOCK_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED, mem_fd, 0);
--        if ((uint32_t)gpio_map < 0) {
-+        if (gpio_map == MAP_FAILED) {
-             return SETUP_MMAP_FAIL;
-         } else {
-             return SETUP_OK;
-@@ -127,7 +127,7 @@ int setup(void)
- 
-     gpio_map = (uint32_t *)mmap( (void *)gpio_mem, BLOCK_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_FIXED, mem_fd, gpio_base);
- 
--    if ((uint32_t)gpio_map < 0)
-+    if (gpio_map == MAP_FAILED)
-         return SETUP_MMAP_FAIL;
- 
-     return SETUP_OK;
 diff --git a/source/py_gpio.c b/source/py_gpio.c
 index d54cc7f..007bad5 100644
 --- a/source/py_gpio.c

--- a/recipes-devtools/python/rpi-gpio_0.7.0.bb
+++ b/recipes-devtools/python/rpi-gpio_0.7.0.bb
@@ -1,14 +1,14 @@
 DESCRIPTION = "A module to control Raspberry Pi GPIO channels"
-HOMEPAGE = "http://code.google.com/p/raspberry-gpio-python/"
+HOMEPAGE = "https://sourceforge.net/projects/raspberry-gpio-python/"
 SECTION = "devel/python"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENCE.txt;md5=9b95630a648966b142f1a0dcea001cb7"
 
 PYPI_PACKAGE = "RPi.GPIO"
-inherit pypi distutils
+inherit pypi distutils3
 
 SRC_URI += "file://0001-Remove-nested-functions.patch"
-SRC_URI[md5sum] = "e4abe1cfb5eacebe53078032256eb837"
-SRC_URI[sha256sum] = "a5fc0eb5e401963b6c0a03650da6b42c4005f02d962b81241d96c98d0a578516"
+SRC_URI[md5sum] = "777617f9dea9a1680f9af43db0cf150e"
+SRC_URI[sha256sum] = "7424bc6c205466764f30f666c18187a0824077daf20b295c42f08aea2cb87d3f"
 
 COMPATIBLE_MACHINE = "^rpi$"


### PR DESCRIPTION
Also:
  - update the HOMEPAGE location
  - refresh patch
  - use 'distutils3' to support python3 -> python2 is now deprecated

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>