### PR TITLE
mesa-gl: Enable swrast dri backend for rpi/userland

### DIFF
--- a/recipes-graphics/mesa/mesa-gl_%.bbappend
+++ b/recipes-graphics/mesa/mesa-gl_%.bbappend
@@ -1,6 +1,8 @@
 PACKAGECONFIG_append_rpi = " gbm"
 PROVIDES_append_rpi = " virtual/libgbm"
 
+DRIDRIVERS_append_rpi = ",swrast"
+
 do_install_append_rpi() {
     rm -rf ${D}${includedir}/KHR/khrplatform.h
 }


### PR DESCRIPTION
After mesa switched build system to meson, the logic to generate dri
related artifacts changed too, which means when no dri backend is
enabled then dri drivers and corresponding headers dont get generated
and hence we end up with missing pkgconfig files e.g. dri.pc which
usually will come from full mesa3d package, but in rpi when userland is
used we only build GL pieces of mesa.

This patch therefore enables swrast dri backend when using userland,
which gives us the needed header and .pc files to build packages like
Xorg server, since EGL driver will come from userland, the dri backend
would be unused and hence should not be effective at runtime.

Addresses issue report with https://github.com/agherzan/meta-raspberrypi/pull/773

Signed-off-by: Khem Raj <raj.khem@gmail.com>
Cc: Trevor Woerner <twoerner@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
