### PR TITLE
psplash: Do not define ALTERNATIVE_PRIORITY for non-existing provider

### DIFF
--- a/recipes-core/psplash/psplash_%.bbappend
+++ b/recipes-core/psplash/psplash_%.bbappend
@@ -1,3 +1,2 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SPLASH_IMAGES_append_rpi = " file://psplash-raspberrypi-img.h;outsuffix=raspberrypi"
-ALTERNATIVE_PRIORITY_psplash-raspberrypi[psplash] = "200"
+SPLASH_IMAGES_rpi = "file://psplash-raspberrypi-img.h;outsuffix=raspberrypi"


### PR DESCRIPTION
This simply causes build warnings about priority of two packages being
same, but infact this is redundant, therefore remove setting ALTERNATIVE_PRIORITY
for psplash-raspberrypi

Signed-off-by: Khem Raj <raj.khem@gmail.com>
