### PR TITLE
[RFC] kas-poky-rpi: add kas file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ This layer depends on:
 5. dd to a SD card the generated sdimg file (use xzcat if rpi-sdimg.xz is used)
 6. Boot your RPI.
 
+## Quick Start with kas
+
+1. Install kas build tool from PyPi (sudo pip3 install kas)
+2. kas build meta-raspberrypi/kas-poky-rpi.yml
+3. dd to a SD card the generated sdimg file (use xzcat if rpi-sdimg.xz is used)
+4. Boot your RPI.
+
+To adjust the build configuration with specific options (I2C, SPI, ...), simply add
+a section as follows:
+
+```
+local_conf_header:
+  rpi-specific: |
+    ENABLE_I2C = "1"
+    RPI_EXTRA_CONFIG = "dtoverlay=pi3-disable-bt"
+```
+
+To configure the machine, you have to update the `machine` variable.
+And the same for the `distro`.
+
+For further information, you can read more at <https://kas.readthedocs.io/en/1.0/index.html>
+
 ## Maintainers
 
 * Andrei Gherzan `<andrei at gherzan.ro>`

--- a/kas-poky-rpi.yml
+++ b/kas-poky-rpi.yml
@@ -1,0 +1,58 @@
+header:
+  version: 8
+
+machine: raspberrypi4
+distro: poky
+target:
+  - core-image-base
+
+repos:
+  meta-raspberry:
+
+  poky:
+    url: https://git.yoctoproject.org/git/poky
+    refspec: master
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-openembedded:
+    url: http://git.openembedded.org/meta-openembedded
+    refspec: master
+    layers:
+      meta-oe:
+      meta-python:
+      meta-networking:
+      meta-perl:
+
+  meta-qt5:
+    url: https://github.com/meta-qt5/meta-qt5/
+    refspec: master
+
+bblayers_conf_header:
+  standard: |
+    POKY_BBLAYERS_CONF_VERSION = "2"
+    BBPATH = "${TOPDIR}"
+    BBFILES ?= ""
+local_conf_header:
+  reduce_diskspace: |
+    INHERIT += "rm_work_and_downloads"
+  standard: |
+    CONF_VERSION = "1"
+    PACKAGE_CLASSES = "package_rpm"
+    SDKMACHINE = "x86_64"
+    USER_CLASSES = "buildstats image-mklibs image-prelink"
+    PATCHRESOLVE = "noop"
+  debug-tweaks: |
+    EXTRA_IMAGE_FEATURES = "debug-tweaks"
+  diskmon: |
+    BB_DISKMON_DIRS = "\
+        STOPTASKS,${TMPDIR},1G,100K \
+        STOPTASKS,${DL_DIR},1G,100K \
+        STOPTASKS,${SSTATE_DIR},1G,100K \
+        STOPTASKS,/tmp,100M,100K \
+        ABORT,${TMPDIR},100M,1K \
+        ABORT,${DL_DIR},100M,1K \
+        ABORT,${SSTATE_DIR},100M,1K \
+        ABORT,/tmp,10M,1K"


### PR DESCRIPTION
The kas tool provides an easy mechanism to setup bitbake based projects.

As explained in [1] the key features provided by kas are:

- clone and checkout bitbake layers
- create default bitbake settings (machine, arch, ...)
- launch minimal build environment, reducing risk of host contamination
- initiate bitbake build process

So, let's create a minimal example in this layer to build an image with a
small effort. This seems interesting for new users of the meta-raspberrypi.

For example:

$: sudo pip3 install kas
$: mkdir rpi
$: cd rpi
$: git clone https://github.com/agherzan/meta-raspberrypi.git
$: kas build meta-raspberrypi/kas-rpi.yml

and that's all !

To adjust the construction with specific options (I2C, SPI, ...), simply add
a section as follows:

local_conf_header:
  rpi-specific: |
    ENABLE_I2C = "1"
    RPI_EXTRA_CONFIG = "dtoverlay=pi3-disable-bt"

To configure the machine, the user have to update the 'machine' variable.
And the same for the 'distro'.

[1] - https://kas.readthedocs.io/en/1.0/userguide.html

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>