### PR TITLE
Bump/kernel

### DIFF
--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,10 +1,10 @@
-RPIFW_DATE ?= "20200504"
-SRCREV ?= "7eff9f6774bb43bfd61e749a0b45ffddc98c2311"
+RPIFW_DATE ?= "20200603"
+SRCREV ?= "23548e550a757d368d3d5220373fe829b5961c42"
 RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[md5sum] = "05cd161dca5a6f02684794960913e04c"
-SRC_URI[sha256sum] = "77ad450dd7cabb58ca04a18fd704844df6e642374346cf006a07edca46615af1"
+SRC_URI[md5sum] = "acd99b86ab857b43d3e3a6bf53ee7d89"
+SRC_URI[sha256sum] = "ea8accaecd4bd1ff5e1ca2c0cf4c182c829779d89a6fc4d64a058c6ddd6b654b"
 
 PV = "${RPIFW_DATE}"

--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -1,7 +1,7 @@
-LINUX_VERSION ?= "4.19.120"
+LINUX_VERSION ?= "4.19.126"
 LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 
-SRCREV = "9da67d7329873623bd5c13fae5835d76d5be8806"
+SRCREV = "f6b3ac28f0a9137d4c24c0b8832e693bbd16f5b7"
 
 require linux-raspberrypi_4.19.inc
 


### PR DESCRIPTION
Tested on rpi3:

```
Found U-Boot script /boot.scr
213 bytes read in 2 ms (103.5 KiB/s)
## Executing script at 02400000
5436192 bytes read in 232 ms (22.3 MiB/s)
## Booting kernel from Legacy Image at 00080000 ...
   Image Name:   Linux-4.19.126-v7
   Image Type:   ARM Linux Kernel Image (uncompressed)
   Data Size:    5436128 Bytes = 5.2 MiB
   Load Address: 00008000
   Entry Point:  00008000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 2eff9400
   Booting using the fdt blob at 0x2eff9400
   Loading Kernel Image
   Using Device Tree in place at 2eff9400, end 2f002f9b

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0
[    0.000000] Linux version 4.19.126-v7 (oe-user@oe-host) (gcc version 10.1.0 (GCC)) #1 SMP Wed Jun 3 14:46:19 UTC 2020
```
