### PR TITLE
rpi-config: Add CAN_OSCILLATOR variable to set mcp2515 crystal frequency

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -252,21 +252,27 @@ When using device tree kernels, set this variable to enable the 802.15.4 hat:
 
 See: <https://openlabs.co/OSHW/Raspberry-Pi-802.15.4-radio>
 
-## Enable CAN with Pican2
+## Enable CAN
 
-In order to use Pican2 CAN module, set the following variables:
+In order to use CAN with an MCP2515-based module, set the following variables:
 
 	ENABLE_SPI_BUS = "1"
 	ENABLE_CAN = "1"
 
-See: <http://skpang.co.uk/catalog/pican2-canbus-board-for-raspberry-pi-23-p-1475.html>
+In case of dual CAN module (e.g. PiCAN2 Duo), set following variables instead:
 
-In order to use Pican2 Duo CAN module, set the following variables:
-
-	ENABLE_SPI_BUS = "1"
+    ENABLE_SPI_BUS = "1"
 	ENABLE_DUAL_CAN = "1"
 
-See: <http://skpang.co.uk/catalog/pican2-duo-canbus-board-for-raspberry-pi-23-p-1480.html>
+Some modules may require setting the frequency of the crystal oscillator used on the particular board. The frequency is usually marked on the package of the crystal. By default, it is set to 16 MHz. To change that to 8 MHz, the following variable also has to be set:
+
+    CAN_OSCILLATOR="8000000"
+
+Tested modules:
+
+* PiCAN2 (16 MHz crystal): <http://skpang.co.uk/catalog/pican2-canbus-board-for-raspberry-pi-23-p-1475.html>
+* WaveShare RS485 CAN HAT (8 MHz or 12 MHz crystal): <https://www.waveshare.com/rs485-can-hat.htm>
+* PiCAN2 Duo (16 MHz crystal): <http://skpang.co.uk/catalog/pican2-duo-canbus-board-for-raspberry-pi-23-p-1480.html>
 
 ## Enable infrared
 

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -28,6 +28,8 @@ VC4DTBO ?= "vc4-kms-v3d"
 GPIO_IR ?= "18"
 GPIO_IR_TX ?= "17"
 
+CAN_OSCILLATOR ?= "16000000"
+
 inherit deploy nopackages
 
 do_deploy() {
@@ -201,12 +203,12 @@ do_deploy() {
     # ENABLE DUAL CAN
     if [ "${ENABLE_DUAL_CAN}" = "1" ]; then
         echo "# Enable DUAL CAN" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=25" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=mcp2515-can1,oscillator=16000000,interrupt=24" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "dtoverlay=mcp2515-can0,oscillator=${CAN_OSCILLATOR},interrupt=25" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "dtoverlay=mcp2515-can1,oscillator=${CAN_OSCILLATOR},interrupt=24" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     # ENABLE CAN
     elif [ "${ENABLE_CAN}" = "1" ]; then
         echo "# Enable CAN" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=25" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "dtoverlay=mcp2515-can0,oscillator=${CAN_OSCILLATOR},interrupt=25" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
 
     # Append extra config if the user has provided any


### PR DESCRIPTION
Add CAN_OSCILLATOR variable to make it possible to set frequency of the crystal oscillator used on the actual CAN board.

Current configuration (16MHz) is made for the PiCAN2 board, that uses 16MHz crystal. I use Waveshare RS485 CAN HAT that has 8MHz crystal soldered (although according to Waveshare there is also a 16MHz crystal version of the board).