### PR TITLE
rpi-cmdline: remove unnecessary spaces from cmdline.txt

### DIFF
--- a/recipes-bsp/bootfiles/rpi-cmdline.bb
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bb
@@ -37,7 +37,7 @@ CMDLINE = " \
     "
 
 do_compile() {
-    echo "${CMDLINE}" > "${WORKDIR}/cmdline.txt"
+    echo "${@' '.join('${CMDLINE}'.split())}" > "${WORKDIR}/cmdline.txt"
 }
 
 do_deploy() {


### PR DESCRIPTION
With current recipe formatting CMDLINE variable contains
many unnecessary white spaces. This patch allow to drop
unnecessary spaces at the moment of writing them to
cmdline.txt. This will improve readability of cmdline.txt,
/proc/cmdline and dmesg output.

Signed-off-by: Bartłomiej Burdukiewicz <bartlomiej.burdukiewicz@gmail.com>
