### PR TITLE
cairo bbappend: remove egl with userland

### DIFF
--- a/recipes-graphics/cairo/cairo_%.bbappend
+++ b/recipes-graphics/cairo/cairo_%.bbappend
@@ -1,3 +1,3 @@
 PACKAGECONFIG_GLESV2 = " ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'glesv2', d)}"
 
-PACKAGECONFIG_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' egl ${PACKAGECONFIG_GLESV2}', d)}"
+PACKAGECONFIG_append_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' ${PACKAGECONFIG_GLESV2}', d)}"


### PR DESCRIPTION
When using the userland graphics (i.e. DISABLE_VC4GRAPHICS) cairo isn't able
to use the provided EGL:

	| checking for cairo's EGL functions feature...
	| checking whether cairo's EGL functions feature could be enabled... no (not required by any backend)
	| configure: error:  EGL functions feature could not be enabled

Signed-off-by: Trevor Woerner <twoerner@gmail.com>