### PR TITLE
'inherit kernel' is already required

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -8,7 +8,7 @@ COMPATIBLE_MACHINE = "^rpi$"
 PE = "1"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
-inherit kernel siteinfo
+inherit siteinfo
 require recipes-kernel/linux/linux-yocto.inc
 
 SRC_URI += " \


### PR DESCRIPTION
'recipes-kernel/linux/linux-yocto.inc' already inherits 'kernel'.
This commit removes the superfluous one.

Resolves #797.