### PR TITLE
python3-adafruit-blinka: Make it available only for 32bit rpi machines

### DIFF
--- a/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
+++ b/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
@@ -12,6 +12,14 @@ inherit setuptools3
 
 DEPENDS += "python3-setuptools-scm-native"
 
+do_install_append() {
+# it ships ./bcm283x/pulseio/libgpiod_pulsein which is a prebuilt
+# 32bit binary therefore we should make this specific to 32bit rpi machines (based on bcm283x) only
+    if [ ${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', '1', '0', d)} = "0" ]; then
+        rm -rf ${D}${PYTHON_SITEPACKAGES_DIR}/adafruit_blinka/microcontroller/bcm283x
+    fi
+}
+
 RDEPENDS_${PN} += " \
     libgpiod \
     python3-adafruit-platformdetect \


### PR DESCRIPTION
It has prebuilt binary libgpiod_pulsein for rpi machines and these binary is 32bit
therefore we can not include it for 64bit machines even if they are rpi
based unless they have multilib enabled.

This patch makes it visible only on rpi-32bit

Fixes QA errors like
ERROR: QA Issue: Architecture did not match (ARM, expected AArch64) in /usr/lib/python3.9/site-packages/adafruit_blinka/microcontroller/bcm283x/pulseio/.debug/libgpiod_pulsein [arch]

