### PR TITLE
linux-raspberrypi-5.4: revert 1 commit from upstream to fix lttng-mod…

### DIFF
--- a/recipes-kernel/linux/files/0001-Revert-writeback-Fix-sync-livelock-due-to-b_dirty_ti.patch
+++ b/recipes-kernel/linux/files/0001-Revert-writeback-Fix-sync-livelock-due-to-b_dirty_ti.patch
@@ -1,0 +1,194 @@
+From a9d72cb8d30eb0ab0175e9b055f0a1a19a8142b0 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Mon, 14 Sep 2020 16:24:07 +0200
+Subject: [PATCH] Revert "writeback: Fix sync livelock due to b_dirty_time
+ processing"
+
+This reverts commit 6623c19042b63018230e9468ac16cd1be01abaa3.
+
+* fixes:
+  lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:131:6: error: conflicting types for 'trace_writeback_queue_io'
+
+* The issue is that writeback_queue_io was updated in lttng-modules in:
+  https://github.com/lttng/lttng-modules/commit/817e02f9e256b8f2cbb9e3125eb061757b83bd4a
+  which isn't included in 2.12.2 version currently in oe-core and even if it is, then it
+  checks for kernel version 5.9 and won't work with this commit backported from 5.9 to rpi-5.4.y.
+  at least until this lttng-modules commit which improves the LINUX_VERSION_CODE check to
+  include LTTNG_KERNEL_RANGE(5,4,62, 5,5,0)
+  https://github.com/lttng/lttng-modules/commit/b6af46d166c48c9e59600a60b5a2a7ead10f179a
+
+Upstream-Status: Pending
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+
+---
+ fs/fs-writeback.c                | 44 ++++++++++++++++++++------------
+ include/trace/events/writeback.h | 13 +++++-----
+ 2 files changed, 34 insertions(+), 23 deletions(-)
+
+diff --git a/fs/fs-writeback.c b/fs/fs-writeback.c
+index 5f6400ba82c0..51f87b673084 100644
+--- a/fs/fs-writeback.c
++++ b/fs/fs-writeback.c
+@@ -42,6 +42,7 @@
+ struct wb_writeback_work {
+ 	long nr_pages;
+ 	struct super_block *sb;
++	unsigned long *older_than_this;
+ 	enum writeback_sync_modes sync_mode;
+ 	unsigned int tagged_writepages:1;
+ 	unsigned int for_kupdate:1;
+@@ -1233,13 +1234,16 @@ static bool inode_dirtied_after(struct inode *inode, unsigned long t)
+ #define EXPIRE_DIRTY_ATIME 0x0001
+ 
+ /*
+- * Move expired (dirtied before dirtied_before) dirty inodes from
++ * Move expired (dirtied before work->older_than_this) dirty inodes from
+  * @delaying_queue to @dispatch_queue.
+  */
+ static int move_expired_inodes(struct list_head *delaying_queue,
+ 			       struct list_head *dispatch_queue,
+-			       int flags, unsigned long dirtied_before)
++			       int flags,
++			       struct wb_writeback_work *work)
+ {
++	unsigned long *older_than_this = NULL;
++	unsigned long expire_time;
+ 	LIST_HEAD(tmp);
+ 	struct list_head *pos, *node;
+ 	struct super_block *sb = NULL;
+@@ -1247,9 +1251,16 @@ static int move_expired_inodes(struct list_head *delaying_queue,
+ 	int do_sb_sort = 0;
+ 	int moved = 0;
+ 
++	if ((flags & EXPIRE_DIRTY_ATIME) == 0)
++		older_than_this = work->older_than_this;
++	else if (!work->for_sync) {
++		expire_time = jiffies - (dirtytime_expire_interval * HZ);
++		older_than_this = &expire_time;
++	}
+ 	while (!list_empty(delaying_queue)) {
+ 		inode = wb_inode(delaying_queue->prev);
+-		if (inode_dirtied_after(inode, dirtied_before))
++		if (older_than_this &&
++		    inode_dirtied_after(inode, *older_than_this))
+ 			break;
+ 		list_move(&inode->i_io_list, &tmp);
+ 		moved++;
+@@ -1295,22 +1306,18 @@ static int move_expired_inodes(struct list_head *delaying_queue,
+  *                                           |
+  *                                           +--> dequeue for IO
+  */
+-static void queue_io(struct bdi_writeback *wb, struct wb_writeback_work *work,
+-		     unsigned long dirtied_before)
++static void queue_io(struct bdi_writeback *wb, struct wb_writeback_work *work)
+ {
+ 	int moved;
+-	unsigned long time_expire_jif = dirtied_before;
+ 
+ 	assert_spin_locked(&wb->list_lock);
+ 	list_splice_init(&wb->b_more_io, &wb->b_io);
+-	moved = move_expired_inodes(&wb->b_dirty, &wb->b_io, 0, dirtied_before);
+-	if (!work->for_sync)
+-		time_expire_jif = jiffies - dirtytime_expire_interval * HZ;
++	moved = move_expired_inodes(&wb->b_dirty, &wb->b_io, 0, work);
+ 	moved += move_expired_inodes(&wb->b_dirty_time, &wb->b_io,
+-				     EXPIRE_DIRTY_ATIME, time_expire_jif);
++				     EXPIRE_DIRTY_ATIME, work);
+ 	if (moved)
+ 		wb_io_lists_populated(wb);
+-	trace_writeback_queue_io(wb, work, dirtied_before, moved);
++	trace_writeback_queue_io(wb, work, moved);
+ }
+ 
+ static int write_inode(struct inode *inode, struct writeback_control *wbc)
+@@ -1822,7 +1829,7 @@ static long writeback_inodes_wb(struct bdi_writeback *wb, long nr_pages,
+ 	blk_start_plug(&plug);
+ 	spin_lock(&wb->list_lock);
+ 	if (list_empty(&wb->b_io))
+-		queue_io(wb, &work, jiffies);
++		queue_io(wb, &work);
+ 	__writeback_inodes_wb(wb, &work);
+ 	spin_unlock(&wb->list_lock);
+ 	blk_finish_plug(&plug);
+@@ -1842,7 +1849,7 @@ static long writeback_inodes_wb(struct bdi_writeback *wb, long nr_pages,
+  * takes longer than a dirty_writeback_interval interval, then leave a
+  * one-second gap.
+  *
+- * dirtied_before takes precedence over nr_to_write.  So we'll only write back
++ * older_than_this takes precedence over nr_to_write.  So we'll only write back
+  * all dirty pages if they are all attached to "old" mappings.
+  */
+ static long wb_writeback(struct bdi_writeback *wb,
+@@ -1850,11 +1857,14 @@ static long wb_writeback(struct bdi_writeback *wb,
+ {
+ 	unsigned long wb_start = jiffies;
+ 	long nr_pages = work->nr_pages;
+-	unsigned long dirtied_before = jiffies;
++	unsigned long oldest_jif;
+ 	struct inode *inode;
+ 	long progress;
+ 	struct blk_plug plug;
+ 
++	oldest_jif = jiffies;
++	work->older_than_this = &oldest_jif;
++
+ 	blk_start_plug(&plug);
+ 	spin_lock(&wb->list_lock);
+ 	for (;;) {
+@@ -1888,14 +1898,14 @@ static long wb_writeback(struct bdi_writeback *wb,
+ 		 * safe.
+ 		 */
+ 		if (work->for_kupdate) {
+-			dirtied_before = jiffies -
++			oldest_jif = jiffies -
+ 				msecs_to_jiffies(dirty_expire_interval * 10);
+ 		} else if (work->for_background)
+-			dirtied_before = jiffies;
++			oldest_jif = jiffies;
+ 
+ 		trace_writeback_start(wb, work);
+ 		if (list_empty(&wb->b_io))
+-			queue_io(wb, work, dirtied_before);
++			queue_io(wb, work);
+ 		if (work->sb)
+ 			progress = writeback_sb_inodes(work->sb, wb, work);
+ 		else
+diff --git a/include/trace/events/writeback.h b/include/trace/events/writeback.h
+index 67434278b81d..66282552db20 100644
+--- a/include/trace/events/writeback.h
++++ b/include/trace/events/writeback.h
+@@ -499,9 +499,8 @@ DEFINE_WBC_EVENT(wbc_writepage);
+ TRACE_EVENT(writeback_queue_io,
+ 	TP_PROTO(struct bdi_writeback *wb,
+ 		 struct wb_writeback_work *work,
+-		 unsigned long dirtied_before,
+ 		 int moved),
+-	TP_ARGS(wb, work, dirtied_before, moved),
++	TP_ARGS(wb, work, moved),
+ 	TP_STRUCT__entry(
+ 		__array(char,		name, 32)
+ 		__field(unsigned long,	older)
+@@ -511,17 +510,19 @@ TRACE_EVENT(writeback_queue_io,
+ 		__field(unsigned int,	cgroup_ino)
+ 	),
+ 	TP_fast_assign(
++		unsigned long *older_than_this = work->older_than_this;
+ 		strscpy_pad(__entry->name, bdi_dev_name(wb->bdi), 32);
+-		__entry->older	= dirtied_before;
+-		__entry->age	= (jiffies - dirtied_before) * 1000 / HZ;
++		__entry->older	= older_than_this ?  *older_than_this : 0;
++		__entry->age	= older_than_this ?
++				  (jiffies - *older_than_this) * 1000 / HZ : -1;
+ 		__entry->moved	= moved;
+ 		__entry->reason	= work->reason;
+ 		__entry->cgroup_ino	= __trace_wb_assign_cgroup(wb);
+ 	),
+ 	TP_printk("bdi %s: older=%lu age=%ld enqueue=%d reason=%s cgroup_ino=%u",
+ 		__entry->name,
+-		__entry->older,	/* dirtied_before in jiffies */
+-		__entry->age,	/* dirtied_before in relative milliseconds */
++		__entry->older,	/* older_than_this in jiffies */
++		__entry->age,	/* older_than_this in relative milliseconds */
+ 		__entry->moved,
+ 		__print_symbolic(__entry->reason, WB_WORK_REASON),
+ 		__entry->cgroup_ino

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -8,6 +8,7 @@ require linux-raspberrypi_5.4.inc
 SRC_URI += "file://0001-Revert-selftests-bpf-Skip-perf-hw-events-test-if-the.patch \
             file://0002-Revert-selftests-bpf-Fix-perf_buffer-test-on-systems.patch \
             file://0001-perf-cs-etm-Move-definition-of-traceid_list-global-v.patch \
+            file://0001-Revert-writeback-Fix-sync-livelock-due-to-b_dirty_ti.patch \
             file://powersave.cfg \
             file://android-drivers.cfg \
            "


### PR DESCRIPTION
…ules build

* fixes:
  lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:131:6: error: conflicting types for 'trace_writeback_queue_io'

* fixes:
  https://github.com/agherzan/meta-raspberrypi/pull/721