### PR TITLE
packagegroup-rpi-test: resolve `wireless-regdb` conflict

### DIFF
--- a/recipes-core/packagegroups/packagegroup-rpi-test.bb
+++ b/recipes-core/packagegroups/packagegroup-rpi-test.bb
@@ -20,7 +20,7 @@ RDEPENDS_${PN} = "\
     python3-sense-hat \
     connman \
     connman-client \
-    wireless-regdb \
+    wireless-regdb-static \
     bluez5 \
 "
 


### PR DESCRIPTION
Replaces `wireless-regdb` with `wireless-regdb-static` provided by poky.

Fixes #639.

Signed-off-by: Jon Magnuson <jon.magnuson@gmail.com>