### PR TITLE
Add brcmfmac43456-sdio for Pi400 and CM4

### DIFF
--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -8,6 +8,7 @@ SECTION = "kernel"
 # In maintained upstream linux-firmware:
 # * brcmfmac43430-sdio falls under LICENCE.cypress
 # * brcmfmac43455-sdio falls under LICENCE.broadcom_bcm43xx
+# * brcmfmac43456-sdio falls under LICENCE.broadcom_bcm43xx
 #
 # It is likely[^1] that both of these should be under LICENCE.cypress.
 # Further, at this time the text of LICENCE.broadcom_bcm43xx is the same
@@ -35,8 +36,8 @@ NO_GENERIC_LICENSE[WHENCE] = "WHENCE"
 
 SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree"
 
-SRCREV = "98e815735e2c805d65994ccc608f399595b74438"
-PV = "20190114-1+rpt8"
+SRCREV = "b66ab26cebff689d0d3257f56912b9bb03c20567"
+PV = "20190114-1+rpt10"
 
 S = "${WORKDIR}/git"
 
@@ -56,7 +57,7 @@ do_install() {
     # Replace outdated linux-firmware files with updated ones from
     # raspbian firmware-nonfree. Raspbian adds blobs and nvram
     # definitions that are also necessary so copy those too.
-    for fw in brcmfmac43430-sdio brcmfmac43455-sdio ; do
+    for fw in brcmfmac43430-sdio brcmfmac43455-sdio brcmfmac43456-sdio ; do
         install -m 0644 brcm/${fw}.* ${D}${nonarch_base_libdir}/firmware/brcm/
     done
     # add compat links. Fixes errors like
@@ -71,16 +72,20 @@ PACKAGES = "\
     ${PN}-broadcom-license \
     ${PN}-bcm43430 \
     ${PN}-bcm43455 \
+    ${PN}-bcm43456 \
 "
 
 LICENSE_${PN}-bcm43430 = "Firmware-broadcom_bcm43xx-rpidistro"
 LICENSE_${PN}-bcm43455 = "Firmware-broadcom_bcm43xx-rpidistro"
+LICENSE_${PN}-bcm43456 = "Firmware-broadcom_bcm43xx-rpidistro"
 LICENSE_${PN}-broadcom-license = "Firmware-broadcom_bcm43xx-rpidistro"
 FILES_${PN}-broadcom-license = "${nonarch_base_libdir}/firmware/LICENCE.broadcom_bcm43xx-rpidistro"
 FILES_${PN}-bcm43430 = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43430*"
 FILES_${PN}-bcm43455 = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43455*"
+FILES_${PN}-bcm43456 = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43456*"
 RDEPENDS_${PN}-bcm43430 += "${PN}-broadcom-license"
 RDEPENDS_${PN}-bcm43455 += "${PN}-broadcom-license"
+RDEPENDS_${PN}-bcm43456 += "${PN}-broadcom-license"
 RCONFLICTS_${PN}-bcm43430 = "\
     linux-firmware-bcm43430 \
     linux-firmware-raspbian-bcm43430 \
@@ -96,6 +101,14 @@ RCONFLICTS_${PN}-bcm43455 = "\
 RREPLACES_${PN}-bcm43455 = "\
     linux-firmware-bcm43455 \
     linux-firmware-raspbian-bcm43455 \
+"
+RCONFLICTS_${PN}-bcm43456 = "\
+    linux-firmware-bcm43456 \
+    linux-firmware-raspbian-bcm43456 \
+"
+RREPLACES_${PN}-bcm43456 = "\
+    linux-firmware-bcm43456 \
+    linux-firmware-raspbian-bcm43456 \
 "
 
 # Firmware files are generally not run on the CPU, so they can be


### PR DESCRIPTION
Pi400 and CM4 use brcmfmac43456-sdio

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Pi 400 and CM4 use the Broadcom BCM43456 WiFi chip instead of the BCM43455 in the Pi 4. This adds support.

**- How I did it**

Pull in the firmware files for brcmfmac43456-sdio from the RPi-Distro repo