### PR TITLE
[dunfell] layer.conf: Remove older releases from LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "raspberrypi"
 BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
-LAYERSERIES_COMPAT_raspberrypi = "sumo thud warrior zeus dunfell"
+LAYERSERIES_COMPAT_raspberrypi = "dunfell"
 
 # Additional license directories.
 LICENSE_PATH += "${LAYERDIR}/files/custom-licenses"


### PR DESCRIPTION
* since
  https://github.com/agherzan/meta-raspberrypi/commit/36c3c2e7ca09806da460328767565bbf872a6ad8
  which renamed gstreamer1.0-omx_1.14%.bbappend to gstreamer1.0-omx_1.16%.bbappend it didn't
  parse with zeus and older
* with zeus it parses OK, but I believe people who use meta-raspberrypi
  from dunfell branch in zeus builds should rather ask for backports they
  are missing in zeus branch