### PR TITLE
docs/extra-build-config.md: Auto-load I2C modules

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -184,6 +184,10 @@ When using device tree kernels, set this variable to enable I2C:
 
     ENABLE_I2C = "1"
 
+Furthermore, to auto-load I2C kernel modules set:
+
+    KERNEL_MODULE_AUTOLOAD_rpi += "i2c-dev i2c-bcm2708"
+
 ## Enable PiTFT support
 
 Basic support for using PiTFT screens can be enabled by adding below in


### PR DESCRIPTION
Add instructions how to auto-load I2C kernel modules with
KERNEL_MODULE_AUTOLOAD when I2C is enabled.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Updated the documentation and added instructions how to auto-load I2C kernel modules when I2C is enabled.

**- How I did it**

By default, even when I2C is enabled with `ENABLE_I2C="1"`, related kernel modules `i2c-dev` and `i2c-bcm2708` are not automatically loaded. In many cases developers prefer to have they automatically loaded and this can be achieved with the following additional settings:

```
KERNEL_MODULE_AUTOLOAD_rpi += "i2c-dev i2c-bcm2708"
```

I have added the example to the documentation. Although I am aware about this detail, I often forget to set `KERNEL_MODULE_AUTOLOAD`. Probably others are having the same issue. By having the example in the documents using I2C will be easier and straight-forward.

Best regards,
Leon
