### PR TITLE
Add overlay to allow 64 bit usage with CM3

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -53,8 +53,10 @@ RPI_KERNEL_DEVICETREE ?= " \
     bcm2710-rpi-3-b.dtb \
     bcm2710-rpi-3-b-plus.dtb \
     bcm2711-rpi-4-b.dtb \
+    bcm2711-rpi-400.dtb \
     bcm2708-rpi-cm.dtb \
     bcm2710-rpi-cm3.dtb \
+    bcm2711-rpi-cm4.dtb \
     "
 
 KERNEL_DEVICETREE ??= " \

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -46,10 +46,13 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     "
 
 RPI_KERNEL_DEVICETREE ?= " \
+    bcm2708-rpi-zero.dtb \
     bcm2708-rpi-zero-w.dtb \
     bcm2708-rpi-b.dtb \
+    bcm2708-rpi-b-rev1.dtb \
     bcm2708-rpi-b-plus.dtb \
     bcm2709-rpi-2-b.dtb \
+    bcm2710-rpi-2-b.dtb \
     bcm2710-rpi-3-b.dtb \
     bcm2710-rpi-3-b-plus.dtb \
     bcm2711-rpi-4-b.dtb \

--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -18,6 +18,7 @@ RPI_KERNEL_DEVICETREE = " \
     broadcom/bcm2710-rpi-3-b.dtb \
     broadcom/bcm2710-rpi-3-b-plus.dtb \
     broadcom/bcm2837-rpi-3-b.dtb \
+    broadcom/bcm2710-rpi-cm3.dtb \
     "
 
 SERIAL_CONSOLES ?= "115200;ttyS0"

--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -15,6 +15,8 @@ include conf/machine/include/rpi-base.inc
 
 RPI_KERNEL_DEVICETREE = " \
     broadcom/bcm2711-rpi-4-b.dtb \
+    broadcom/bcm2711-rpi-400.dtb \
+    broadcom/bcm2711-rpi-cm4.dtb \
 "
 
 SDIMG_KERNELIMAGE ?= "kernel8.img"


### PR DESCRIPTION
Add overlay to allow 64 bit usage with CM3

Change-type: patch
Signed-off-by: Aaron Shaw <aaron@balena.io>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Add CM3 overlay so you can use CM3 in 64 bit mode

**- How I did it**

Add overlay to conf file