### PR TITLE
rpi-config: comment updated

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -118,10 +118,15 @@ do_deploy() {
 
     # Video camera support
     if [ "${VIDEO_CAMERA}" = "1" ]; then
-        # TODO: It has been observed that Raspberry Pi 4B 4GB may fail to enable the camera if "start_x=1" is at the end
-        #       of the file. The underlying cause is unknown, but it can be related with a file size limitation affecting
-        #       this variable. Therefore, "start_x=1" has been set to replace the original occurrence in config.txt,
-        #       which is at the middle of the file.
+        #   It has been observed that Raspberry Pi 4B 4GB may fail to enable the
+        # camera if "start_x=1" is at the end of the file. Therefore,
+        # "start_x=1" has been set to replace the original occurrence in
+        # config.txt, which is at the middle of the file.
+        #   The exact underlying cause is unknown. There are similar issues
+        # reported in the raspberrypi/firware repo and the conclusion reached
+        # was that there could be a file size limitation affecting certain
+        # variables. It was commented that this limitation could be 4k but
+        # not proved.
         sed -i '/#start_x=/ c\start_x=1' $CONFIG
     fi
 


### PR DESCRIPTION
Hi,

I opened a thread in raspberrypi forum: https://www.raspberrypi.org/forums/viewtopic.php?f=66&t=298129 regarding the issue tackled in https://github.com/agherzan/meta-raspberrypi/commit/74deec51ded5b22b31b69b30537a6e9ed0997aea, and I got answered that there could be a "4K limit on reading config.txt in certain circumstances", and there was a similar case in which another variable was affected: https://github.com/raspberrypi/firmware/issues/1012

They also suggested to do not use the commented version file because it can very slightly increase the booting time as the firmware has more to parse.

Regards