### PR TITLE
linux-raspberry: Drop 64-bit specific do_compile_append()

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -34,10 +34,3 @@ KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", 
 # set by default in rpi-4.8.y and later branches so we need to provide it
 # manually. This value unused if KERNEL_IMAGETYPE is not uImage.
 KERNEL_EXTRA_ARGS += "LOADADDR=0x00008000"
-
-do_compile_append() {
-    if [ "${SITEINFO_BITS}" = "64" ]; then
-        cc_extra=$(get_cc_option)
-        oe_runmake dtbs CC="${KERNEL_CC} $cc_extra " LD="${KERNEL_LD}" ${KERNEL_EXTRA_ARGS}
-    fi
-}


### PR DESCRIPTION
The functionality provided by this compile append is already present in
kernel-devicetree.bbclass since oe-core commit:
https://github.com/openembedded/openembedded-core/commit/74619de02774

The md5sums of the generated dtbs for raspberrypi3-64 and raspberrypi4-64 do
not change with this patch applied.

Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
