### PR TITLE
conf/machine/include/rpi-base.inc: Added can1 interface to bsp

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -28,6 +28,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/iqaudio-dacplus.dtbo \
     overlays/miniuart-bt.dtbo \
     overlays/mcp2515-can0.dtbo \
+    overlays/mcp2515-can1.dtbo \
     overlays/pitft22.dtbo \
     overlays/pitft28-resistive.dtbo \
     overlays/pitft28-capacitive.dtbo \

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -261,6 +261,13 @@ In order to use Pican2 CAN module, set the following variables:
 
 See: <http://skpang.co.uk/catalog/pican2-canbus-board-for-raspberry-pi-23-p-1475.html>
 
+In order to use Pican2 Duo CAN module, set the following variables:
+
+	ENABLE_SPI_BUS = "1"
+	ENABLE_DUAL_CAN = "1"
+
+See: <http://skpang.co.uk/catalog/pican2-duo-canbus-board-for-raspberry-pi-23-p-1480.html>
+
 ## Enable infrared
 
 Users who want to enable infrared support, for example for using LIRC (Linux

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -198,8 +198,13 @@ do_deploy() {
         echo "dtoverlay=at86rf233,speed=3000000" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
+    # ENABLE DUAL CAN
+    if [ "${ENABLE_DUAL_CAN}" = "1" ]; then
+        echo "# Enable DUAL CAN" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=25" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "dtoverlay=mcp2515-can1,oscillator=16000000,interrupt=24" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     # ENABLE CAN
-    if [ "${ENABLE_CAN}" = "1" ]; then
+    elif [ "${ENABLE_CAN}" = "1" ]; then
         echo "# Enable CAN" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=25" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi


### PR DESCRIPTION
The device tree only supports a single CAN interface.  This prevents
compatiblity with dual-CAN boards like the PiCAN2 Duo.

The mcp2515-can1 device tree blob for overlay was added to RPI_KERNEL_DEVICETREE_OVERLAYS in order to support dual-CAN hats.

Signed-off-by: Colin McAllister <colinmca242@gmail.com>