### PR TITLE
Bump/kernel

### DIFF
--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,10 +1,10 @@
-RPIFW_DATE ?= "20200417"
-SRCREV ?= "84523e0b9a9e78aa69fca1f1a8d75b2bdb5155fc"
+RPIFW_DATE ?= "20200504"
+SRCREV ?= "7eff9f6774bb43bfd61e749a0b45ffddc98c2311"
 RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[md5sum] = "657e10e0e9f12ad03a91ff0cd28ac628"
-SRC_URI[sha256sum] = "93986d256d2791c3d151e01d12176f470ec085c93a32e0c85d7cec51bd4319c1"
+SRC_URI[md5sum] = "05cd161dca5a6f02684794960913e04c"
+SRC_URI[sha256sum] = "77ad450dd7cabb58ca04a18fd704844df6e642374346cf006a07edca46615af1"
 
 PV = "${RPIFW_DATE}"

--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -1,7 +1,7 @@
-LINUX_VERSION ?= "4.19.115"
+LINUX_VERSION ?= "4.19.120"
 LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 
-SRCREV = "b13fc60b529fe9e4fee4a7a5caf73d582003abfa"
+SRCREV = "9da67d7329873623bd5c13fae5835d76d5be8806"
 
 require linux-raspberrypi_4.19.inc
 


### PR DESCRIPTION
Tested on rpi3 with U-Boot enabled:

```
starting USB...
Bus usb@7e980000: scanning bus usb@7e980000 for devices... 3 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:  0 
switch to partitions #0, OK
mmc0 is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
213 bytes read in 1 ms (208 KiB/s)
## Executing script at 02400000
5433536 bytes read in 227 ms (22.8 MiB/s)
## Booting kernel from Legacy Image at 00080000 ...
   Image Name:   Linux-4.19.120-v7
   Image Type:   ARM Linux Kernel Image (uncompressed)
   Data Size:    5433472 Bytes = 5.2 MiB
   Load Address: 00008000
   Entry Point:  00008000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 2eff9400
   Booting using the fdt blob at 0x2eff9400
   Loading Kernel Image
   Using Device Tree in place at 2eff9400, end 2f002f7a

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0
```
