### PR TITLE
rpi-base.inc: Include modules if I2C is enaled

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -76,7 +76,7 @@ MACHINE_FEATURES += "apm usbhost keyboard vfat ext2 screen touchscreen alsa blue
 # Raspberry Pi has no hardware clock
 MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
 
-MACHINE_EXTRA_RRECOMMENDS += " kernel-modules udev-rules-rpi"
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " kernel-modules udev-rules-rpi"
 
 # Set Raspberrypi splash image
 SPLASH = "psplash-raspberrypi"


### PR DESCRIPTION
Add kernel modules i2c-dev and i2c-bcm2708 to variable
MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS if ENABLE_I2C is set to 1.
This affects images based on packagegroup-core-boot, including
the core-image-minimal image.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

The patch ensures that kernel modules` i2c-dev` and `i2c-bcm2708` are included in `core-image-minimal` if ENABLE_I2C is set to 1. This fix is for all images based on `packagegroup-core-boot`, including the `core-image-minimal` image which otherwise doesn't include`kernel-modules` because they are set in variable `MACHINE_EXTRA_RRECOMMENDS` which does **not** have effect for `core-image-minimal`. The patch improves the developer experience while working on `core-image-minimal` with I2C support.

**- How I did it**

I added Linux kernel modules `i2c-dev` and `i2c-bcm2708` to variable `MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS` if I2C is enabled, aka if variable `ENABLE_I2C` is set to 1. This affects images based on `packagegroup-core-boot`, including the `core-image-minimal image`.

Best regards, Leon