### PR TITLE
rpi-base.inc: Add infrared dtbo

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -39,6 +39,8 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/vc4-fkms-v3d.dtbo \
     overlays/w1-gpio-pullup.dtbo \
     overlays/w1-gpio.dtbo \
+    overlays/gpio-ir.dtbo \
+    overlays/gpio-ir-tx.dtbo \
     "
 
 RPI_KERNEL_DEVICETREE ?= " \


### PR DESCRIPTION
Add device tree binary overlays gpio-ir-tx and gpio-ir-tx to
support peripherals for sending and receiving infrared signals.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Included gpio-ir-tx and gpio-ir-tx dtbo which are required for peripherals for sending and receiving infrared signals (for example using LIRC).

**- How I did it**

By adding gpio-ir-tx and gpio-ir-tx dtbo to variable `RPI_KERNEL_DEVICETREE_OVERLAYS`.

In the mean time I have submitted a patch to the upstream of meta-oe for upgrading LIRC to version 0.10.1. If it is approved I will carry on with LIRC bbappend file specific for Raspberry Pi.

Best regards, Leon
