### PR TITLE
bootfiles, rpi-config, rpi-base: generalize the bootfiles recipe

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -26,7 +26,7 @@ inherit image_types
 IMAGE_TYPEDEP_rpi-sdimg = "${SDIMG_ROOTFS_TYPE}"
 
 # Set kernel and boot loader
-IMAGE_BOOTLOADER ?= "bcm2835-bootfiles"
+IMAGE_BOOTLOADER ?= "bootfiles"
 
 # Kernel image name
 SDIMG_KERNELIMAGE_raspberrypi  ?= "kernel.img"
@@ -114,7 +114,7 @@ IMAGE_CMD_rpi-sdimg () {
     BOOT_BLOCKS=$(LC_ALL=C parted -s ${SDIMG} unit b print | awk '/ 1 / { print substr($4, 1, length($4 -1)) / 512 /2 }')
     rm -f ${WORKDIR}/boot.img
     mkfs.vfat -F32 -n "${BOOTDD_VOLUME_ID}" -S 512 -C ${WORKDIR}/boot.img $BOOT_BLOCKS
-    mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/* ::/ || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/* into boot.img"
+    mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${BOOTFILES_DIR_NAME}/* ::/ || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/${BOOTFILES_DIR_NAME}/* into boot.img"
     if [ "${@bb.utils.contains("MACHINE_FEATURES", "armstub", "1", "0", d)}" = "1" ]; then
         mcopy -v -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/armstubs/${ARMSTUB} ::/ || bbfatal "mcopy cannot copy ${DEPLOY_DIR_IMAGE}/armstubs/${ARMSTUB} into boot.img"
     fi

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -84,6 +84,10 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "${@oe.utils.conditional('ENABLE_IR', '1'
 
 SERIAL_CONSOLES_CHECK ??= "${SERIAL_CONSOLES}"
 
+# The name of the deploy directory for raspberry pi boot files.
+# This variable is referred to by recipes fetching / generating the files.
+BOOTFILES_DIR_NAME ?= "bootfiles"
+
 # Set Raspberrypi splash image
 SPLASH = "psplash-raspberrypi"
 
@@ -110,14 +114,14 @@ def make_dtb_boot_files(d):
     return ' '.join([transform(dtb) for dtb in alldtbs.split(' ') if dtb])
 
 
-IMAGE_BOOT_FILES ?= "bcm2835-bootfiles/* \
+IMAGE_BOOT_FILES ?= "${BOOTFILES_DIR_NAME}/* \
                  ${@make_dtb_boot_files(d)} \
                  ${@bb.utils.contains('RPI_USE_U_BOOT', '1', \
                     '${KERNEL_IMAGETYPE} u-boot.bin;${SDIMG_KERNELIMAGE} boot.scr', \
                     '${KERNEL_IMAGETYPE};${SDIMG_KERNELIMAGE}', d)} \
                  "
 do_image_wic[depends] += " \
-    bcm2835-bootfiles:do_deploy \
+    bootfiles:do_deploy \
     ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
     "
 

--- a/recipes-bsp/bootfiles/bootfiles.bb
+++ b/recipes-bsp/bootfiles/bootfiles.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "Closed source binary files to help boot the ARM on the BCM2835."
+DESCRIPTION = "Closed source binary files to help boot all raspberry pi devices."
 LICENSE = "Broadcom-RPi"
 
 LIC_FILES_CHKSUM = "file://LICENCE.broadcom;md5=c403841ff2837657b2ed8e5bb474ac8d"

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -31,203 +31,203 @@ GPIO_IR_TX ?= "17"
 inherit deploy nopackages
 
 do_deploy() {
-    install -d ${DEPLOYDIR}/bcm2835-bootfiles
+    install -d ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}
 
-    cp ${S}/config.txt ${DEPLOYDIR}/bcm2835-bootfiles/
+    cp ${S}/config.txt ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/
 
     if [ -n "${KEY_DECODE_MPG2}" ]; then
-        sed -i '/#decode_MPG2=/ c\decode_MPG2=${KEY_DECODE_MPG2}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#decode_MPG2=/ c\decode_MPG2=${KEY_DECODE_MPG2}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${KEY_DECODE_WVC1}" ]; then
-        sed -i '/#decode_WVC1=/ c\decode_WVC1=${KEY_DECODE_WVC1}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#decode_WVC1=/ c\decode_WVC1=${KEY_DECODE_WVC1}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${DISABLE_OVERSCAN}" ]; then
-        sed -i '/#disable_overscan=/ c\disable_overscan=${DISABLE_OVERSCAN}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#disable_overscan=/ c\disable_overscan=${DISABLE_OVERSCAN}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ "${DISABLE_SPLASH}" = "1" ]; then
-        sed -i '/#disable_splash=/ c\disable_splash=${DISABLE_SPLASH}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#disable_splash=/ c\disable_splash=${DISABLE_SPLASH}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # Set overclocking options
     if [ -n "${ARM_FREQ}" ]; then
-        sed -i '/#arm_freq=/ c\arm_freq=${ARM_FREQ}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#arm_freq=/ c\arm_freq=${ARM_FREQ}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${GPU_FREQ}" ]; then
-        sed -i '/#gpu_freq=/ c\gpu_freq=${GPU_FREQ}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#gpu_freq=/ c\gpu_freq=${GPU_FREQ}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${CORE_FREQ}" ]; then
-        sed -i '/#core_freq=/ c\core_freq=${CORE_FREQ}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#core_freq=/ c\core_freq=${CORE_FREQ}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${SDRAM_FREQ}" ]; then
-        sed -i '/#sdram_freq=/ c\sdram_freq=${SDRAM_FREQ}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#sdram_freq=/ c\sdram_freq=${SDRAM_FREQ}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${OVER_VOLTAGE}" ]; then
-        sed -i '/#over_voltage=/ c\over_voltage=${OVER_VOLTAGE}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#over_voltage=/ c\over_voltage=${OVER_VOLTAGE}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # GPU memory
     if [ -n "${GPU_MEM}" ]; then
-        sed -i '/#gpu_mem=/ c\gpu_mem=${GPU_MEM}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#gpu_mem=/ c\gpu_mem=${GPU_MEM}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${GPU_MEM_256}" ]; then
-        sed -i '/#gpu_mem_256=/ c\gpu_mem_256=${GPU_MEM_256}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#gpu_mem_256=/ c\gpu_mem_256=${GPU_MEM_256}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${GPU_MEM_512}" ]; then
-        sed -i '/#gpu_mem_512=/ c\gpu_mem_512=${GPU_MEM_512}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#gpu_mem_512=/ c\gpu_mem_512=${GPU_MEM_512}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${GPU_MEM_1024}" ]; then
-        sed -i '/#gpu_mem_1024=/ c\gpu_mem_1024=${GPU_MEM_1024}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#gpu_mem_1024=/ c\gpu_mem_1024=${GPU_MEM_1024}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # Set boot delay
     if [ -n "${BOOT_DELAY}" ]; then
-        sed -i '/#boot_delay=/ c\boot_delay=${BOOT_DELAY}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#boot_delay=/ c\boot_delay=${BOOT_DELAY}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${BOOT_DELAY_MS}" ]; then
-        sed -i '/#boot_delay_ms=/ c\boot_delay_ms=${BOOT_DELAY_MS}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#boot_delay_ms=/ c\boot_delay_ms=${BOOT_DELAY_MS}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # Set HDMI and composite video options
     if [ -n "${HDMI_FORCE_HOTPLUG}" ]; then
-        sed -i '/#hdmi_force_hotplug=/ c\hdmi_force_hotplug=${HDMI_FORCE_HOTPLUG}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#hdmi_force_hotplug=/ c\hdmi_force_hotplug=${HDMI_FORCE_HOTPLUG}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${HDMI_DRIVE}" ]; then
-        sed -i '/#hdmi_drive=/ c\hdmi_drive=${HDMI_DRIVE}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#hdmi_drive=/ c\hdmi_drive=${HDMI_DRIVE}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${HDMI_GROUP}" ]; then
-        sed -i '/#hdmi_group=/ c\hdmi_group=${HDMI_GROUP}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#hdmi_group=/ c\hdmi_group=${HDMI_GROUP}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${HDMI_MODE}" ]; then
-        sed -i '/#hdmi_mode=/ c\hdmi_mode=${HDMI_MODE}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#hdmi_mode=/ c\hdmi_mode=${HDMI_MODE}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${CONFIG_HDMI_BOOST}" ]; then
-        sed -i '/#config_hdmi_boost=/ c\config_hdmi_boost=${CONFIG_HDMI_BOOST}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#config_hdmi_boost=/ c\config_hdmi_boost=${CONFIG_HDMI_BOOST}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${SDTV_MODE}" ]; then
-        sed -i '/#sdtv_mode=/ c\sdtv_mode=${SDTV_MODE}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#sdtv_mode=/ c\sdtv_mode=${SDTV_MODE}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${SDTV_ASPECT}" ]; then
-        sed -i '/#sdtv_aspect=/ c\sdtv_aspect=${SDTV_ASPECT}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#sdtv_aspect=/ c\sdtv_aspect=${SDTV_ASPECT}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ -n "${DISPLAY_ROTATE}" ]; then
-        sed -i '/#display_rotate=/ c\display_rotate=${DISPLAY_ROTATE}' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        sed -i '/#display_rotate=/ c\display_rotate=${DISPLAY_ROTATE}' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # Video camera support
     if [ "${VIDEO_CAMERA}" = "1" ]; then
-        echo "# Enable video camera" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "start_x=1" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable video camera" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "start_x=1" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # Offline compositing support
     if [ "${DISPMANX_OFFLINE}" = "1" ]; then
-        echo "# Enable offline compositing" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dispmanx_offline=1" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable offline compositing" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dispmanx_offline=1" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # SPI bus support
     if [ "${ENABLE_SPI_BUS}" = "1" ] || [ "${PITFT}" = "1" ]; then
-        echo "# Enable SPI bus" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtparam=spi=on" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable SPI bus" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtparam=spi=on" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # I2C support
     if [ "${ENABLE_I2C}" = "1" ] || [ "${PITFT}" = "1" ]; then
-        echo "# Enable I2C" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtparam=i2c1=on" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtparam=i2c_arm=on" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable I2C" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtparam=i2c1=on" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtparam=i2c_arm=on" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # PiTFT22 display support
     if [ "${PITFT22}" = "1" ]; then
-        echo "# Enable PITFT22 display" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=pitft22,rotate=270,speed=32000000,txbuflen=32768" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable PITFT22 display" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=pitft22,rotate=270,speed=32000000,txbuflen=32768" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ "${PITFT28r}" = "1" ]; then
-        echo "# Enable PITFT28r display" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=pitft28-resistive,rotate=90,speed=32000000,txbuflen=32768" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable PITFT28r display" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=pitft28-resistive,rotate=90,speed=32000000,txbuflen=32768" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ "${PITFT28c}" = "1" ]; then
-        echo "# Enable PITFT28c display" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=pitft28-capacitive,rotate=90,speed=32000000,txbuflen=32768" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=pitft28-capacitive,touch-swapxy,touch-invx" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable PITFT28c display" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=pitft28-capacitive,rotate=90,speed=32000000,txbuflen=32768" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=pitft28-capacitive,touch-swapxy,touch-invx" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
     if [ "${PITFT35r}" = "1" ]; then
-        echo "# Enable PITFT35r display" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=pitft35-resistive,rotate=90,speed=42000000,fps=20" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable PITFT35r display" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=pitft35-resistive,rotate=90,speed=42000000,fps=20" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # UART support
     if [ "${ENABLE_UART}" = "1" ]; then
-        echo "# Enable UART" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "enable_uart=1" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable UART" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "enable_uart=1" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # Infrared support
     if [ "${ENABLE_IR}" = "1" ]; then
-        echo "# Enable infrared" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=gpio-ir,gpio_pin=${GPIO_IR}" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=gpio-ir-tx,gpio_pin=${GPIO_IR_TX}" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable infrared" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=gpio-ir,gpio_pin=${GPIO_IR}" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=gpio-ir-tx,gpio_pin=${GPIO_IR_TX}" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # VC4 Graphics support
     if [ "${VC4GRAPHICS}" = "1" ]; then
-        echo "# Enable VC4 Graphics" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=${VC4DTBO}" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable VC4 Graphics" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=${VC4DTBO}" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # Waveshare "C" 1024x600 7" Rev2.1 IPS capacitive touch (http://www.waveshare.com/7inch-HDMI-LCD-C.htm)
     if [ "${WAVESHARE_1024X600_C_2_1}" = "1" ]; then
-        echo "# Waveshare \"C\" 1024x600 7\" Rev2.1 IPS capacitive touch screen" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "max_usb_current=1" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "hdmi_group=2" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "hdmi_mode=87" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "hdmi_cvt 1024 600 60 6 0 0 0" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "hdmi_drive=1" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Waveshare \"C\" 1024x600 7\" Rev2.1 IPS capacitive touch screen" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "max_usb_current=1" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "hdmi_group=2" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "hdmi_mode=87" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "hdmi_cvt 1024 600 60 6 0 0 0" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "hdmi_drive=1" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # DWC2 USB peripheral support
     if [ "${ENABLE_DWC2_PERIPHERAL}" = "1" ]; then
-        echo "# Enable USB peripheral mode" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=dwc2,dr_mode=peripheral" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable USB peripheral mode" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=dwc2,dr_mode=peripheral" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # AT86RF23X support
     if [ "${ENABLE_AT86RF}" = "1" ]; then
-        echo "# Enable AT86RF23X" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=at86rf233,speed=3000000" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable AT86RF23X" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=at86rf233,speed=3000000" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # ENABLE CAN
     if [ "${ENABLE_CAN}" = "1" ]; then
-        echo "# Enable CAN" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=25" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "# Enable CAN" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=25" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
     # Append extra config if the user has provided any
-    printf "${RPI_EXTRA_CONFIG}\n" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    printf "${RPI_EXTRA_CONFIG}\n" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
 
     # Handle setup with armstub file
     if [ "${@bb.utils.contains("MACHINE_FEATURES", "armstub", "1", "0", d)}" = "1" ]; then
-        echo "\n# ARM stub configuration" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-        echo "armstub=${ARMSTUB}" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "\n# ARM stub configuration" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "armstub=${ARMSTUB}" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
         case "${ARMSTUB}" in
             *-gic.bin)
-                echo  "enable_gic=1" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+                echo  "enable_gic=1" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
                 ;;
         esac
     fi
 }
 
 do_deploy_append_raspberrypi3-64() {
-    echo "# have a properly sized image" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-    echo "disable_overscan=1" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    echo "# have a properly sized image" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+    echo "disable_overscan=1" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
 
-    echo "# Enable audio (loads snd_bcm2835)" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-    echo "dtparam=audio=on" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    echo "# Enable audio (loads snd_bcm2835)" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+    echo "dtparam=audio=on" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
 }
 
 addtask deploy before do_build after do_install
-do_deploy[dirs] += "${DEPLOYDIR}/bcm2835-bootfiles"
+do_deploy[dirs] += "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -131,10 +131,10 @@ do_compile_append() {
 
 do_deploy_append() {
     # Deploy cmdline.txt
-    install -d ${DEPLOYDIR}/bcm2835-bootfiles
+    install -d ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}
     PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
     if [ ${PITFT} = "1" ]; then
         PITFT_PARAMS="fbcon=map:10 fbcon=font:VGA8x8"
     fi
-    echo "${CMDLINE}${PITFT_PARAMS}" > ${DEPLOYDIR}/bcm2835-bootfiles/cmdline.txt
+    echo "${CMDLINE}${PITFT_PARAMS}" > ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/cmdline.txt
 }


### PR DESCRIPTION
**- What I did**
Generalized the bootfiles recipe and its output directory to remove the implication that they only support
the bcm2835 and not raspberry pi 4s bcm2711.

**- How I did it**
* Recipe is renamed to simply "bootfiles" from "bcm2835-bootfiles"
* Output directory and all references to it across all recipes renamed to "bootfiles" from "bcm2835-bootfiles"