### PR TITLE
python3-rtimu: don't use trailing slash in S

### DIFF
--- a/recipes-devtools/python/python3-rtimu_git.bb
+++ b/recipes-devtools/python/python3-rtimu_git.bb
@@ -10,6 +10,6 @@ SRC_URI = "git://github.com/RPi-Distro/RTIMULib.git;protocol=http;branch=master 
           "
 SRCREV = "b949681af69b45f0f7f4bb53b6770037b5b02178"
 
-S = "${WORKDIR}/git/Linux/python/"
+S = "${WORKDIR}/git/Linux/python"
 
 inherit setuptools3


### PR DESCRIPTION
* see oe-core base.bbclass changes from:
  https://lists.openembedded.org/g/openembedded-core/message/143159
  https://lists.openembedded.org/g/openembedded-core/message/143161

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>