### PR TITLE
Remove UART usage in U-Boot when ENABLE_UART=0

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -160,7 +160,7 @@ do_deploy() {
     fi
 
     # UART support
-    if [ "${ENABLE_UART}" = "1" ]; then
+    if [ "${ENABLE_UART}" = "1" -o "${RPI_USE_U_BOOT}" = "1" ]; then
         echo "# Enable UART" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
         echo "enable_uart=1" >>${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi


### PR DESCRIPTION
This fixes booting on Rasbpberry Pi 4 when config.txt doesn't
contain enable_uart=1. Seems like u-boot tries to write to serial
but serial doesn't exist and it stalls.
Related to issue: #732 


<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

