### PR TITLE
linux-raspberrypi_5.4.bb: Add kernel-cache source

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -1,7 +1,8 @@
 LINUX_VERSION ?= "5.4.64"
 LINUX_RPI_BRANCH ?= "rpi-5.4.y"
 
-SRCREV = "65caf603f3b1c43f4c92939f7fbb7149e054f486"
+SRCREV_machine = "65caf603f3b1c43f4c92939f7fbb7149e054f486"
+SRCREV_meta = "5d52d9eea95fa09d404053360c2351b2b91b323b"
 
 require linux-raspberrypi_5.4.inc
 

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.inc
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.inc
@@ -1,7 +1,10 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 
+KMETA = "kernel-meta"
+
 SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;branch=${LINUX_RPI_BRANCH} \
+    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.4;destsuffix=${KMETA} \
     "
 SRC_URI_remove = "file://rpi-kernel-misc.cfg"
 


### PR DESCRIPTION
Fixes the following error:
ERROR. input file "cfg/virtio.scc" does not exist

Signed-off-by: Murat Kilivan <murat.kilivan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
