### PR TITLE
raspidmx: Disable for all non-rpi hosts

### DIFF
--- a/recipes-graphics/raspidmx/raspidmx_git.bb
+++ b/recipes-graphics/raspidmx/raspidmx_git.bb
@@ -4,6 +4,7 @@ SECTION = "graphics"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=52962875ab02c36df6cde47b1f463024"
 
+COMPATIBLE_HOST = "null"
 COMPATIBLE_HOST_rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'null', '(.*)', d)}"
 
 SRC_URI = "git://github.com/AndrewFromMelbourne/raspidmx;protocol=https \


### PR DESCRIPTION
Currently its only disabled when vc4graphics is in use but this recipe
actually needs userland and therefore can not be used for non-rpi
machines as well.

Signed-off-by: Khem Raj <raj.khem@gmail.com>

