### PR TITLE
sdcard_image-rpi.bbclass: Fix when RPI_SDIMG_EXTRA_DEPENDS not defined

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -49,6 +49,8 @@ SDIMG_ROOTFS = "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${SDIMG_ROOTFS_TYPE}"
 # For the names of kernel artifacts
 inherit kernel-artifact-names
 
+RPI_SDIMG_EXTRA_DEPENDS ?= ""
+
 do_image_rpi_sdimg[depends] = " \
     parted-native:do_populate_sysroot \
     mtools-native:do_populate_sysroot \


### PR DESCRIPTION
This includes a fix for https://github.com/agherzan/meta-raspberrypi/pull/684/files
CC @dozylynx
