### PR TITLE
libcamera: Added a recipe file for libcamera

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -31,6 +31,8 @@ BBFILES_DYNAMIC += " \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bb \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bbappend \
+    multimedia-layer:${LAYERDIR}/dynamic-layers/multimedia-layer/*/*/*.bb \
+    multimedia-layer:${LAYERDIR}/dynamic-layers/multimedia-layer/*/*/*.bbappend \
 "
 
 DEFAULT_TEST_SUITES_remove_rpi = "parselogs"

--- a/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera/libcamera.bbappend
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera/libcamera.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG[raspberrypi] = "-Dpipelines=raspberrypi"
+PACKAGECONFIG_append_rpi = " raspberrypi"


### PR DESCRIPTION
libcamera middleware has supported many pipeline for frame capturing.
To enable the frame capture from raspberrypi board, added new
bbappend file, which will enable the raspberrypi pipeline while compiling.

Signed-off-by: Madhavan Krishnan <madhavan.krishnan@linaro.org>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
