### PR TITLE
RFC: raspberrypi3: Switch to vc4-fkms-v3d.

### DIFF
--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -31,4 +31,5 @@ KERNEL_IMAGETYPE_UBOOT ?= "Image"
 KERNEL_IMAGETYPE_DIRECT ?= "Image"
 KERNEL_BOOTCMD ?= "booti"
 
+VC4DTBO ?= "vc4-fkms-v3d"
 ARMSTUB ?= "armstub8.bin"

--- a/conf/machine/raspberrypi3.conf
+++ b/conf/machine/raspberrypi3.conf
@@ -17,4 +17,5 @@ SDIMG_KERNELIMAGE ?= "kernel7.img"
 UBOOT_MACHINE = "rpi_3_32b_config"
 SERIAL_CONSOLES ?= "115200;ttyS0"
 
+VC4DTBO ?= "vc4-fkms-v3d"
 ARMSTUB ?= "armstub7.bin"


### PR DESCRIPTION
This seems to be required to have a functional DSI display.

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Troubleshooting of blank Xorg display using the Pi Foundation display.

**- How I did it**

After changing this, core-image-sato works on both HDMI and the DSI display.