### PR TITLE
lirc_%.bbappend: Fix for gpio-ir

### DIFF
--- a/recipes-connectivity/lirc/lirc/lirc-gpio-ir-0.10.patch
+++ b/recipes-connectivity/lirc/lirc/lirc-gpio-ir-0.10.patch
@@ -1,0 +1,175 @@
+diff -ruN lirc-0.10.1.orig/lib/config_file.c lirc-0.10.1/lib/config_file.c
+--- lirc-0.10.1.orig/lib/config_file.c	2017-09-10 17:52:19.000000000 +0900
++++ lirc-0.10.1/lib/config_file.c	2019-06-26 00:39:45.734320696 +0900
+@@ -71,7 +71,7 @@
+ typedef void* (*array_guest_func)(void* item, void* arg);
+ 
+ 
+-#define LINE_LEN 1024
++#define LINE_LEN 4096
+ #define MAX_INCLUDES 10
+ 
+ const char* whitespace = " \t";
+diff -ruN lirc-0.10.1.orig/lib/ir_remote.h lirc-0.10.1/lib/ir_remote.h
+--- lirc-0.10.1.orig/lib/ir_remote.h	2017-09-10 17:52:19.000000000 +0900
++++ lirc-0.10.1/lib/ir_remote.h	2019-06-26 00:39:45.714321224 +0900
+@@ -110,12 +110,17 @@
+ 
+ static inline int is_pulse(lirc_t data)
+ {
+-	return data & PULSE_BIT ? 1 : 0;
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_PULSE) ? 1 : 0;
+ }
+ 
+ static inline int is_space(lirc_t data)
+ {
+-	return !is_pulse(data);
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_SPACE) ? 1 : 0;
++}
++
++static inline int is_timeout(lirc_t data)
++{
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_TIMEOUT) ? 1 : 0;
+ }
+ 
+ static inline int has_repeat(const struct ir_remote* remote)
+diff -ruN lirc-0.10.1.orig/lib/irrecord.c lirc-0.10.1/lib/irrecord.c
+--- lirc-0.10.1.orig/lib/irrecord.c	2017-09-10 17:52:19.000000000 +0900
++++ lirc-0.10.1/lib/irrecord.c	2019-06-26 00:39:45.724320960 +0900
+@@ -1398,9 +1398,16 @@
+ 		state->retval = 0;
+ 		return STS_LEN_TIMEOUT;
+ 	}
++	if (is_timeout(state->data)) {
++		return STS_LEN_AGAIN;
++	}
+ 	state->count++;
+ 	if (state->mode == MODE_GET_GAP) {
+-		state->sum += state->data & PULSE_MASK;
++		if (state->sum != 0 || is_pulse(state->data)) {
++			state->sum += state->data & PULSE_MASK;
++		}else{
++			return STS_LEN_AGAIN;
++		}
+ 		if (state->average == 0 && is_space(state->data)) {
+ 			if (state->data > 100000) {
+ 				state->sum = 0;
+@@ -1472,6 +1479,10 @@
+ 		state->keypresses = lastmaxcount;
+ 		return STS_LEN_AGAIN;
+ 	} else if (state->mode == MODE_HAVE_GAP) {
++		if (state->count==1 && is_space(state->data))  {
++			state->count = 0;
++			return STS_LEN_AGAIN;
++		}
+ 		if (state->count <= MAX_SIGNALS) {
+ 			signals[state->count - 1] = state->data & PULSE_MASK;
+ 		} else {
+@@ -1510,7 +1521,7 @@
+ 			/* such long pulses may appear with
+ 			 * crappy hardware (receiver? / remote?)
+ 			 */
+-			else {
++			else if(is_pulse(state->data)) {
+ 				remote->gap = 0;
+ 				return STS_LEN_NO_GAP_FOUND;
+ 			}
+@@ -1811,22 +1822,24 @@
+ 
+ static int raw_data_ok(struct button_state* btn_state)
+ {
+-	int r;
++	int r = 0;
+ 	int ref;
+ 
+-	if (!is_space(btn_state->data)) {
++	if (is_pulse(btn_state->data)) {
+ 		r = 0;
+-	} else if (is_const(&remote)) {
+-		if (remote.gap > btn_state->sum) {
+-			ref = (remote.gap - btn_state->sum);
+-			ref *= (100 - remote.eps);
+-			ref /= 100;
++	} else if (is_space(btn_state->data)) {
++		if (is_const(&remote)) {
++			if (remote.gap > btn_state->sum) {
++				ref = (remote.gap - btn_state->sum);
++				ref *= (100 - remote.eps);
++				ref /= 100;
++			} else {
++				ref = 0;
++			}
++			r = btn_state->data > ref;
+ 		} else {
+-			ref = 0;
++			r = btn_state->data > (remote.gap * (100 - remote.eps)) / 100;
+ 		}
+-		r = btn_state->data > ref;
+-	} else {
+-		r = btn_state->data > (remote.gap * (100 - remote.eps)) / 100;
+ 	}
+ 	return r;
+ }
+@@ -1970,7 +1983,7 @@
+ 				btn_state->data = remote.gap;
+ 			}
+ 			if (btn_state->count == 0) {
+-				if (!is_space(btn_state->data)
++				if (is_pulse(btn_state->data)
+ 				    || btn_state->data <
+ 				    remote.gap - remote.gap * remote.eps /
+ 				    100) {
+diff -ruN lirc-0.10.1.orig/lib/lirc/ir_remote.h lirc-0.10.1/lib/lirc/ir_remote.h
+--- lirc-0.10.1.orig/lib/lirc/ir_remote.h	2017-09-10 17:52:58.000000000 +0900
++++ lirc-0.10.1/lib/lirc/ir_remote.h	2019-06-26 00:39:45.724320960 +0900
+@@ -110,12 +110,17 @@
+ 
+ static inline int is_pulse(lirc_t data)
+ {
+-	return data & PULSE_BIT ? 1 : 0;
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_PULSE) ? 1 : 0;
+ }
+ 
+ static inline int is_space(lirc_t data)
+ {
+-	return !is_pulse(data);
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_SPACE) ? 1 : 0;
++}
++
++static inline int is_timeout(lirc_t data)
++{
++	return ((data & LIRC_MODE2_MASK)==LIRC_MODE2_TIMEOUT) ? 1 : 0;
+ }
+ 
+ static inline int has_repeat(const struct ir_remote* remote)
+diff -ruN lirc-0.10.1.orig/tools/mode2.cpp lirc-0.10.1/tools/mode2.cpp
+--- lirc-0.10.1.orig/tools/mode2.cpp	2017-09-10 17:52:19.000000000 +0900
++++ lirc-0.10.1/tools/mode2.cpp	2019-06-26 00:45:38.840404976 +0900
+@@ -326,12 +326,24 @@
+ void print_mode2_data(unsigned int data)
+ {
+ 	static int bitno = 1;
++	static bool leading_space = true;
++	unsigned int msg = data & LIRC_MODE2_MASK;
+ 
+ 	switch (opt_dmode) {
+ 	case 0:
+-		printf("%s %u\n", (
+-			       data & PULSE_BIT) ? "pulse" : "space",
+-		       (uint32_t)(data & PULSE_MASK));
++		if (leading_space && msg == LIRC_MODE2_SPACE ) {
++			break;
++		} else {
++			leading_space = false;
++		}
++		if (msg == LIRC_MODE2_PULSE) {
++			printf("pulse %u\n", (__u32)(data & PULSE_MASK));
++		} else if (msg == LIRC_MODE2_SPACE) {
++			printf("space %u\n", (__u32)(data & PULSE_MASK));
++		} else if (msg == LIRC_MODE2_TIMEOUT) {
++			printf("timeout %u\n", (__u32)(data & PULSE_MASK));
++			leading_space = true;
++		}
+ 		break;
+ 	case 1: {
+ 		/* print output like irrecord raw config file data */

--- a/recipes-connectivity/lirc/lirc_%.bbappend
+++ b/recipes-connectivity/lirc/lirc_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append_rpi = " \
+	file://lirc-gpio-ir-0.10.patch \
+"


### PR DESCRIPTION
Apply Raspberry Pi specific fix for gpio-ir kernel module:
https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=235256

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Fix LIRC on Raspberry Pi with a patch that is known to work with gpio-ir kernel module as explained in the Raspberry Pi forums:
https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=235256

**- How I did it**

With a `.bbappend` file for LIRC that applies the Raspberry Pi specific patch.

Best regards,
Leon