### PR TITLE
vc4 support on morty branch

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -42,7 +42,7 @@ KERNEL_DEVICETREE ?= " \
     "
 KERNEL_IMAGETYPE ?= "Image"
 
-MACHINE_FEATURES += "apm usbhost keyboard vfat ext2 screen touchscreen alsa bluetooth wifi sdio"
+MACHINE_FEATURES += "apm usbhost keyboard vfat ext2 screen touchscreen alsa bluetooth wifi sdio ${@bb.utils.contains('DISABLE_VC4GRAPHICS', '1', '', 'vc4graphics', d)}"
 
 # Raspberry Pi has no hardware clock
 MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -7,10 +7,9 @@ LIC_FILES_CHKSUM = "file://LICENCE;md5=0448d6488ef8cc380632b1569ee6d196"
 
 PR = "r5"
 
-PROVIDES = "virtual/libgles2 \
-            virtual/egl"
+PROVIDES = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'virtual/libgles2 virtual/egl', d)}"
 
-RPROVIDES_${PN} += "libgles2 libgl"
+RPROVIDES_${PN} += "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'libgles2 egl', d)}"
 
 COMPATIBLE_MACHINE = "raspberrypi"
 
@@ -58,6 +57,14 @@ do_install_append () {
 		sed -i 's/include "vcos_futex_mutex.h"/include "pthreads\/vcos_futex_mutex.h"/g' ${f}
 		sed -i 's/include "vcos_platform_types.h"/include "pthreads\/vcos_platform_types.h"/g' ${f}
 	done
+        if [ "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}" = "1" ]; then
+                rm -rf ${D}${libdir}/libEGL*
+                rm -rf ${D}${libdir}/libGLES*
+                rm -rf ${D}${libdir}/libwayland-*
+                rm -rf ${D}${libdir}/pkgconfig/egl.pc ${D}${libdir}/pkgconfig/glesv2.pc \
+                        ${D}${libdir}/pkgconfig/wayland-egl.pc
+                rm -rf ${D}${includedir}/EGL ${D}${includedir}/GLES* ${D}${includedir}/KHR
+        fi
 }
 
 # Shared libs from userland package  build aren't versioned, so we need
@@ -77,3 +84,4 @@ FILES_${PN}-dbg += "${libdir}/plugins/.debug"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 RDEPENDS_${PN} += "bash"
+RDEPENDS_${PN} += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "libegl-mesa", "", d)}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -3,7 +3,9 @@ EXTRA_OECONF_append_rpi = " CPPFLAGS='-I${STAGING_INCDIR}/interface/vcos/pthread
 
 # if using bcm driver enable dispmanx not when using VC4 driver
 
-PACKAGECONFIG_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' dispmanx', d)}"
+PACKAGECONFIG_append_rpi = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', \
+                                    bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d), \
+                                    'dispmanx', d)}"
 
 PACKAGECONFIG_GL_rpi = "egl gles2"
 


### PR DESCRIPTION
Enabling vc4graphics support on morty branch

**- What I did**
To bring vc4graphics enabled RPI image from morty branch, remaining changes to enable vc4graphics are notified and applied.

**- How I did it**
Userland required some more changes in EGL provider's changes between userland and mesa. This is notified and applied.