### PR TITLE
linux-raspberrypi: Only deploy cmdline.txt for the main kernel

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -130,11 +130,13 @@ do_compile_append() {
 }
 
 do_deploy_append() {
-    # Deploy cmdline.txt
-    install -d ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}
-    PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
-    if [ ${PITFT} = "1" ]; then
-        PITFT_PARAMS="fbcon=map:10 fbcon=font:VGA8x8"
+    # Deploy cmdline.txt only for the main kernel package
+    if [ ${KERNEL_PACKAGE_NAME} = "kernel" ]; then
+        install -d ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}
+        PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
+        if [ ${PITFT} = "1" ]; then
+            PITFT_PARAMS="fbcon=map:10 fbcon=font:VGA8x8"
+        fi
+        echo "${CMDLINE}${PITFT_PARAMS}" > ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/cmdline.txt
     fi
-    echo "${CMDLINE}${PITFT_PARAMS}" > ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/cmdline.txt
 }


### PR DESCRIPTION
When multiple kernels are being built, not all of them can deploy the
same file.

This patch assumes the same command line arguments is used by all kernels.

Related to https://github.com/agherzan/meta-raspberrypi/pull/736

