### PR TITLE
 conf/layer.conf: Add LAYERDEPENDS_raspberrypi 

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,6 +10,7 @@ BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
 LAYERSERIES_COMPAT_raspberrypi = "sumo thud warrior zeus dunfell"
+LAYERDEPENDS_raspberrypi = "core meta-python"
 
 # Additional license directories.
 LICENSE_PATH += "${LAYERDIR}/files/custom-licenses"


### PR DESCRIPTION
To allow the command
  bitbake-layers layerindex-fetch meta-raspberrypi

to work out, we need to declare the dependencies.
Use the same dependencies as declared in kas-poky-rpi.yaml .

Question is if we add the multimedia layer as well
(as mentioned in the README.md but not in the kas-poky-rpi.yaml).

 
LAYERDEPENDS_raspberrypi = "core networking-layer perl-layer qt5-layer"
