### PR TITLE
rpi-u-boot-scr: drop hard-coded 'arm'

### DIFF
--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -13,10 +13,10 @@ do_compile() {
     sed -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
         -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
         "${WORKDIR}/boot.cmd.in" > "${WORKDIR}/boot.cmd"
-    mkimage -A arm -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
+    mkimage -A ${UBOOT_ARCH} -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
 }
 
-inherit deploy nopackages
+inherit kernel-arch deploy nopackages
 
 do_deploy() {
     install -d ${DEPLOYDIR}


### PR DESCRIPTION
Let's inherit kernel-arch and use ${UBOOT_ARCH} to replace the
hard-coded 'arm'.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
