### PR TITLE
gstreamer: Fix the compilation issue in meta multimedia image

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,1 +1,2 @@
-PACKAGECONFIG_append_rpi = " hls libmms faad"
+PACKAGECONFIG_append_rpi = " hls libmms \
+                   ${@bb.utils.contains('LICENSE_FLAGS_WHITELIST', 'commercial', 'faad', '', d)}"


### PR DESCRIPTION
When we tried to build the meta-multimedia-image, we faced the
compilation issue with faad component.

Since faad component has commercial license, we could not able
to build with multimedia image. So we have modified the faad
component to be included when commercial licenese is supported.

Signed-off-by: Madhavan Krishnan <madhavan.krishnan@linaro.org>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
