### PR TITLE
RPI CONFIG: Disable UART fix

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -228,9 +228,15 @@ RaspberryPi 0 Wifi or 3 will have to explicitly set in local.conf:
 
     ENABLE_UART = "1"
 
+Users who don't want the serial console support at all should explicitly
+disable the UART in local.conf. This permit to use it for something else:
+
+    ENABLE_UART = "0"
+
 Ref.:
 * <https://github.com/raspberrypi/firmware/issues/553>
 * <https://github.com/RPi-Distro/repo/issues/22>
+* <https://github.com/agherzan/meta-raspberrypi/issues/567>
 
 ## Enable USB Peripheral (Gadget) support
 

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -159,6 +159,9 @@ do_deploy() {
     if [ "${ENABLE_UART}" = "1" ]; then
         echo "# Enable UART" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "enable_uart=1" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    elif [ "${ENABLE_UART}" = "0" ]; then
+        echo "# Disable UART" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "enable_uart=0" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
     # VC4 Graphics support


### PR DESCRIPTION
Re-push of #568 

**- What I did**

Explicitly set "enable_uart=0" when the console is disabled.

**- How I did it**

Modify rpi-config recipe.