### PR TITLE
bump kernel

### DIFF
--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,10 +1,10 @@
-RPIFW_DATE ?= "20200603"
-SRCREV ?= "23548e550a757d368d3d5220373fe829b5961c42"
+RPIFW_DATE ?= "20200713"
+SRCREV ?= "7e74bcb4f9706f36f752d1c3d3164628ccf2aae5"
 RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[md5sum] = "acd99b86ab857b43d3e3a6bf53ee7d89"
-SRC_URI[sha256sum] = "ea8accaecd4bd1ff5e1ca2c0cf4c182c829779d89a6fc4d64a058c6ddd6b654b"
+SRC_URI[md5sum] = "46a19d68b81f388443394492dd6a873c"
+SRC_URI[sha256sum] = "f987cafcbc72179493673191e3e4aa8c1f18eccf871546be5d26156abbf8eff1"
 
 PV = "${RPIFW_DATE}"

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -1,7 +1,7 @@
-LINUX_VERSION ?= "5.4.50"
+LINUX_VERSION ?= "5.4.51"
 LINUX_RPI_BRANCH ?= "rpi-5.4.y"
 
-SRCREV = "856e83151cf3f802c495585ac176bb135a08030f"
+SRCREV = "95a969f451f6ed61029741411c1c9aa44023e465"
 
 require linux-raspberrypi_5.4.inc
 


### PR DESCRIPTION
Tested on RPi3 with U-Boot:

```
U-Boot 2020.04 (Apr 13 2020 - 15:02:18 +0000)

DRAM:  948 MiB
RPI 3 Model B (0xa02082)
MMC:   mmc@7e202000: 0, sdhci@7e300000: 1
Loading Environment from FAT... OK
In:    serial
Out:   vidconsole
Err:   vidconsole
Net:   No ethernet found.
starting USB...
Bus usb@7e980000: scanning bus usb@7e980000 for devices... 3 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:  0 
switch to partitions #0, OK
mmc0 is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
263 bytes read in 1 ms (256.8 KiB/s)
## Executing script at 02400000
5628880 bytes read in 235 ms (22.8 MiB/s)
## Booting kernel from Legacy Image at 00080000 ...
   Image Name:   Linux-5.4.51-v7
   Image Type:   ARM Linux Kernel Image (uncompressed)
   Data Size:    5628816 Bytes = 5.4 MiB
   Load Address: 00008000
   Entry Point:  00008000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 2eff8e00
   Booting using the fdt blob at 0x2eff8e00
   Loading Kernel Image
   Using Device Tree in place at 2eff8e00, end 2f002f39

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0
[    0.000000] Linux version 5.4.51-v7 (oe-user@oe-host) (gcc version 10.1.0 (GCC)) #1 SMP Mon Jul 13 13:49:42 UTC 2020
[    0.000000] CPU: ARMv7 Processor [410fd034] revision 4 (ARMv7), cr=10c5383d
...
```

Fixes #681 