### PR TITLE
libcamera: Enabled camera overlays define based

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -42,6 +42,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/w1-gpio.dtbo \
     overlays/gpio-ir.dtbo \
     overlays/gpio-ir-tx.dtbo \
+    overlays/imx219.dtbo \
     "
 
 RPI_KERNEL_DEVICETREE ?= " \

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -326,3 +326,17 @@ option:
         # Raspberry Pi 7\" display/touch screen \n \
         lcd_rotate=2 \n \
         '
+## Enable Raspberrypi Camera V2
+
+RaspberryPi does not have the unicam device ( RaspberryPi Camera ) enabled by default.
+Because this unicam device ( bcm2835-unicam ) as of now is used by libcamera opensource.
+So we have to explicitly set in local.conf.
+
+    RASPBERRYPI_CAMERA_V2 = "1"
+
+This will add the device tree overlays imx219 ( RaspberryPi Camera sensor V2 driver ) to config.txt.
+Also, this will enable adding Contiguous Memory Allocation value in the cmdline.txt.
+
+Ref.:
+* <https://github.com/raspberrypi/documentation/blob/master/linux/software/libcamera/README.md>
+* <https://www.raspberrypi.org/blog/an-open-source-camera-stack-for-raspberry-pi-using-libcamera/>

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -178,6 +178,12 @@ do_deploy() {
         echo "dtoverlay=${VC4DTBO}" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
     fi
 
+    # Choose Camera Sensor to be used, default imx219 sensor
+    if [ "${RASPBERRYPI_CAMERA_V2}" = "1" ]; then
+        echo "# Enable Sony RaspberryPi Camera" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+        echo "dtoverlay=imx219" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+    fi
+
     # Waveshare "C" 1024x600 7" Rev2.1 IPS capacitive touch (http://www.waveshare.com/7inch-HDMI-LCD-C.htm)
     if [ "${WAVESHARE_1024X600_C_2_1}" = "1" ]; then
         echo "# Waveshare \"C\" 1024x600 7\" Rev2.1 IPS capacitive touch screen" >> ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -27,7 +27,8 @@ LINUX_VERSION_EXTENSION ?= ""
 
 # CMDLINE for raspberrypi
 SERIAL = "${@oe.utils.conditional("ENABLE_UART", "1", "console=serial0,115200", "", d)}"
-CMDLINE ?= "dwc_otg.lpm_enable=0 ${SERIAL} root=/dev/mmcblk0p2 rootfstype=ext4 rootwait"
+CMA ?= "${@oe.utils.conditional("RASPBERRYPI_CAMERA_V2", "1", "cma=64M", "", d)}"
+CMDLINE ?= "dwc_otg.lpm_enable=0 ${SERIAL} root=/dev/mmcblk0p2 rootfstype=ext4 rootwait ${CMA}"
 
 # Add the kernel debugger over console kernel command line option if enabled
 CMDLINE_append = ' ${@oe.utils.conditional("ENABLE_KGDB", "1", "kgdboc=serial0,115200", "", d)}'


### PR DESCRIPTION
Added imx219.dtbo file in the overlays, and added dtoverlay in
/boot/config.txt define based.

To enable SOny Raspberry pi camera imx219 sensor, need to set
the variable ENABLE_CAMERA_OVERLAY as 1.

In future, we can add any camera overlays here to support and
use them with libcamera.

Signed-off-by: Madhavan Krishnan <madhavan.krishnan@linaro.org>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
