### PR TITLE
Add 5.4 kernel recipe

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -28,8 +28,6 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/iqaudio-dacplus.dtbo \
     overlays/miniuart-bt.dtbo \
     overlays/mcp2515-can0.dtbo \
-    overlays/pi3-disable-bt.dtbo \
-    overlays/pi3-miniuart-bt.dtbo \
     overlays/pitft22.dtbo \
     overlays/pitft28-resistive.dtbo \
     overlays/pitft28-capacitive.dtbo \

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -1,0 +1,6 @@
+LINUX_VERSION ?= "5.4.29"
+LINUX_RPI_BRANCH ?= "rpi-5.4.y"
+
+SRCREV = "dc11cb9f890197f976033255e09023c28c988b76"
+
+require linux-raspberrypi_5.4.inc

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.inc
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.inc
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
+
+SRC_URI = " \
+    git://github.com/raspberrypi/linux.git;branch=${LINUX_RPI_BRANCH} \
+    "
+SRC_URI_remove = "file://rpi-kernel-misc.cfg"
+
+require linux-raspberrypi.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+
+KERNEL_EXTRA_ARGS_append_rpi = " DTC_FLAGS='-@ -H epapr'"


### PR DESCRIPTION
This is next LTS that linux-raspberrypi is going to support. see [this](https://github.com/raspberrypi/linux/issues/3525)
