### PR TITLE
Add recipes for most of the Adafruit CircuitPython Python libraries

### DIFF
--- a/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
+++ b/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
@@ -1,0 +1,21 @@
+SUMMARY = "CircuitPython APIs for non-CircuitPython versions of Python such as CPython on Linux and MicroPython."
+HOMEPAGE = "https://github.com/adafruit/Adafruit_Blinka"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=660e614bc7efb0697cc793d8a22a55c2"
+
+SRC_URI = "git://github.com/adafruit/Adafruit_Blinka.git"
+SRCREV = "dc688f354fe779c9267c208b99f310af87e79272"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+DEPENDS += "python3-setuptools-scm-native"
+
+RDEPENDS_${PN} += " \
+    libgpiod \
+    python3-adafruit-platformdetect \
+    python3-adafruit-pureio \
+    python3-core \
+    rpi-gpio \
+"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-busdevice_5.0.5.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-busdevice_5.0.5.bb
@@ -1,0 +1,18 @@
+SUMMARY = "CircuitPython bus device classes to manage bus sharing."
+HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_BusDevice"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=6ec69d6e9e6c85adfb7799d7f8cf044e"
+
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_BusDevice.git"
+SRCREV = "1bfe8005293205e2f7b2cc498ab5a946f1133b40"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+DEPENDS += "python3-setuptools-scm-native"
+
+RDEPENDS_${PN} += " \
+    python3-adafruit-blinka \
+    python3-core \
+"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-motor_3.2.6.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-motor_3.2.6.bb
@@ -1,0 +1,18 @@
+SUMMARY = "CircuitPython helper library provides higher level objects to control motors and servos."
+HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_Motor"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b72678307cc7c10910b5ef460216af07"
+
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Motor.git"
+SRCREV = "2251bfc0501d0acfb96c0a43f4f2b4c6a10ca14e"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+DEPENDS += "python3-setuptools-scm-native"
+
+RDEPENDS_${PN} += " \
+    python3-adafruit-blinka \
+    python3-core \
+"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-motorkit_1.6.1.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-motorkit_1.6.1.bb
@@ -1,0 +1,22 @@
+SUMMARY = "CircuitPython helper library for DC & Stepper Motor FeatherWing, Shield, and Pi Hat kits."
+HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_MotorKit"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=6ad4a8854b39ad474755ef1aea813bac"
+
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_MotorKit.git"
+SRCREV = "8c1462b4129b21f6db156d1517abb017bb74b982"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+DEPENDS += "python3-setuptools-scm-native"
+
+RDEPENDS_${PN} += " \
+    python3-adafruit-blinka \
+    python3-adafruit-circuitpython-busdevice \
+    python3-adafruit-circuitpython-motor \
+    python3-adafruit-circuitpython-pca9685 \
+    python3-adafruit-circuitpython-register \
+    python3-core \
+"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-pca9685_3.3.4.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-pca9685_3.3.4.bb
@@ -1,0 +1,20 @@
+SUMMARY = "CircuitPython driver for motor, stepper, and servo based on PCA9685."
+HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_PCA9685"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e7eb6b599fb0cfb06485c64cd4242f62"
+
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_PCA9685.git"
+SRCREV = "2780c4102f4c23fbab252aa1198b61ba7e2d1b2c"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+DEPENDS += "python3-setuptools-scm-native"
+
+RDEPENDS_${PN} += " \
+    python3-adafruit-blinka \
+    python3-adafruit-circuitpython-busdevice \
+    python3-adafruit-circuitpython-register \
+    python3-core \
+"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.4.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.4.bb
@@ -1,0 +1,15 @@
+SUMMARY = "CircuitPython data descriptor classes to represent hardware registers on I2C and SPI devices."
+HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_Register"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=6ec69d6e9e6c85adfb7799d7f8cf044e"
+
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+
+S = "${WORKDIR}/git"
+SRCREV = "5fee6e0c3878110844bc51e16063eeae7d94c457"
+
+DEPENDS += "python3-setuptools-scm-native"
+
+inherit setuptools3
+
+RDEPENDS_${PN} += "python3-core"

--- a/recipes-devtools/python/python3-adafruit-platformdetect_3.1.1.bb
+++ b/recipes-devtools/python/python3-adafruit-platformdetect_3.1.1.bb
@@ -1,0 +1,15 @@
+SUMMARY = "Platform detection for use by libraries like Adafruit-Blinka."
+HOMEPAGE = "https://github.com/adafruit/Adafruit_Python_PlatformDetect"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=fccd531dce4b989c05173925f0bbb76c"
+
+SRC_URI = "git://github.com/adafruit/Adafruit_Python_PlatformDetect.git"
+SRCREV = "e0fe1b012898fa824944d6805ca74be0fa027968"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+DEPENDS += "python3-setuptools-scm-native"
+
+RDEPENDS_${PN} += "python3-core"

--- a/recipes-devtools/python/python3-adafruit-pureio_1.1.8.bb
+++ b/recipes-devtools/python/python3-adafruit-pureio_1.1.8.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Pure python (i.e. no native extensions) access to Linux IO    including I2C and SPI. Drop in replacement for smbus and spidev modules."
+HOMEPAGE = "https://github.com/adafruit/Adafruit_Python_PureIO"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2a21fcca821a506d4c36f7bbecc0d009"
+
+SRC_URI = "git://github.com/adafruit/Adafruit_Python_PureIO.git"
+SRCREV = "f4d0973da05b8b21905ff6bab69cdb652128f342"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+DEPENDS += "python3-setuptools-scm-native"
+
+RDEPENDS_${PN} += " \
+    python3-core \
+    python3-ctypes \
+    python3-fcntl \
+"


### PR DESCRIPTION
This makes it easy to use various Adafruit products, such as the DC & Stepper Motor Bonnet.