### PR TITLE
Add overlay "vc4-kms-dsi-7inch.dtbo"

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -44,6 +44,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/rpi-poe.dtbo \
     overlays/vc4-fkms-v3d.dtbo \
     overlays/vc4-kms-v3d.dtbo \
+    overlays/vc4-kms-dsi-7inch.dtbo \
     overlays/w1-gpio.dtbo \
     overlays/w1-gpio-pullup.dtbo \
     "


### PR DESCRIPTION
In theory, this would allow one to use the official 7-inch touchscreen
in combination with the (non-firmware) kms driver by adding the
following lines to config.txt:

ignore_lcd=1
dtoverlay=vc4-kms-v3d
dtoverlay=vc4-kms-dsi-7inch

Signed-off-by: Mike Looijmans <mike.looijmans@topic.nl>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
