### PR TITLE
Kernel updates and minor config tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build*
 *.rej
 *.log
 docs/_build
+/layers

--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -22,7 +22,7 @@ RPI_KERNEL_DEVICETREE = " \
 
 SERIAL_CONSOLES ?= "115200;ttyS0"
 
-UBOOT_MACHINE = "rpi_3_config"
+UBOOT_MACHINE = "rpi_arm64_config"
 
 # When u-boot is enabled we need to use the "Image" format and the "booti"
 # command to load the kernel

--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -20,7 +20,7 @@ RPI_KERNEL_DEVICETREE = " \
 SDIMG_KERNELIMAGE ?= "kernel8.img"
 SERIAL_CONSOLES ?= "115200;ttyS0"
 
-UBOOT_MACHINE = "rpi_4_config"
+UBOOT_MACHINE = "rpi_arm64_config"
 
 VC4DTBO ?= "vc4-fkms-v3d"
 

--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -31,6 +31,4 @@ KERNEL_IMAGETYPE_UBOOT ?= "Image"
 KERNEL_IMAGETYPE_DIRECT ?= "Image"
 KERNEL_BOOTCMD ?= "booti"
 
-RPI_EXTRA_CONFIG += "\n# Force arm in 64bit mode. See: https://github.com/raspberrypi/firmware/issues/1193.\narm_64bit=1"
-
 ARMSTUB ?= "armstub8-gic.bin"

--- a/kas-poky-rpi.yml
+++ b/kas-poky-rpi.yml
@@ -11,6 +11,7 @@ repos:
 
   poky:
     url: https://git.yoctoproject.org/git/poky
+    path: layers/poky
     refspec: master
     layers:
       meta:
@@ -19,6 +20,7 @@ repos:
 
   meta-openembedded:
     url: http://git.openembedded.org/meta-openembedded
+    path: layers/meta-openembedded
     refspec: master
     layers:
       meta-oe:
@@ -28,6 +30,7 @@ repos:
 
   meta-qt5:
     url: https://github.com/meta-qt5/meta-qt5/
+    path: layers/meta-qt5
     refspec: master
 
 bblayers_conf_header:

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -2,7 +2,7 @@ LINUX_VERSION ?= "5.4.83"
 LINUX_RPI_BRANCH ?= "rpi-5.4.y"
 
 SRCREV_machine = "08ae2dd9e7dc89c20bff823a3ef045de09bfd090"
-SRCREV_meta = "5d52d9eea95fa09d404053360c2351b2b91b323b"
+SRCREV_meta = "d676bf5ff7b7071e14f44498d2482c0a596f14cd"
 
 KMETA = "kernel-meta"
 

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -1,7 +1,7 @@
-LINUX_VERSION ?= "5.4.79"
+LINUX_VERSION ?= "5.4.83"
 LINUX_RPI_BRANCH ?= "rpi-5.4.y"
 
-SRCREV_machine = "9797f1a4938c20139b00a25de93cc99efb5c291b"
+SRCREV_machine = "08ae2dd9e7dc89c20bff823a3ef045de09bfd090"
 SRCREV_meta = "5d52d9eea95fa09d404053360c2351b2b91b323b"
 
 KMETA = "kernel-meta"


### PR DESCRIPTION
* Update the kernel & yocto-kernel-cache to the latest upstream commits.
* Use unified u-boot config for 64-bit targets.
* We no longer need to force `arm_64bit=1` to boot Raspberry Pi 4 in 64-bit mode.
* Tidy up kas builds a little: Place cloned layers under a `layers` subdirectory and ignore this from git.