### PR TITLE
Fix fw_printenv when using U-Boot

### DIFF
--- a/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
+++ b/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
@@ -1,3 +1,4 @@
 fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
 fatload mmc 0:1 ${kernel_addr_r} @@KERNEL_IMAGETYPE@@
+if test ! -e mmc 0:1 uboot.env; then saveenv; fi;
 @@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr}

--- a/recipes-bsp/u-boot/files/fw_env.config
+++ b/recipes-bsp/u-boot/files/fw_env.config
@@ -1,0 +1,1 @@
+/boot/uboot.env 0x0000    0x4000

--- a/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append_rpi = " \
+    file://fw_env.config \
+"
+
+DEPENDS_append_rpi = " rpi-u-boot-scr"
+
+do_install_append_rpi () {
+    install -d ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/fw_env.config ${D}${sysconfdir}/fw_env.config
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Fix the following issue with `fw_printenv` while running an image with U-Boot:
```
root@raspberrypi3:~# fw_printenv 
Configuration file wrong or corrupted
```

To reproduce this issue add the following configurations to `local.conf`:

```
RPI_USE_U_BOOT = "1"
IMAGE_INSTALL_append = " u-boot-fw-utils"
```

**- How I did it**

The fix contains two parts (each in a separate git commit):
* Create `/boot/uboot.env` through `boot.cmd.in` from recipe `rpi-u-boot-scr`
* Add `fw_env.config` that uses `/boot/uboot.env` to run successfully `fw_printenv`
