### PR TITLE
machine: use weak default for kernel and KERNEL_DEVICETREE settings

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -57,7 +57,7 @@ RPI_KERNEL_DEVICETREE ?= " \
     bcm2710-rpi-cm3.dtb \
     "
 
-KERNEL_DEVICETREE ?= " \
+KERNEL_DEVICETREE ??= " \
     ${RPI_KERNEL_DEVICETREE} \
     ${RPI_KERNEL_DEVICETREE_OVERLAYS} \
     "

--- a/conf/machine/include/rpi-default-providers.inc
+++ b/conf/machine/include/rpi-default-providers.inc
@@ -1,6 +1,6 @@
 # RaspberryPi BSP default providers
 
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-raspberrypi"
+PREFERRED_PROVIDER_virtual/kernel ??= "linux-raspberrypi"
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 PREFERRED_PROVIDER_virtual/egl ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "mesa", "userland", d)}"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "mesa", "userland", d)}"


### PR DESCRIPTION
**Updated PR description:**

To allow other layers to easily provide a default kernel preference to use with the Raspberry Pi MACHINEs, switch to use the `??=` assignment operator for setting the default kernel and the device tree value in this layer.

This change is motivated by enabling Xen support in meta-virtualization to use the raspberrypi4-64 MACHINE definition from this layer with the Yocto Linux kernels.

Signed-off-by: Christopher Clark <christopher.w.clark@gmail.com>



**The previous PR description with the original commits that were proposed, and have since been replaced, was:**
_machine: add vendorkernel to MACHINE_FEATURES for default kernel pref_

Xen support in the meta-virtualization layer uses the raspberrypi4-64
MACHINE definition from this layer with the Yocto Linux kernels rather
than the board-vendor-provided linux-raspberrypi kernel.

To improve support for selecting the kernel, introduce vendorkernel into
the available MACHINE_FEATURES: this sets the default kernel preference
and the inclusion of the Raspberry Pi kernel device tree overlays to
match the kernel. Add a DISABLE_VENDORKERNEL variable for ease of
toggling the default in meta-virtualization.

Since Xen support on the Raspberry Pi 4 board requires at least Linux
5.9, with 5.10 preferred, the non-vendor kernel default preference is
currently set to linux-yocto-dev.

Signed-off-by: Christopher Clark <christopher.w.clark@gmail.com>