### PR TITLE
Revert "libcamera: Define packageconfig to enable rpi pipeline"

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -31,8 +31,6 @@ BBFILES_DYNAMIC += " \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bb \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bbappend \
-    multimedia-layer:${LAYERDIR}/dynamic-layers/multimedia-layer/*/*/*.bb \
-    multimedia-layer:${LAYERDIR}/dynamic-layers/multimedia-layer/*/*/*.bbappend \
 "
 
 DEFAULT_TEST_SUITES_remove_rpi = "parselogs"

--- a/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera/libcamera.bbappend
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera/libcamera.bbappend
@@ -1,2 +1,0 @@
-PACKAGECONFIG[raspberrypi] = "-Dpipelines=raspberrypi"
-PACKAGECONFIG_append_rpi = " raspberrypi"


### PR DESCRIPTION
This reverts commit a27f10b76cb1dbf089a3f0980e97f1931b090f17.

This was backported to dunfell together with many other changes in:
https://github.com/agherzan/meta-raspberrypi/pull/754

but 202002 version in dunfell fails with:
ERROR: QA Issue: libcamera: configure was passed unrecognised options: pipelines [unknown-configure-option]

202008 version in gatesgarth is fine, it was added in March:
https://git.linuxtv.org/libcamera.git/commit/meson_options.txt?id=ee7e2c93dfbf34b3500c895115c516e5e90d3e31

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>