### PR TITLE
pi-bluetooth: Fix signature failures

### DIFF
--- a/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.12.bb
+++ b/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.12.bb
@@ -21,8 +21,6 @@ SYSTEMD_SERVICE_${PN} = "\
     bthelper@.service \
 "
 
-inherit allarch
-
 do_install() {
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${S}/lib/udev/rules.d/* ${D}${sysconfdir}/udev/rules.d


### PR DESCRIPTION
After bc7b654feecceee46bb11800b69994640d03b0ad, we made this package
depend on a package that is not allarch while this is. Let's drop it for
this package as well to avoid these sstate signature issues.

Signed-off-by: Andrei Gherzan <andrei@gherzan.ro>
