### PR TITLE
packagegroup-rpi-test: include bigbuckbunny in RRECOMMENDS_${PN} only…

### DIFF
--- a/recipes-core/packagegroups/packagegroup-rpi-test.bb
+++ b/recipes-core/packagegroups/packagegroup-rpi-test.bb
@@ -23,8 +23,6 @@ RDEPENDS_${PN} = "\
 "
 
 RRECOMMENDS_${PN} = "\
-    bigbuckbunny-1080p \
-    bigbuckbunny-480p \
-    bigbuckbunny-720p \
+    ${@bb.utils.contains("BBFILE_COLLECTIONS", "meta-multimedia", "bigbuckbunny-1080p bigbuckbunny-480p bigbuckbunny-720p", "", d)} \
     ${MACHINE_EXTRA_RRECOMMENDS} \
 "

--- a/recipes-core/packagegroups/packagegroup-rpi-test.bb
+++ b/recipes-core/packagegroups/packagegroup-rpi-test.bb
@@ -2,6 +2,8 @@ DESCRIPTION = "RaspberryPi Test Packagegroup"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 inherit packagegroup
 
 COMPATIBLE_MACHINE = "^rpi$"


### PR DESCRIPTION
… with meta-multimedia

* resolves:
  ERROR: Nothing RPROVIDES 'bigbuckbunny-480p' (but meta-raspberrypi/recipes-core/packagegroups/packagegroup-rpi-test.bb RDEPENDS on or otherwise requires it)
  NOTE: Runtime target 'bigbuckbunny-480p' is unbuildable, removing...
  Missing or unbuildable dependency chain was: ['bigbuckbunny-480p']
  ERROR: Required build target 'meta-world-pkgdata' has no buildable providers.
  Missing or unbuildable dependency chain was: ['meta-world-pkgdata', 'packagegroup-rpi-test', 'bigbuckbunny-480p']

  when building without meta-multimedia layer included

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>