### PR TITLE
linux-raspberrypi: pass dtc flags via KERNEL_DTC_FLAGS

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -24,7 +24,7 @@ require linux-raspberrypi.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-KERNEL_EXTRA_ARGS += "DTC_FLAGS='-@ -H epapr'"
+KERNEL_DTC_FLAGS += "-@ -H epapr"
 
 # Disable version check so that we don't have to edit this recipe every time
 # upstream bumps the version

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -19,4 +19,4 @@ require linux-raspberrypi.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-KERNEL_EXTRA_ARGS += "DTC_FLAGS='-@ -H epapr'"
+KERNEL_DTC_FLAGS += "-@ -H epapr"


### PR DESCRIPTION
Currently, the do_compile log is cluttered with dtc warnings that should only
be printed when compiling with W="123":
...
/soc: node has a reg or ranges property, but no unit name
/soc/gpu: missing or empty reg/ranges property
/soc/firmware/gpio: missing or empty reg/ranges property
...

This happens because we pass dtc flags via KERNEL_EXTRA_ARGS directly on the
make command line, preventing scripts/Makefile.lib logic from appending flags
that silence dtc warnings (all assignments done from within a makefile, to a
variable specified on the command line, are ignored).

oe-core commit [1] introduced the dedicated KERNEL_DTC_FLAGS variable to pass
dtc flags via the environment. Use this variable to get rid of the do_compile
log noise.

The md5sums of the generated dtbs for raspberrypi3-64 and raspberrypi4-64 do
not change with this patch applied.

[1] https://github.com/openembedded/openembedded-core/commit/063b5de86624

Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
