### PR TITLE
Update runtime dependency from -imaging to -pillow

### DIFF
--- a/recipes-devtools/python/python3-sense-hat_2.2.0.bb
+++ b/recipes-devtools/python/python3-sense-hat_2.2.0.bb
@@ -20,5 +20,5 @@ DEPENDS += " \
 RDEPENDS_${PN} += " \
     ${PYTHON_PN}-numpy \
     ${PYTHON_PN}-rtimu \
-    ${PYTHON_PN}-imaging \
+    ${PYTHON_PN}-pillow \
     "


### PR DESCRIPTION

bitbake world will fail with ERROR: Nothing RPROVIDES 'python3-imaging' . 

Replace with python3-pillow .

