### PR TITLE
raspberrypi-{firmware,tools}: set downloadfilename

### DIFF
--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,6 +1,6 @@
 RPIFW_DATE ?= "20200911"
 SRCREV ?= "a490197f0672d948860b2b807884ae65eabc4d4f"
-RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz"
+RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz;downloadfilename=raspberrypi-firmware-${SRCREV}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
 
 SRC_URI = "${RPIFW_SRC_URI}"

--- a/recipes-bsp/common/raspberrypi-tools.inc
+++ b/recipes-bsp/common/raspberrypi-tools.inc
@@ -1,5 +1,5 @@
 SRCREV ?= "b0c869bc929587a7e1d20a98e2dc828a24ca396a"
-RPITOOLS_SRC_URI ?= "https://github.com/raspberrypi/tools/archive/${SRCREV}.tar.gz"
+RPITOOLS_SRC_URI ?= "https://github.com/raspberrypi/tools/archive/${SRCREV}.tar.gz;downloadfilename=raspberrypi-tools-${SRCREV}.tar.gz"
 RPITOOLS_S ?= "${WORKDIR}/tools-${SRCREV}"
 
 SRC_URI = "${RPITOOLS_SRC_URI}"


### PR DESCRIPTION
* otherwise we end with big archives in downloads directory without clear
  indication from where they came
* e.g. in one of my jenkins builds I've noticed:
```
  -rw-rw-r-- 1 jenkins jenkins 178M Jun 30 15:45 downloads/23548e550a757d368d3d5220373fe829b5961c42.tar.gz
  -rw-rw-r-- 1 jenkins jenkins 152M Sep  5  2019 downloads/7163480fff007dc98978899b556dcf06f8a462c8.tar.gz
  -rw-rw-r-- 1 jenkins jenkins 179M Jul 23 01:34 downloads/7e74bcb4f9706f36f752d1c3d3164628ccf2aae5.tar.gz
  -rw-rw-r-- 1 jenkins jenkins 178M Jun  5 12:34 downloads/7eff9f6774bb43bfd61e749a0b45ffddc98c2311.tar.gz
  -rw-rw-r-- 1 jenkins jenkins 177M Apr 23 14:49 downloads/84523e0b9a9e78aa69fca1f1a8d75b2bdb5155fc.tar.gz
  -rw-rw-r-- 1 jenkins jenkins 178M Jan 13  2020 downloads/9d6be5b07e81bdfb9c4b9a560e90fbc7477fdc6e.tar.gz
```
```
  -rw-rw-r-- 1 jenkins jenkins  463 Jul  1 03:58 downloads/23548e550a757d368d3d5220373fe829b5961c42.tar.gz.done
  -rw-rw-r-- 1 jenkins jenkins  141 Jan 16  2020 downloads/7163480fff007dc98978899b556dcf06f8a462c8.tar.gz.done
  -rw-rw-r-- 1 jenkins jenkins  463 Aug  1 15:40 downloads/7e74bcb4f9706f36f752d1c3d3164628ccf2aae5.tar.gz.done
  -rw-rw-r-- 1 jenkins jenkins  463 Jun  6 09:54 downloads/7eff9f6774bb43bfd61e749a0b45ffddc98c2311.tar.gz.done
  -rw-rw-r-- 1 jenkins jenkins  463 May 16 03:35 downloads/84523e0b9a9e78aa69fca1f1a8d75b2bdb5155fc.tar.gz.done
  -rw-rw-r-- 2 jenkins jenkins  141 Aug  7 22:10 downloads/9d6be5b07e81bdfb9c4b9a560e90fbc7477fdc6e.tar.gz.done
```

* unfortunately using git fetcher is still problematic because of git repo size:
  15G   firmware
  1,6G  tools

```
  -rw-rw-r-- 1 jenkins jenkins 180M Sep 17 13:59 downloads/raspberrypi-firmware-a490197f0672d948860b2b807884ae65eabc4d4f.tar.gz
  -rw-rw-r-- 1 jenkins jenkins  463 Sep 17 14:09 downloads/raspberrypi-firmware-a490197f0672d948860b2b807884ae65eabc4d4f.tar.gz.done
  -rw-rw-r-- 1 jenkins jenkins 324M Sep 17 14:10 downloads/raspberrypi-tools-b0c869bc929587a7e1d20a98e2dc828a24ca396a.tar.gz
  -rw-rw-r-- 1 jenkins jenkins  463 Sep 17 14:10 downloads/raspberrypi-tools-b0c869bc929587a7e1d20a98e2dc828a24ca396a.tar.gz.done
```

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>