### PR TITLE
Rpi eeprom upstream

### DIFF
--- a/recipes-bsp/rpi-eeprom/files/0001-rpi-eeprom-config-convert-sheabang-from-python-to-py.patch
+++ b/recipes-bsp/rpi-eeprom/files/0001-rpi-eeprom-config-convert-sheabang-from-python-to-py.patch
@@ -1,0 +1,27 @@
+From 6297ecd4a75667ae9e1756534f2c50d8b5e6f2ff Mon Sep 17 00:00:00 2001
+From: leckijakub <jakub.lecki@3mdeb.com>
+Date: Tue, 8 Sep 2020 12:35:42 +0200
+Subject: [PATCH] rpi-eeprom-config: convert sheabang from python to python3
+
+In Yocto/OE we use python3 rather than python
+
+Upstream-Status: Pending
+
+Signed-off-by: leckijakub <jakub.lecki@3mdeb.com>
+---
+ rpi-eeprom-config | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rpi-eeprom-config b/rpi-eeprom-config
+index af0d63b11b75..6950fac311e6 100755
+--- a/rpi-eeprom-config
++++ b/rpi-eeprom-config
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # rpi-eeprom-config
+ # Utility for reading and writing the configuration file in the
+-- 
+2.25.1
+

--- a/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
+++ b/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
@@ -1,0 +1,60 @@
+SUMMARY = "Installation scripts and binaries for the Raspberry Pi 4 EEPROM"
+DESCRIPTION = "This repository contains the rpi4 bootloader and scripts \
+for updating it in the spi eeprom"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7dcd1a1eb18ae569857c21cae81347cb"
+
+SRC_URI = " \
+    git://github.com/raspberrypi/rpi-eeprom.git;protocol=git \
+    file://0001-rpi-eeprom-config-convert-sheabang-from-python-to-py.patch \
+"
+
+S = "${WORKDIR}/git"
+
+SRCREV = "09f77ad9fa8655a28de754640e82ca67aabe6c33"
+
+RDEPENDS_${PN} += " \
+    coreutils \
+    python3 \
+    ${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "userlandtools", "userland", d)} \
+"
+
+PV = "0.0+git${SRCPV}"
+
+inherit python3native
+
+do_install() {
+    install -d ${D}${bindir}
+
+    # install executables
+    install -m 0755 ${S}/firmware/vl805 ${D}${bindir}
+    install -m 0755 ${S}/rpi-eeprom-update ${D}${bindir}
+    install -m 0755 ${S}/rpi-eeprom-config ${D}${bindir}
+
+    # copy firmware files
+    install -d ${D}${base_libdir}/firmware/raspberrypi/bootloader/critical
+    install -d ${D}${base_libdir}/firmware/raspberrypi/bootloader/stable
+    install -d ${D}${base_libdir}/firmware/raspberrypi/bootloader/beta
+
+    install -m 644 ${S}/firmware/critical/* ${D}${base_libdir}/firmware/raspberrypi/bootloader/critical
+    install -m 644 ${S}/firmware/stable/* ${D}${base_libdir}/firmware/raspberrypi/bootloader/stable
+    install -m 644 ${S}/firmware/beta/* ${D}${base_libdir}/firmware/raspberrypi/bootloader/beta
+
+    # copy default config
+    install -d ${D}${sysconfdir}/default
+    install -D ${S}/rpi-eeprom-update-default ${D}${sysconfdir}/default/rpi-eeprom-update
+}
+
+FILES_${PN} += " ${sbindir}/vl805"
+FILES_${PN} += "${base_libdir}/firmware/raspberrypi/bootloader/*"
+FILES_${PN} += "${sysconfdir}/*"
+
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
+# vl805 tool sources are not available (yet), as it comes as a precompiled
+# binary only. It has ARM architecture whereas target machine is Aarch64. We
+# need to disable arch check for it otherwise it cannot packed.
+QAPATHTEST[arch] = ""
+
+COMPATIBLE_MACHINE = "raspberrypi4-64"

--- a/recipes-graphics/userland/userland.inc
+++ b/recipes-graphics/userland/userland.inc
@@ -1,0 +1,38 @@
+DESCRIPTION = "This repository contains the source code for the ARM side \
+libraries used on Raspberry Pi. These typically are installed in /opt/vc/lib \
+and includes source for the ARM side code to interface to: EGL, mmal, GLESv2,\
+vcos, openmaxil, vchiq_arm, bcm_host, WFC, OpenVG."
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENCE;md5=0448d6488ef8cc380632b1569ee6d196"
+
+COMPATIBLE_MACHINE = "^rpi$"
+
+SRCBRANCH = "master"
+SRCFORK = "raspberrypi"
+SRCREV = "188d3bfe4a0ac36b119a2cee35a6be8d0c68e09e"
+
+# Use the date of the above commit as the package version. Update this when
+# SRCREV is changed.
+PV = "20200624"
+
+SRC_URI = "git://github.com/${SRCFORK}/userland.git;protocol=git;branch=${SRCBRANCH}"
+
+S = "${WORKDIR}/git"
+
+inherit cmake pkgconfig
+
+ASNEEDED = ""
+
+EXTRA_OECMAKE = "-DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS='-Wl,--no-as-needed' \
+                 -DVMCS_INSTALL_PREFIX=${exec_prefix} \
+"
+
+EXTRA_OECMAKE_append_aarch64 = " -DARM64=ON "
+
+# Shared libs from userland package  build aren't versioned, so we need
+# to force the .so files into the runtime package (and keep them
+# out of -dev package).
+FILES_SOLIBSDEV = ""
+INSANE_SKIP_${PN} += "dev-so"
+
+RDEPENDS_${PN} += "bash"

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -1,9 +1,4 @@
-DESCRIPTION = "This repository contains the source code for the ARM side \
-libraries used on Raspberry Pi. These typically are installed in /opt/vc/lib \
-and includes source for the ARM side code to interface to: EGL, mmal, GLESv2,\
-vcos, openmaxil, vchiq_arm, bcm_host, WFC, OpenVG."
-LICENSE = "BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://LICENCE;md5=0448d6488ef8cc380632b1569ee6d196"
+require userland.inc
 
 PROVIDES += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "", "virtual/libgles2 virtual/egl", d)}"
 PROVIDES += "virtual/libomxil"
@@ -11,16 +6,9 @@ PROVIDES += "virtual/libomxil"
 RPROVIDES_${PN} += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "", "libgles2 egl libegl libegl1 libglesv2-2", d)}"
 COMPATIBLE_MACHINE = "^rpi$"
 
-SRCBRANCH = "master"
-SRCFORK = "raspberrypi"
-SRCREV = "188d3bfe4a0ac36b119a2cee35a6be8d0c68e09e"
+RCONFLICTS_${PN} = "userlandtools"
 
-# Use the date of the above commit as the package version. Update this when
-# SRCREV is changed.
-PV = "20200624"
-
-SRC_URI = "\
-    git://github.com/${SRCFORK}/userland.git;protocol=git;branch=${SRCBRANCH} \
+SRC_URI += "\
     file://0001-Allow-applications-to-set-next-resource-handle.patch \
     file://0002-wayland-Add-support-for-the-Wayland-winsys.patch \
     file://0003-wayland-Add-Wayland-example.patch \
@@ -43,18 +31,6 @@ SRC_URI = "\
     file://0020-openmaxil-add-pkg-config-file.patch \
     file://0021-cmake-Disable-format-overflow-warning-as-error.patch \
 "
-S = "${WORKDIR}/git"
-
-inherit cmake pkgconfig
-
-ASNEEDED = ""
-
-EXTRA_OECMAKE = "-DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS='-Wl,--no-as-needed' \
-                 -DVMCS_INSTALL_PREFIX=${exec_prefix} \
-"
-
-EXTRA_OECMAKE_append_aarch64 = " -DARM64=ON "
-
 
 PACKAGECONFIG ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d)}"
 
@@ -83,12 +59,6 @@ do_install_append () {
 	fi
 }
 
-# Shared libs from userland package  build aren't versioned, so we need
-# to force the .so files into the runtime package (and keep them
-# out of -dev package).
-FILES_SOLIBSDEV = ""
-INSANE_SKIP_${PN} += "dev-so"
-
 FILES_${PN} += " \
     ${libdir}/*.so \
     ${libdir}/plugins"
@@ -97,5 +67,4 @@ FILES_${PN}-dev += "${includedir} \
 FILES_${PN}-doc += "${datadir}/install"
 FILES_${PN}-dbg += "${libdir}/plugins/.debug"
 
-RDEPENDS_${PN} += "bash"
 RDEPENDS_${PN} += "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "libegl-mesa", "", d)}"

--- a/recipes-graphics/userland/userlandtools_git.bb
+++ b/recipes-graphics/userland/userlandtools_git.bb
@@ -1,0 +1,33 @@
+require userland.inc
+
+RCONFLICTS_${PN} = "userland"
+
+# Keep only those libs & bins that are actually used during EEPROM update
+do_install_append () {
+    # move out the files we need  to a temproary location
+    install -d ${D}/../mvtmp${bindir} ${D}/../mvtmp${libdir}
+    mv ${D}${bindir}/dtoverlay ${D}${bindir}/vcgencmd \
+        ${D}${bindir}/vcmailbox ${D}/../mvtmp${bindir}
+    mv ${D}${libdir}/libdtovl.so ${D}${libdir}/libvchiq_arm.so \
+        ${D}${libdir}/libvcos.so ${D}/../mvtmp${libdir}
+
+    # remove everything within the image directory
+    rm -rf ${D}/*
+
+    # install back only the selected files
+    install -d ${D}${bindir} ${D}${libdir}
+    install -m 0755 ${D}/../mvtmp${bindir}/dtoverlay ${D}${bindir}/
+    install -m 0755 ${D}/../mvtmp${bindir}/vcgencmd ${D}${bindir}/
+    install -m 0755 ${D}/../mvtmp${bindir}/vcmailbox ${D}${bindir}/
+    ln -s dtoverlay ${D}${bindir}/dtparam
+    install -m 0644 ${D}/../mvtmp${libdir}/libdtovl.so ${D}${libdir}/
+    install -m 0644 ${D}/../mvtmp${libdir}/libvchiq_arm.so ${D}${libdir}/
+    install -m 0644 ${D}/../mvtmp${libdir}/libvcos.so ${D}${libdir}/
+
+    # cleanup temporary directory
+    rm -rf ${D}/../mvtmp
+}
+
+FILES_${PN} += "${libdir}/*.so"
+
+COMPATIBLE_MACHINE = "raspberrypi4-64"


### PR DESCRIPTION
Fixes: https://github.com/agherzan/meta-raspberrypi/issues/515

**- What I did**
- added rpi-eeprom recipe to allow EEPROM firmware update on the RPI4 devices
- added userlandtools recipe, which provides part of the userland tools required for EEPROM update

**- How I did it**
- inspired by the recipes from Balena
- more detailed description in the commit messages
- tested only on dunfell so far, that is why this PR targets dunfell