### PR TITLE
oeqa: Add rpi specific kernel dmesg parser

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -32,3 +32,6 @@ BBFILES_DYNAMIC += " \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bb \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bbappend \
 "
+
+DEFAULT_TEST_SUITES_remove_rpi = "parselogs"
+DEFAULT_TEST_SUITES_append_rpi = " parselogs_rpi"

--- a/lib/oeqa/runtime/cases/parselogs_rpi.py
+++ b/lib/oeqa/runtime/cases/parselogs_rpi.py
@@ -1,0 +1,15 @@
+from oeqa.runtime.cases.parselogs import *
+
+rpi_errors = [
+    'bcmgenet fd580000.genet: failed to get enet-eee clock',
+    'bcmgenet fd580000.genet: failed to get enet-wol clock',
+    'bcmgenet fd580000.genet: failed to get enet clock',
+]
+
+ignore_errors['raspberrypi4'] = rpi_errors + common_errors
+ignore_errors['raspberrypi4-64'] = rpi_errors + common_errors
+ignore_errors['raspberrypi3'] = rpi_errors + common_errors
+ignore_errors['raspberrypi3-64'] = rpi_errors + common_errors
+
+class ParseLogsTestRpi(ParseLogsTest):
+    pass


### PR DESCRIPTION
These errors are harmless on rpi3/rpi4 [1]

[1] https://github.com/raspberrypi/linux/issues/3195

Signed-off-by: Khem Raj <raj.khem@gmail.com>


