### PR TITLE
linux-raspberry: bump to Linux version 4.19.108

### DIFF
--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,10 +1,10 @@
-RPIFW_DATE ?= "20200220"
-SRCREV ?= "02bff4e75712094ffb1ab2ec58a8115ca3e52290"
+RPIFW_DATE ?= "20200306"
+SRCREV ?= "163d84cbeb7038a4fd71d817eae43a535eb3df62"
 RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[md5sum] = "0ff79476623af1182f6ddc4baeb7d2ed"
-SRC_URI[sha256sum] = "08188344f592aecfa611a268b89762f7e48d08b1242185cb2627bb28e59d5f1a"
+SRC_URI[md5sum] = "8be0bd27fc4f31ecb0a9b48d8f27f933"
+SRC_URI[sha256sum] = "4a62e6d37598300a42fc9c9f6b554e08f3ea825695e429f7f3674d4afc0d5803"
 
 PV = "${RPIFW_DATE}"

--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -1,7 +1,7 @@
-LINUX_VERSION ?= "4.19.105"
+LINUX_VERSION ?= "4.19.108"
 LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 
-SRCREV = "e645cec69367ba4b6daf63933f48661ab4b59ee1"
+SRCREV = "2fab54c74bf956951e61c6d4fe473995e8d07010"
 
 require linux-raspberrypi_4.19.inc
 


### PR DESCRIPTION
Tested on rpi3:

```
root@raspberrypi3:~# uname -a
Linux raspberrypi3 4.19.108-v7 #1 SMP Fri Mar 6 17:51:28 UTC 2020 armv7l GNU/Linux
```