### PR TITLE
docs: Correct Quick Start instructions to show the new .wic.bz2 extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ This layer depends on:
 2. Add this layer to bblayers.conf and the dependencies above
 3. Set MACHINE in local.conf to one of the supported boards
 4. bitbake core-image-base
-5. Use bmaptool to copy the generated .wic.bz2 file to the SD card (use xzcat if rpi-sdimg.xz is used)
+5. Use bmaptool to copy the generated .wic.bz2 file to the SD card
 6. Boot your RPI
 
 ## Quick Start with kas
 
 1. Install kas build tool from PyPi (sudo pip3 install kas)
 2. kas build meta-raspberrypi/kas-poky-rpi.yml
-3. Use bmaptool to copy the generated .wic.bz2 file to the SD card (use xzcat if rpi-sdimg.xz is used)
+3. Use bmaptool to copy the generated .wic.bz2 file to the SD card
 4. Boot your RPI
 
 To adjust the build configuration with specific options (I2C, SPI, ...), simply add

--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ This layer depends on:
 2. Add this layer to bblayers.conf and the dependencies above
 3. Set MACHINE in local.conf to one of the supported boards
 4. bitbake core-image-base
-5. dd to a SD card the generated sdimg file (use xzcat if rpi-sdimg.xz is used)
-6. Boot your RPI.
+5. Use bmaptool to copy the generated .wic.bz2 file to the SD card (use xzcat if rpi-sdimg.xz is used)
+6. Boot your RPI
 
 ## Quick Start with kas
 
 1. Install kas build tool from PyPi (sudo pip3 install kas)
 2. kas build meta-raspberrypi/kas-poky-rpi.yml
-3. dd to a SD card the generated sdimg file (use xzcat if rpi-sdimg.xz is used)
-4. Boot your RPI.
+3. Use bmaptool to copy the generated .wic.bz2 file to the SD card (use xzcat if rpi-sdimg.xz is used)
+4. Boot your RPI
 
 To adjust the build configuration with specific options (I2C, SPI, ...), simply add
 a section as follows:


### PR DESCRIPTION
Fixes incorrect Quick Start documentation, which previously suggested to dd an sdimg to the SD card rather than using bmaptool to copy the .wic.bz2 file. See #637.

I have left in the tip about using xzcat if an .xz is used, I can fix this up if this advice is also no longer valid.