### PR TITLE
Add support for PiTFT 2.8" with capacitive touch

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -30,6 +30,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/pi3-miniuart-bt.dtbo \
     overlays/pitft22.dtbo \
     overlays/pitft28-resistive.dtbo \
+    overlays/pitft28-capacitive.dtbo \
     overlays/pitft35-resistive.dtbo \
     overlays/pps-gpio.dtbo \
     overlays/rpi-ft5406.dtbo \

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -204,6 +204,7 @@ modelname should be added as a MACHINE_FEATURES in local.conf like below:
 List of currently supported models:
 * pitft22
 * pitft28r
+* pitft28c
 * pitft35r
 
 ## Misc. display

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -20,6 +20,7 @@ INHIBIT_DEFAULT_DEPS = "1"
 PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
 PITFT22="${@bb.utils.contains("MACHINE_FEATURES", "pitft22", "1", "0", d)}"
 PITFT28r="${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "1", "0", d)}"
+PITFT28c="${@bb.utils.contains("MACHINE_FEATURES", "pitft28c", "1", "0", d)}"
 PITFT35r="${@bb.utils.contains("MACHINE_FEATURES", "pitft35r", "1", "0", d)}"
 
 VC4GRAPHICS="${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"
@@ -143,6 +144,11 @@ do_deploy() {
     if [ "${PITFT28r}" = "1" ]; then
         echo "# Enable PITFT28r display" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dtoverlay=pitft28-resistive,rotate=90,speed=32000000,txbuflen=32768" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
+    if [ "${PITFT28c}" = "1" ]; then
+        echo "# Enable PITFT28c display" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "dtoverlay=pitft28-capacitive,rotate=90,speed=32000000,txbuflen=32768" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "dtoverlay=pitft28-capacitive,touch-swapxy,touch-invx" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
     if [ "${PITFT35r}" = "1" ]; then
         echo "# Enable PITFT35r display" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt


### PR DESCRIPTION
Add support for the Adafruit PiTFT Plus 320x240 2.8" TFT with
Capacitive Touchscreen, using the same patterns used for the other
versions of the PiTFT screens.

Signed-off-by: Erik Botö <erik.boto@gmail.com>
