### PR TITLE
rpi-config: Add support for CM4 host USB

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -269,6 +269,15 @@ local.conf:
 
     ENABLE_DWC2_PERIPHERAL = "1"
 
+## Enable USB host support
+
+By default in case of the Compute Module 4 IO Board the standard USB driver
+that usually supports host mode operations is disabled for power saving reasons.
+Users who want to use the 2 USB built-in ports or the other ports provided via
+the header extension should set the following in local.conf:
+
+    ENABLE_DWC2_HOST = "1"
+
 ## Enable Openlabs 802.15.4 radio module
 
 When using device tree kernels, set this variable to enable the 802.15.4 hat:

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -204,6 +204,12 @@ do_deploy() {
         echo "dtoverlay=dwc2,dr_mode=peripheral" >> $CONFIG
     fi
 
+    # DWC2 USB host mode support
+    if [ "${ENABLE_DWC2_HOST}" = "1" ]; then
+        echo "# Enable USB host mode" >> $CONFIG
+        echo "dtoverlay=dwc2,dr_mode=host" >> $CONFIG
+    fi
+
     # AT86RF23X support
     if [ "${ENABLE_AT86RF}" = "1" ]; then
         echo "# Enable AT86RF23X" >>$CONFIG


### PR DESCRIPTION
By default in case of CM4 IO board, the USB ports (header + built-in)
are disabled. In order to enable them the DWC2 mode needs to be set to
host.

Signed-off-by: Aurelian Zanoschi <aurelian17@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
Added support for dwc2 host mode.

**- How I did it**
Modified the rpi-config recipe to support dwc2 host mode when ENABLE_DWC2_HOST option is enabled in conf.