### PR TITLE
linux-raspberrypi: fix perf build with latest binutils

### DIFF
--- a/recipes-kernel/linux/files/0001-perf-Make-perf-able-to-build-with-latest-libbfd.patch
+++ b/recipes-kernel/linux/files/0001-perf-Make-perf-able-to-build-with-latest-libbfd.patch
@@ -1,0 +1,57 @@
+From e66a0be4fac135d67ab228a6fd1453b9e36a3644 Mon Sep 17 00:00:00 2001
+From: Changbin Du <changbin.du@gmail.com>
+Date: Tue, 28 Jan 2020 23:29:38 +0800
+Subject: [PATCH] perf: Make perf able to build with latest libbfd
+
+libbfd has changed the bfd_section_* macros to inline functions
+bfd_section_<field> since 2019-09-18. See below two commits:
+  o http://www.sourceware.org/ml/gdb-cvs/2019-09/msg00064.html
+  o https://www.sourceware.org/ml/gdb-cvs/2019-09/msg00072.html
+
+This fix make perf able to build with both old and new libbfd.
+
+Signed-off-by: Changbin Du <changbin.du@gmail.com>
+Acked-by: Jiri Olsa <jolsa@redhat.com>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Link: http://lore.kernel.org/lkml/20200128152938.31413-1-changbin.du@gmail.com
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/srcline.c | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/srcline.c b/tools/perf/util/srcline.c
+index af3f9b9f1e8b..b8e77617fdc4 100644
+--- a/tools/perf/util/srcline.c
++++ b/tools/perf/util/srcline.c
+@@ -191,16 +191,30 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data)
+ 	bfd_vma pc, vma;
+ 	bfd_size_type size;
+ 	struct a2l_data *a2l = data;
++	flagword flags;
+ 
+ 	if (a2l->found)
+ 		return;
+ 
+-	if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0)
++#ifdef bfd_get_section_flags
++	flags = bfd_get_section_flags(abfd, section);
++#else
++	flags = bfd_section_flags(section);
++#endif
++	if ((flags & SEC_ALLOC) == 0)
+ 		return;
+ 
+ 	pc = a2l->addr;
++#ifdef bfd_get_section_vma
+ 	vma = bfd_get_section_vma(abfd, section);
++#else
++	vma = bfd_section_vma(section);
++#endif
++#ifdef bfd_get_section_size
+ 	size = bfd_get_section_size(section);
++#else
++	size = bfd_section_size(section);
++#endif
+ 
+ 	if (pc < vma || pc >= vma + size)
+ 		return;

--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -4,3 +4,5 @@ LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 SRCREV = "e645cec69367ba4b6daf63933f48661ab4b59ee1"
 
 require linux-raspberrypi_4.19.inc
+
+SRC_URI += "file://0001-perf-Make-perf-able-to-build-with-latest-libbfd.patch"


### PR DESCRIPTION
* fixes:
|   LINK     /OE/build/oe-core/tmp-glibc/work/raspberrypi4-oe-linux-gnueabi/perf/1.0-r9/perf-1.0/perf
| /OE/build/oe-core/tmp-glibc/work/raspberrypi4-oe-linux-gnueabi/perf/1.0-r9/perf-1.0/libperf.a(libperf-in.o):srcline.c:function find_address_in_section: error: undefined reference to 'bfd_get_section_flags'
| /OE/build/oe-core/tmp-glibc/work/raspberrypi4-oe-linux-gnueabi/perf/1.0-r9/perf-1.0/libperf.a(libperf-in.o):srcline.c:function find_address_in_section: error: undefined reference to 'bfd_get_section_vma'
| /OE/build/oe-core/tmp-glibc/work/raspberrypi4-oe-linux-gnueabi/perf/1.0-r9/perf-1.0/libperf.a(libperf-in.o):srcline.c:function find_address_in_section: error: undefined reference to 'bfd_get_section_size'
| collect2: error: ld returned 1 exit status
| make[2]: *** [Makefile.perf:519: /OE/build/oe-core/tmp-glibc/work/raspberrypi4-oe-linux-gnueabi/perf/1.0-r9/perf-1.0/perf] Error 1
| make[1]: *** [Makefile.perf:206: sub-make] Error 2
| make: *** [Makefile:70: all] Error 2
| make: Leaving directory '/OE/build/oe-core/tmp-glibc/work/raspberrypi4-oe-linux-gnueabi/perf/1.0-r9/perf-1.0/tools/perf'
| WARNING: exit code 1 from a shell command.

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>