### PR TITLE
dunfell: rpi-base: add SERIAL_CONSOLES_CHECK to default to SERIAL_CONSOLES

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -82,6 +82,7 @@ MACHINE_EXTRA_RRECOMMENDS += "kernel-modules udev-rules-rpi"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "${@oe.utils.conditional('ENABLE_I2C', '1', 'kernel-module-i2c-dev kernel-module-i2c-bcm2708', '', d)}"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "${@oe.utils.conditional('ENABLE_IR', '1', 'kernel-module-gpio-ir kernel-module-gpio-ir-tx', '', d)}"
 
+SERIAL_CONSOLES_CHECK ??= "${SERIAL_CONSOLES}"
 
 # Set Raspberrypi splash image
 SPLASH = "psplash-raspberrypi"


### PR DESCRIPTION
Apply this fix from master (#683) to dunfell. Tested on Raspberry Pi 4.

As per the example in the bsp-guide, and the qemu and other machine
configs. Assists when running virtualized, where serial console
device can differ.

Signed-off-by: Christopher Clark <christopher.w.clark@gmail.com>