### PR TITLE
userland: Apply format-overflow warning patch for gcc alone

### DIFF
--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -43,6 +43,9 @@ SRC_URI = "\
     file://0020-openmaxil-add-pkg-config-file.patch \
     file://0021-cmake-Disable-format-overflow-warning-as-error.patch \
 "
+
+SRC_URI_remove_toolchain-clang = "file://0021-cmake-Disable-format-overflow-warning-as-error.patch"
+
 S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig


### PR DESCRIPTION
This warning is gcc specific and causes build failures when building
with clang, lets therefore remove it when build is using clang compiler

Signed-off-by: Khem Raj <raj.khem@gmail.com>
