### PR TITLE
rpi-config: Relocated "start_x=1" in config.txt

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -117,8 +117,11 @@ do_deploy() {
 
     # Video camera support
     if [ "${VIDEO_CAMERA}" = "1" ]; then
-        echo "# Enable video camera" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
-        echo "start_x=1" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        # TODO: It has been observed that Raspberry Pi 4B 4GB may fail to enable the camera if "start_x=1" is at the end
+        #       of the file. The underlying cause is unknown, but it can be related with a file size limitation affecting
+        #       this variable. Therefore, "start_x=1" has been set to replace the original occurrence in config.txt,
+        #       which is at the middle of the file.
+        sed -i '/#start_x=/ c\start_x=1' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
     # Offline compositing support


### PR DESCRIPTION
@NobuoTsukamoto figured out that It seems like "start_x=1" needs to be earlier in the file to work properly on the Rapberry Pi 4 B.

Fixes: #670 
