### PR TITLE
sdcard_image-rpi.bbclass: increase default boot partition size from 40MiB to 48MiB

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -13,14 +13,14 @@ inherit image_types
 #                                                     Default Free space = 1.3x
 #                                                     Use IMAGE_OVERHEAD_FACTOR to add more space
 #                                                     <--------->
-#            4MiB              40MiB           SDIMG_ROOTFS
+#            4MiB              48MiB           SDIMG_ROOTFS
 # <-----------------------> <----------> <---------------------->
 #  ------------------------ ------------ ------------------------
 # | IMAGE_ROOTFS_ALIGNMENT | BOOT_SPACE | ROOTFS_SIZE            |
 #  ------------------------ ------------ ------------------------
 # ^                        ^            ^                        ^
 # |                        |            |                        |
-# 0                      4MiB     4MiB + 40MiB       4MiB + 40Mib + SDIMG_ROOTFS
+# 0                      4MiB     4MiB + 48MiB       4MiB + 48Mib + SDIMG_ROOTFS
 
 # This image depends on the rootfs image
 IMAGE_TYPEDEP_rpi-sdimg = "${SDIMG_ROOTFS_TYPE}"
@@ -34,7 +34,7 @@ SDIMG_KERNELIMAGE_raspberrypi3-64 ?= "kernel8.img"
 BOOTDD_VOLUME_ID ?= "${MACHINE}"
 
 # Boot partition size [in KiB] (will be rounded up to IMAGE_ROOTFS_ALIGNMENT)
-BOOT_SPACE ?= "40960"
+BOOT_SPACE ?= "49152"
 
 # Set alignment to 4MB [in KiB]
 IMAGE_ROOTFS_ALIGNMENT = "4096"


### PR DESCRIPTION
* 5.10 kernel got a bit bigger especially for aarch64:
  5.10:   22M     deploy/images/raspberrypi4-64/Image-raspberrypi4-64.bin
  5.10:  7.0M     deploy/images/raspberrypi4/uImage-raspberrypi4.bin
  5.4:    16M     deploy/images/raspberrypi4-64/Image-raspberrypi4-64.bin
  5.4:   6.2M     deploy/images/raspberrypi4/uImage-raspberrypi4.bin

* and the space in fat boot partition was already tight:
  Filesystem      Size  Used Avail Use% Mounted on
  /dev/mmcblk0p1   40M   38M  1.7M  96% /

* increase the size to compensate for it, otherwise
  do_image_rpi_sdimg now fails with:

Creating filesystem with Boot partition 40960 KiB and RootFS 1822720 KiB
0+0 records in
0+0 records out
0 bytes copied, 0.000100992 s, 0.0 kB/s
Model:  (file)
Disk foo.rootfs.rpi-sdimg: 1913MB
Sector size (logical/physical): 512B/512B
Partition Table: msdos
Disk Flags:

Number  Start   End     Size    Type     File system  Flags
 1      4194kB  46.1MB  41.9MB  primary               boot, lba
 2      46.1MB  1913MB  1866MB  primary

mkfs.fat: warning - lowercase labels might not work properly with DOS or Windows
mkfs.fat 4.1 (2017-01-24)
Copying bootcode.bin
Copying cmdline.txt
Copying config.txt
Copying fixup.dat
Copying fixup4.dat
Copying fixup4cd.dat
Copying fixup4db.dat
Copying fixup4x.dat
Copying fixup_cd.dat
Copying fixup_db.dat
Copying fixup_x.dat
Copying rpi-bootfiles-20210205.stamp
Copying start.elf
Copying start4.elf
Copying start4cd.elf
Copying start4db.elf
Copying start4x.elf
Copying start_cd.elf
Copying start_db.elf
Copying start_x.elf
Copying bcm2711-rpi-4-b.dtb
Copying at86rf233.dtbo
Copying disable-bt.dtbo
Copying dwc2.dtbo
Copying gpio-ir.dtbo
Copying gpio-ir-tx.dtbo
Copying gpio-key.dtbo
Copying hifiberry-amp.dtbo
Copying hifiberry-dac.dtbo
Copying hifiberry-dacplus.dtbo
Copying hifiberry-digi.dtbo
Copying justboom-both.dtbo
Copying justboom-dac.dtbo
Copying justboom-digi.dtbo
Copying i2c-rtc.dtbo
Copying imx219.dtbo
Copying iqaudio-dac.dtbo
Copying iqaudio-dacplus.dtbo
Copying mcp2515-can0.dtbo
Copying mcp2515-can1.dtbo
Copying miniuart-bt.dtbo
Copying pitft22.dtbo
Copying pitft28-capacitive.dtbo
Copying pitft28-resistive.dtbo
Copying pitft35-resistive.dtbo
Copying pps-gpio.dtbo
Copying rpi-ft5406.dtbo
Copying rpi-poe.dtbo
Copying vc4-fkms-v3d.dtbo
Copying vc4-kms-v3d.dtbo
Copying w1-gpio.dtbo
Copying w1-gpio-pullup.dtbo
Copying kernel8.img
Copying boot.scr
Copying Image
Disk full
ERROR: mcopy cannot copy /OE/build/luneos-hardknott/webos-ports/tmp-glibc/deploy/images/raspberrypi4-64/Image into boot.img
WARNING: exit code 1 from a shell command.