### PR TITLE
linux-raspberrypi-5.4: bump SRCREV to latest to fix perf build

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -1,7 +1,7 @@
-LINUX_VERSION ?= "5.4.51"
+LINUX_VERSION ?= "5.4.58"
 LINUX_RPI_BRANCH ?= "rpi-5.4.y"
 
-SRCREV = "4b945d5fb69233f4ddf66d67c3d35145f1039e01"
+SRCREV = "4592a094787fa6a2ac1e95e96abfe4d7124dbb3a"
 
 require linux-raspberrypi_5.4.inc
 


### PR DESCRIPTION
Needs some fixes from newer 5.4 kernel, e.g.:
1b940bbc5c55 Linux 5.4.56
df35e878d0a5 perf bench: Share some global variables to fix build with gcc 10
702d1b287fd2 perf env: Do not return pointers to local variables
73d2d6b421df perf tests bp_account: Make global variable static

to fix:
  LINK     perf/1.0-r9/perf-1.0/perf
perf/1.0-r9/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/10.1.0/ld: error: perf/1.0-r9/perf-1.0/plugins/libtraceevent-dynamic-list:2:15: invalid character
perf/1.0-r9/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/10.1.0/ld: error: perf/1.0-r9/perf-1.0/plugins/libtraceevent-dynamic-list:2:15: syntax error, unexpected end of file, expecting ';'
perf/1.0-r9/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/10.1.0/ld: fatal error: unable to parse dynamic-list script file perf/1.0-r9/perf-1.0/plugins/libtraceevent-dynamic-list
collect2: error: ld returned 1 exit status
Makefile.perf:609: recipe for target 'perf/1.0-r9/perf-1.0/perf' failed
make[2]: *** [perf/1.0-r9/perf-1.0/perf] Error 1
make[2]: *** Waiting for unfinished jobs....
perf/1.0-r9/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/10.1.0/ld: error: perf/1.0-r9/perf-1.0/plugins/libtraceevent-dynamic-list:2:15: invalid character
perf/1.0-r9/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/10.1.0/ld: error: perf/1.0-r9/perf-1.0/plugins/libtraceevent-dynamic-list:2:15: syntax error, unexpected end of file, expecting ';'
perf/1.0-r9/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/10.1.0/ld: fatal error: unable to parse dynamic-list script file perf/1.0-r9/perf-1.0/plugins/libtraceevent-dynamic-list
collect2: error: ld returned 1 exit status
error: command 'arm-oe-linux-gnueabi-gcc' failed with exit status 1
cp: cannot stat 'perf/1.0-r9/perf-1.0/python_ext_build/lib/perf*.so': No such file or directory
Makefile.perf:571: recipe for target 'perf/1.0-r9/perf-1.0/python/perf.so' failed

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
