### PR TITLE
linux-raspberrypi_5.4.bb: Backport the patch to use CHECK macro inste…

### DIFF
--- a/recipes-kernel/linux/files/0001-Revert-selftests-bpf-Skip-perf-hw-events-test-if-the.patch
+++ b/recipes-kernel/linux/files/0001-Revert-selftests-bpf-Skip-perf-hw-events-test-if-the.patch
@@ -1,0 +1,33 @@
+From a7783676c60dd90a6f4c26bcb9be03dc5703b74e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Apr 2020 11:25:32 -0700
+Subject: [PATCH 1/2] Revert "selftests/bpf: Skip perf hw events test if the
+ setup disabled it"
+
+This reverts commit da43712a7262891317883d4b3a909fb18dac4b1d.
+---
+ .../selftests/bpf/prog_tests/stacktrace_build_id_nmi.c    | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/tools/testing/selftests/bpf/prog_tests/stacktrace_build_id_nmi.c b/tools/testing/selftests/bpf/prog_tests/stacktrace_build_id_nmi.c
+index 1735faf17536..f62aa0eb959b 100644
+--- a/tools/testing/selftests/bpf/prog_tests/stacktrace_build_id_nmi.c
++++ b/tools/testing/selftests/bpf/prog_tests/stacktrace_build_id_nmi.c
+@@ -49,12 +49,8 @@ void test_stacktrace_build_id_nmi(void)
+ 	pmu_fd = syscall(__NR_perf_event_open, &attr, -1 /* pid */,
+ 			 0 /* cpu 0 */, -1 /* group id */,
+ 			 0 /* flags */);
+-	if (pmu_fd < 0 && errno == ENOENT) {
+-		printf("%s:SKIP:no PERF_COUNT_HW_CPU_CYCLES\n", __func__);
+-		test__skip();
+-		goto cleanup;
+-	}
+-	if (CHECK(pmu_fd < 0, "perf_event_open", "err %d errno %d\n",
++	if (CHECK(pmu_fd < 0, "perf_event_open",
++		  "err %d errno %d. Does the test host support PERF_COUNT_HW_CPU_CYCLES?\n",
+ 		  pmu_fd, errno))
+ 		goto close_prog;
+ 
+-- 
+2.26.0
+

--- a/recipes-kernel/linux/files/0001-selftest-bpf-Use-CHECK-macro-instead-of-RET_IF.patch
+++ b/recipes-kernel/linux/files/0001-selftest-bpf-Use-CHECK-macro-instead-of-RET_IF.patch
@@ -1,7 +1,7 @@
-From 552084d4da41833a97d19d12f5ee5c3ba02e400a Mon Sep 17 00:00:00 2001
+From 4cd12df48b83cef9cc7d6b80b128afbf68746718 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Sat, 14 Mar 2020 07:31:34 -0700
-Subject: [PATCH V2] selftest/bpf: Use CHECK macro instead of RET_IF
+Subject: [PATCH] selftest/bpf: Use CHECK macro instead of RET_IF
 
 backporting 634efb750435d0a489dc58477d4fcb88b2692942 causes build
 failures because RET_IF is defined in 7ee0d4e97b889c0478af9c1a6e5af658b181423f
@@ -11,36 +11,30 @@ Upstream-Status: Submitted
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 Cc: Jakub Sitnicki <jakub@cloudflare.com>
 Cc: Alexei Starovoitov <ast@kernel.org>
+Signed-off-by: Bruce Ashfield <bruce.ashfield@gmail.com>
 ---
-v2: Add return on check to get complete logic of RET_IF
-
- tools/testing/selftests/bpf/test_select_reuseport.c | 10 ++++++----
- 1 file changed, 6 insertions(+), 4 deletions(-)
+ tools/testing/selftests/bpf/test_select_reuseport.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/tools/testing/selftests/bpf/test_select_reuseport.c b/tools/testing/selftests/bpf/test_select_reuseport.c
-index cdbbdab2725f..093ef8547abb 100644
+index 079d0f5a2909..7e4c91f2238d 100644
 --- a/tools/testing/selftests/bpf/test_select_reuseport.c
 +++ b/tools/testing/selftests/bpf/test_select_reuseport.c
-@@ -616,13 +616,15 @@ static void cleanup_per_test(void)
+@@ -668,12 +668,12 @@ static void cleanup_per_test(void)
  
  	for (i = 0; i < NR_RESULTS; i++) {
  		err = bpf_map_update_elem(result_map, &i, &zero, BPF_ANY);
 -		RET_IF(err, "reset elem in result_map",
--		       "i:%u err:%d errno:%d\n", i, err, errno);
-+		if (CHECK(err, "reset elem in result_map",
-+		       "i:%u err:%d errno:%d\n", i, err, errno))
-+			return;
++		CHECK(err, "reset elem in result_map",
+ 		       "i:%u err:%d errno:%d\n", i, err, errno);
  	}
  
  	err = bpf_map_update_elem(linum_map, &zero, &zero, BPF_ANY);
 -	RET_IF(err, "reset line number in linum_map", "err:%d errno:%d\n",
--	       err, errno);
-+	if (CHECK(err, "reset line number in linum_map", "err:%d errno:%d\n",
-+	       err, errno))
-+		return;
++	CHECK(err, "reset line number in linum_map", "err:%d errno:%d\n",
+ 	       err, errno);
  
  	for (i = 0; i < REUSEPORT_ARRAY_SIZE; i++)
- 		close(sk_fds[i]);
 -- 
-2.25.1
+2.26.0
 

--- a/recipes-kernel/linux/files/0002-Revert-selftests-bpf-Fix-perf_buffer-test-on-systems.patch
+++ b/recipes-kernel/linux/files/0002-Revert-selftests-bpf-Fix-perf_buffer-test-on-systems.patch
@@ -1,0 +1,94 @@
+From 366487b86a8c87954fb4ab7bd88ab49a929a32f6 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Apr 2020 11:25:58 -0700
+Subject: [PATCH 2/2] Revert "selftests/bpf: Fix perf_buffer test on systems w/
+ offline CPUs"
+
+This reverts commit 77bb53cb094828a31cd3c5b402899810f63073c1.
+---
+ .../selftests/bpf/prog_tests/perf_buffer.c    | 29 ++++---------------
+ 1 file changed, 5 insertions(+), 24 deletions(-)
+
+diff --git a/tools/testing/selftests/bpf/prog_tests/perf_buffer.c b/tools/testing/selftests/bpf/prog_tests/perf_buffer.c
+index cf6c87936c69..3003fddc0613 100644
+--- a/tools/testing/selftests/bpf/prog_tests/perf_buffer.c
++++ b/tools/testing/selftests/bpf/prog_tests/perf_buffer.c
+@@ -4,7 +4,6 @@
+ #include <sched.h>
+ #include <sys/socket.h>
+ #include <test_progs.h>
+-#include "libbpf_internal.h"
+ 
+ static void on_sample(void *ctx, int cpu, void *data, __u32 size)
+ {
+@@ -20,7 +19,7 @@ static void on_sample(void *ctx, int cpu, void *data, __u32 size)
+ 
+ void test_perf_buffer(void)
+ {
+-	int err, prog_fd, on_len, nr_on_cpus = 0,  nr_cpus, i, duration = 0;
++	int err, prog_fd, nr_cpus, i, duration = 0;
+ 	const char *prog_name = "kprobe/sys_nanosleep";
+ 	const char *file = "./test_perf_buffer.o";
+ 	struct perf_buffer_opts pb_opts = {};
+@@ -30,27 +29,15 @@ void test_perf_buffer(void)
+ 	struct bpf_object *obj;
+ 	struct perf_buffer *pb;
+ 	struct bpf_link *link;
+-	bool *online;
+ 
+ 	nr_cpus = libbpf_num_possible_cpus();
+ 	if (CHECK(nr_cpus < 0, "nr_cpus", "err %d\n", nr_cpus))
+ 		return;
+ 
+-	err = parse_cpu_mask_file("/sys/devices/system/cpu/online",
+-				  &online, &on_len);
+-	if (CHECK(err, "nr_on_cpus", "err %d\n", err))
+-		return;
+-
+-	for (i = 0; i < on_len; i++)
+-		if (online[i])
+-			nr_on_cpus++;
+-
+ 	/* load program */
+ 	err = bpf_prog_load(file, BPF_PROG_TYPE_KPROBE, &obj, &prog_fd);
+-	if (CHECK(err, "obj_load", "err %d errno %d\n", err, errno)) {
+-		obj = NULL;
+-		goto out_close;
+-	}
++	if (CHECK(err, "obj_load", "err %d errno %d\n", err, errno))
++		return;
+ 
+ 	prog = bpf_object__find_program_by_title(obj, prog_name);
+ 	if (CHECK(!prog, "find_probe", "prog '%s' not found\n", prog_name))
+@@ -77,11 +64,6 @@ void test_perf_buffer(void)
+ 	/* trigger kprobe on every CPU */
+ 	CPU_ZERO(&cpu_seen);
+ 	for (i = 0; i < nr_cpus; i++) {
+-		if (i >= on_len || !online[i]) {
+-			printf("skipping offline CPU #%d\n", i);
+-			continue;
+-		}
+-
+ 		CPU_ZERO(&cpu_set);
+ 		CPU_SET(i, &cpu_set);
+ 
+@@ -99,8 +81,8 @@ void test_perf_buffer(void)
+ 	if (CHECK(err < 0, "perf_buffer__poll", "err %d\n", err))
+ 		goto out_free_pb;
+ 
+-	if (CHECK(CPU_COUNT(&cpu_seen) != nr_on_cpus, "seen_cpu_cnt",
+-		  "expect %d, seen %d\n", nr_on_cpus, CPU_COUNT(&cpu_seen)))
++	if (CHECK(CPU_COUNT(&cpu_seen) != nr_cpus, "seen_cpu_cnt",
++		  "expect %d, seen %d\n", nr_cpus, CPU_COUNT(&cpu_seen)))
+ 		goto out_free_pb;
+ 
+ out_free_pb:
+@@ -109,5 +91,4 @@ void test_perf_buffer(void)
+ 	bpf_link__destroy(link);
+ out_close:
+ 	bpf_object__close(obj);
+-	free(online);
+ }
+-- 
+2.26.0
+

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -6,5 +6,8 @@ SRCREV = "5c08b6e79a8bfa1e59bb0004a1c94ed902a6d615"
 require linux-raspberrypi_5.4.inc
 
 SRC_URI += "file://0001-perf-Make-perf-able-to-build-with-latest-libbfd.patch \
+            file://0001-Revert-selftests-bpf-Skip-perf-hw-events-test-if-the.patch \
+            file://0002-Revert-selftests-bpf-Fix-perf_buffer-test-on-systems.patch \
+            file://0001-selftest-bpf-Use-CHECK-macro-instead-of-RET_IF.patch \
             file://powersave.cfg \
            "


### PR DESCRIPTION
…ad of RET_IF

Fixes

| /usr/src/debug/kernel-selftest/1.0-r0/kernel-selftest-1.0/tools/testing/selftests/bpf/test_select_reuseport.c:671: undefined reference to `RET_IF'

Signed-off-by: Khem Raj <raj.khem@gmail.com>
