### PR TITLE
linux-raspberrypi-5.4: bump SRCREV to fix raspberrypi3-64 builds

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -1,7 +1,7 @@
 LINUX_VERSION ?= "5.4.69"
 LINUX_RPI_BRANCH ?= "rpi-5.4.y"
 
-SRCREV_machine = "69b14a2e6d4e840c7609370dbf0bac847c3bb15c"
+SRCREV_machine = "31d364af258ff9754a1a9c7d8ea532da962797bd"
 SRCREV_meta = "5d52d9eea95fa09d404053360c2351b2b91b323b"
 
 require linux-raspberrypi_5.4.inc


### PR DESCRIPTION
* fixes:
  https://github.com/raspberrypi/linux/issues/3885

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>