### PR TITLE
python3-adafruit-blinka: Make rpi-gpio dependency conditional

### DIFF
--- a/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
+++ b/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
@@ -17,5 +17,6 @@ RDEPENDS_${PN} += " \
     python3-adafruit-platformdetect \
     python3-adafruit-pureio \
     python3-core \
-    rpi-gpio \
 "
+
+RDEPENDS_${PN}_append_rpi = " rpi-gpio"


### PR DESCRIPTION
https://github.com/agherzan/meta-raspberrypi/pull/815

introduced python3-adafruit-blinka and this recipe has added rdep on rpi-gpio,
however rpi-gpio is rpi specific package, and therefore should only be added
when building rpi based platforms, this makes the layer work in a
multi-bsp setup work

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
