### PR TITLE
u-boot: Fix booting raspberrypi CM3 module

### DIFF
--- a/recipes-bsp/u-boot/u-boot/0001-dm-core-Move-ofdata_to_platdata-call-earlier.patch
+++ b/recipes-bsp/u-boot/u-boot/0001-dm-core-Move-ofdata_to_platdata-call-earlier.patch
@@ -1,0 +1,51 @@
+From 336d86ebd146905cf4384912f4f27699b6e37c72 Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Sun, 29 Dec 2019 21:19:17 -0700
+Subject: [PATCH] dm: core: Move ofdata_to_platdata() call earlier
+
+This method is supposed to extract platform data from the device tree. It
+should be done before the device itself is probed. Move it earlier in the
+device_probe() function.
+
+Upstream-Status: Backport
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/core/device.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/core/device.c b/drivers/core/device.c
+index 4e03708..291ff4c 100644
+--- a/drivers/core/device.c
++++ b/drivers/core/device.c
+@@ -375,6 +375,13 @@ int device_probe(struct udevice *dev)
+ 			return 0;
+ 	}
+ 
++	if (drv->ofdata_to_platdata &&
++	    (CONFIG_IS_ENABLED(OF_PLATDATA) || dev_has_of_node(dev))) {
++		ret = drv->ofdata_to_platdata(dev);
++		if (ret)
++			goto fail;
++	}
++
+ 	seq = uclass_resolve_seq(dev);
+ 	if (seq < 0) {
+ 		ret = seq;
+@@ -411,13 +418,6 @@ int device_probe(struct udevice *dev)
+ 			goto fail;
+ 	}
+ 
+-	if (drv->ofdata_to_platdata &&
+-	    (CONFIG_IS_ENABLED(OF_PLATDATA) || dev_has_of_node(dev))) {
+-		ret = drv->ofdata_to_platdata(dev);
+-		if (ret)
+-			goto fail;
+-	}
+-
+ 	/* Only handle devices that have a valid ofnode */
+ 	if (dev_of_valid(dev)) {
+ 		/*
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,1 +1,3 @@
 DEPENDS_append_rpi = " u-boot-default-script"
+
+SRC_URI_append_raspberrypi-cm3 = " file://0001-dm-core-Move-ofdata_to_platdata-call-earlier.patch"


### PR DESCRIPTION
With stock u-bootv2020.01 which we use from poky CM3 module won't boot.
We need to apply this patch in order to have platform again working.

Add it only for cm3 to not break anythign else.

Signed-off-by: Marek Belisko <marek.belisko@open-nandra.com>

