### PR TITLE
Enable use of 'RPI_EXTRA_CONFIG += ...' in local.conf

### DIFF
--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -31,6 +31,6 @@ KERNEL_IMAGETYPE_UBOOT ?= "Image"
 KERNEL_IMAGETYPE_DIRECT ?= "Image"
 KERNEL_BOOTCMD ?= "booti"
 
-RPI_EXTRA_CONFIG ?= "\n# Force arm in 64bit mode. See: https://github.com/raspberrypi/firmware/issues/1193.\narm_64bit=1"
+RPI_EXTRA_CONFIG += "\n# Force arm in 64bit mode. See: https://github.com/raspberrypi/firmware/issues/1193.\narm_64bit=1"
 
 ARMSTUB ?= "armstub8-gic.bin"


### PR DESCRIPTION
Enable the use of RPI_EXTRA_CONFIG when targeting 64bit images on PI4.

Before this patch, use of RPI_EXTRA_CONFIG += in a local.conf would overwrite
the needed 'arm_64bit=1' defined in the core recipes.  The net result would be
a system that did not boot.

This patch fixes the assignment of 'arm_64bit=1' even if RPI_EXTRA_CONFIG
has been set elsewhere.

Signed-off-by: Your Name matthew@thespencers.me.uk