### PR TITLE
qtbase: Append userland to rdeps iff vc4graphics is not enabled

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -15,5 +15,5 @@ do_configure_prepend_rpi() {
         echo "EGLFS_DEVICE_INTEGRATION = ${OE_QTBASE_EGLFS_DEVICE_INTEGRATION}" >> ${S}/mkspecs/oe-device-extra.pri
     fi
 }
-RDEPENDS_${PN}_append_rpi = " userland"
+RDEPENDS_${PN}_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' userland', d)}"
 DEPENDS_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' userland', d)}"


### PR DESCRIPTION
This avoids adding unnessary dependency at runtime on userland graphics
package when vc4 driver is used

Signed-off-by: Khem Raj <raj.khem@gmail.com>
