### PR TITLE
linux-raspberrypi: bump to Linux version 5.4.72

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -1,7 +1,7 @@
-LINUX_VERSION ?= "5.4.59"
+LINUX_VERSION ?= "5.4.72"
 LINUX_RPI_BRANCH ?= "rpi-5.4.y"
 
-SRCREV_machine = "423495b33efd681dc1c8be10b1303e679216be4c"
+SRCREV_machine = "154de7bbd5844a824a635d4f9e3f773c15c6ce11"
 SRCREV_meta = "5d52d9eea95fa09d404053360c2351b2b91b323b"
 
 require linux-raspberrypi_5.4.inc


### PR DESCRIPTION
Tested on CM3

```## Booting kernel from Legacy Image at 00080000 ...
   Image Name:   Linux-5.4.72-v7
   Image Type:   ARM Linux Kernel Image (uncompressed)
   Data Size:    6062056 Bytes = 5.8 MiB
   Load Address: 00008000
   Entry Point:  00008000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 2eff9200
   Booting using the fdt blob at 0x2eff9200
   Loading Kernel Image
   Using Device Tree in place at 2eff9200, end 2f002f3f

Starting kernel ...
```

I also verified that the bleeding tooth proof of concept does not work anymore https://github.com/google/security-research/security/advisories/GHSA-h637-c88j-47wq
