### PR TITLE
rpi-u-boot-scr: Set u-boot-default-script as provider

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -58,7 +58,7 @@ do_image_rpi_sdimg[depends] = " \
     rpi-config:do_deploy \
     ${@bb.utils.contains('MACHINE_FEATURES', 'armstub', 'armstubs:do_deploy', '' ,d)} \
     ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
-    ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'rpi-u-boot-scr:do_deploy', '',d)} \
+    ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot-default-script:do_deploy', '',d)} \
 "
 
 do_image_rpi_sdimg[recrdeps] = "do_build"

--- a/conf/machine/include/rpi-default-providers.inc
+++ b/conf/machine/include/rpi-default-providers.inc
@@ -11,3 +11,5 @@ PREFERRED_PROVIDER_jpeg ?= "jpeg"
 
 PREFERRED_PROVIDER_virtual/libomxil ?= "userland"
 VIRTUAL-RUNTIME_libomxil = "userland"
+
+PREFERRED_PROVIDER_u-boot-default-script ??= "rpi-u-boot-scr"

--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -24,3 +24,5 @@ do_deploy() {
 }
 
 addtask do_deploy after do_compile before do_build
+
+PROVIDES += "u-boot-default-script"

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,1 +1,1 @@
-DEPENDS_append_rpi = " rpi-u-boot-scr"
+DEPENDS_append_rpi = " u-boot-default-script"


### PR DESCRIPTION
Add u-boot-default-script to the PROVIDES variable to make easier to
replace boot script in another layer just by changing
PREFERRED_PROVIDER_u-boot-default-script variable. Set rpi-u-boot-scr as
the default provider for meta-raspberrypi.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>