### PR TITLE
conf/machine: add pci to MACHINE_FEATURES for Pi4

### DIFF
--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -4,6 +4,7 @@
 
 MACHINEOVERRIDES = "raspberrypi4:${MACHINE}"
 
+MACHINE_FEATURES += "pci"
 MACHINE_EXTRA_RRECOMMENDS += "\
     linux-firmware-rpidistro-bcm43455 \
     bluez-firmware-rpidistro-bcm4345c0-hcd \

--- a/conf/machine/raspberrypi4.conf
+++ b/conf/machine/raspberrypi4.conf
@@ -6,6 +6,7 @@ DEFAULTTUNE ?= "cortexa7thf-neon-vfpv4"
 require conf/machine/include/tune-cortexa7.inc
 include conf/machine/include/rpi-base.inc
 
+MACHINE_FEATURES += "pci"
 MACHINE_EXTRA_RRECOMMENDS += "\
     linux-firmware-rpidistro-bcm43455 \
     bluez-firmware-rpidistro-bcm4345c0-hcd \


### PR DESCRIPTION
This pulls in the pciutils package (including `lspci`) via packagegroup-base.