### PR TITLE
gstreamer1.0-plugins-base: respect opengl DISTRO_FEATURES when vc4gra…

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -5,6 +5,7 @@ EXTRA_OECONF_append_rpi = " CPPFLAGS='-I${STAGING_INCDIR}/interface/vcos/pthread
 
 PACKAGECONFIG_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' dispmanx', d)}"
 
-PACKAGECONFIG_GL_rpi = "egl gles2"
+PACKAGECONFIG_GL_VC4GRAPHICS = "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl', '', d)}"
+PACKAGECONFIG_GL_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '${PACKAGECONFIG_GL_VC4GRAPHICS}', 'egl gles2', d)}"
 
 PACKAGECONFIG[dispmanx] = "--enable-dispmanx,--disable-dispmanx,userland"


### PR DESCRIPTION
…phics is in MACHINE_FEATURES

No virtual/egl provider is available in the default setup with
vc4graphics enabled and neither opengl nor vulkan in DISTRO_FEATURES:

$ bitbake -e virtual/egl | tee env.egl
ERROR: Nothing PROVIDES 'virtual/egl'
vc-graphics-hardfp PROVIDES virtual/egl but was skipped: PREFERRED_PROVIDER_virtual/libgles2 set to mesa, not vc-graphics-hardfp
vc-graphics PROVIDES virtual/egl but was skipped: PREFERRED_PROVIDER_virtual/libgles2 set to mesa, not vc-graphics

$ bitbake -e userland 2>&1 | tee env.userland
ERROR: Nothing RPROVIDES 'libegl-mesa' (but /jenkins/mjansa/build-ros/ros2-dashing-warrior/meta-raspberrypi/recipes-graphics/userland/userland_git.bb RDEPENDS on or otherwise requires it)
NOTE: Runtime target 'libegl-mesa' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['libegl-mesa']
ERROR: Required build target 'userland' has no buildable providers.
Missing or unbuildable dependency chain was: ['userland', 'libegl-mesa']

$ bitbake -e mesa 2>&1 | tee env.mesa
ERROR: Nothing PROVIDES 'mesa'
mesa was skipped: one of 'vulkan opengl' needs to be in DISTRO_FEATURES

$ bitbake -e vc-graphics-hardfp 2>&1 | tee env.vc-graphics-hardfp
ERROR: Nothing PROVIDES 'vc-graphics-hardfp'
vc-graphics-hardfp was skipped: PREFERRED_PROVIDER_virtual/libgles2 set to mesa, not vc-graphics-hardfp

There is unbuildable dependency on virtual/egl from gstreamer1.0-plugins-base because:
1) gstreamer1.0-plugins-base depends on virtual/egl because of "egl" PACKAGECONFIG

2) "egl" PACKAGECONFIG is enabled by
   meta-raspberrypi/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
   PACKAGECONFIG_GL_rpi = "egl gles2"

   without respecting the "opengl" in DISTRO_FEATURES like the recipe in oe-core does
   openembedded-core/meta/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.14.4.bb:
   PACKAGECONFIG_GL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl', '', d)}"

3) virtual/egl is provided either by:
   - userland (only without vc4graphics in MACHINE_FEATURES):
     meta-raspberrypi/recipes-graphics/userland/userland_git.bb:PROVIDES += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "", "virtual/libgles2 virtual/egl", d)}"
   - mesa (selected with vc4graphics in MACHINE_FEATURES)
     meta-raspberrypi/conf/machine/include/rpi-default-providers.inc:PREFERRED_PROVIDER_virtual/egl ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "mesa", "userland", d)}"
   - vc-graphics(-hardfp)
     meta-raspberrypirecipes-graphics/vc-graphics/vc-graphics.inc:PROVIDES = "virtual/libgles2 virtual/egl"

4) vc-graphics(-hardfp) recipe are skipped in default setup, because with vc4graphics being
   in MACHINE_FEATURES by default since:
   https://github.com/agherzan/meta-raspberrypi/commit/690bdca57422447e49d4ef43862bf675e9acc28f
   the PREFERRED_PROVIDER_virtual/libgles2 is set to mesa in:
   conf/machine/include/rpi-default-providers.inc:PREFERRED_PROVIDER_virtual/libgles2 ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "mesa", "userland", d)}"

   resulting in skipping the other virtual/libgles2 providers:
   vc-graphics-hardfp PROVIDES virtual/egl but was skipped: PREFERRED_PROVIDER_virtual/libgles2 set to mesa, not vc-graphics-hardfp
   vc-graphics PROVIDES virtual/egl but was skipped: PREFERRED_PROVIDER_virtual/libgles2 set to mesa, not vc-graphics

5) mesa is skipped when neither opengl nor vulkan are in DISTRO_FEATURES

6) userland doesn't provide virtual/egl because we have the default vc4graphics
   meta-raspberrypi/recipes-graphics/userland/userland_git.bb:PROVIDES += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "", "virtual/libgles2 virtual/egl", d)}"
   and it cannot be built anyway, because with the default vc4graphics it depends on libegl-mesa:
   meta-raspberrypi/recipes-graphics/userland/userland_git.bb:RDEPENDS_${PN} += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "libegl-mesa", "", d)}"
   and libegl-mesa is provided only by mesa recipe from oe-core which in turn
   requires either "opengl" or "vulkan" to be in DISTRO_FEATURES

This causes a lot of unresolved dependencies in default setup with vc4graphics but without opengl.
- with Yocto 2.6 Thud and older it worked, because vc4graphics wasn't enabled by default before:
  https://github.com/agherzan/meta-raspberrypi/commit/690bdca57422447e49d4ef43862bf675e9acc28f

To build gstreamer1.0-plugins-base with egl PACKAGECONFIG enabled you have 2 options:
A) Just add "opengl" to DISTRO_FEATURES and use the default vc4graphics with mesa providing virtual/egl
B) Use DISABLE_VC4GRAPHICS added in
   https://github.com/agherzan/meta-raspberrypi/commit/96c8459c9363cc6bf463aedf4d24f92a1ee7d6ba
   to explicitly disable vc4graphics and use userland to provide virtual/egl

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
