### PR TITLE
gstreamer1.0-plugins-base: Adjust for meson conversion

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,7 +1,9 @@
 EXTRA_OECONF_append_rpi = " CPPFLAGS='-I${STAGING_INCDIR}/interface/vcos/pthreads \
                                    -I${STAGING_INCDIR}/interface/vmcs_host/linux'"
 
+# if using bcm driver enable dispmanx not when using VC4 driver
 PACKAGECONFIG_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' dispmanx', d)}"
+DEPENDS_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' userland', d)}"
 
 PACKAGECONFIG_GL_VC4GRAPHICS = "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl', '', d)}"
 PACKAGECONFIG_GL_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '${PACKAGECONFIG_GL_VC4GRAPHICS}', 'egl gles2', d)}"


### PR DESCRIPTION
OE-core now uses meson to build gstreamer

Signed-off-by: Khem Raj <raj.khem@gmail.com>
