### PR TITLE
rpi-base.inc: generate wic images by default

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -5,7 +5,7 @@ include conf/machine/include/rpi-default-providers.inc
 SOC_FAMILY = "rpi"
 include conf/machine/include/soc-family.inc
 
-IMAGE_FSTYPES ?= "tar.bz2 ext3 rpi-sdimg"
+IMAGE_FSTYPES ?= "tar.bz2 ext3 wic.bz2 wic.bmap"
 WKS_FILE ?= "sdimage-raspberrypi.wks"
 
 XSERVER = " \


### PR DESCRIPTION
Also enable wic.bmap image generation.

From the documentation in [1], Bmaptool is a generic tool
for creating the block map (bmap) for a file and copying
files using the block map. The idea is that large files,
like raw system image files, can be copied or flashed a
lot faster and more reliably with bmaptool than with
traditional tools, like "dd" or "cp".

Example:

$: sudo bmaptool copy 'image-name'.wic.xz /dev/'your-block-device'

[1] - https://github.com/intel/bmap-tools

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>