### PR TITLE
bump to Linux version 5.4.64

### DIFF
--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,9 +1,9 @@
-RPIFW_DATE ?= "20200819"
-SRCREV ?= "f293685f683c48b1872beeb38c2f7da1f46141a0"
+RPIFW_DATE ?= "20200911"
+SRCREV ?= "a490197f0672d948860b2b807884ae65eabc4d4f"
 RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[sha256sum] = "dd825e8ccbd524182f7e06c5301f2ed2f8a68200e80cf61b1095271dcfbe0e55"
+SRC_URI[sha256sum] = "be06015688f415fa1b87850d51a4188a766f2a618001f70e7c69b07cbdf9d6ab"
 
 PV = "${RPIFW_DATE}"

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -1,7 +1,7 @@
-LINUX_VERSION ?= "5.4.59"
+LINUX_VERSION ?= "5.4.64"
 LINUX_RPI_BRANCH ?= "rpi-5.4.y"
 
-SRCREV = "423495b33efd681dc1c8be10b1303e679216be4c"
+SRCREV = "65caf603f3b1c43f4c92939f7fbb7149e054f486"
 
 require linux-raspberrypi_5.4.inc
 


### PR DESCRIPTION
Tested on `rpi3`:

```
5896120 bytes read in 247 ms (22.8 MiB/s)
Saving Environment to FAT... OK
## Booting kernel from Legacy Image at 00080000 ...
   Image Name:   Linux-5.4.64-v7
   Image Type:   ARM Linux Kernel Image (uncompressed)
   Data Size:    5896056 Bytes = 5.6 MiB
   Load Address: 00008000
   Entry Point:  00008000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 2eff8e00
   Booting using the fdt blob at 0x2eff8e00
   Loading Kernel Image
   Using Device Tree in place at 2eff8e00, end 2f002f5b

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0
[    0.000000] Linux version 5.4.64-v7 (oe-user@oe-host) (gcc version 10.2.0 (GCC)) #1 SMP Fri Sep 11 12:57:30 UTC 2020
[    0.000000] CPU: ARMv7 Processor [410fd034] revision 4 (ARMv7), cr=10c5383d
[    0.000000] CPU: div instructions available: patching division code
```