### PR TITLE
Kernel 5.10.17

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -15,6 +15,7 @@ XSERVER = " \
     "
 
 RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
+    overlays/overlay_map.dtb \
     overlays/at86rf233.dtbo \
     overlays/disable-bt.dtbo \
     overlays/dwc2.dtbo \
@@ -44,6 +45,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/rpi-poe.dtbo \
     overlays/vc4-fkms-v3d.dtbo \
     overlays/vc4-kms-v3d.dtbo \
+    overlays/vc4-kms-v3d-pi4.dtbo \
     overlays/vc4-kms-dsi-7inch.dtbo \
     overlays/w1-gpio.dtbo \
     overlays/w1-gpio-pullup.dtbo \
@@ -110,17 +112,17 @@ def make_dtb_boot_files(d):
 
     def transform(dtb):
         base = os.path.basename(dtb)
-        if dtb.endswith('dtb'):
-            # eg: whatever/bcm2708-rpi-b.dtb has:
-            #     DEPLOYDIR file: bcm2708-rpi-b.dtb
-            #     destination: bcm2708-rpi-b.dtb
-            return base
-        elif dtb.endswith('dtbo'):
+        if dtb.endswith('dtbo') or base == 'overlay_map.dtb':
             # overlay dtb:
             # eg: overlays/hifiberry-amp.dtbo has:
             #     DEPLOYDIR file: hifiberry-amp.dtbo
             #     destination: overlays/hifiberry-amp.dtbo
             return '{};{}'.format(base, dtb)
+        elif dtb.endswith('dtb'):
+            # eg: whatever/bcm2708-rpi-b.dtb has:
+            #     DEPLOYDIR file: bcm2708-rpi-b.dtb
+            #     destination: bcm2708-rpi-b.dtb
+            return base
 
     return ' '.join([transform(dtb) for dtb in alldtbs.split(' ') if dtb])
 

--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,9 +1,9 @@
-RPIFW_DATE ?= "20210205"
-SRCREV ?= "7d91570f20378afc9414107dccdad70705a8a342"
+RPIFW_DATE ?= "20210225"
+SRCREV ?= "5985247fb75681985547641d66196c77499f26b9"
 RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz;downloadfilename=raspberrypi-firmware-${SRCREV}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[sha256sum] = "2cc9bf2cbcab8283db2eb53ed2a49372b70fe76538994c32f6d261e2da3e9ff4"
+SRC_URI[sha256sum] = "3e2c00e1473bd70e808134925e1b25cd765789d9f0e0683749135b124d835000"
 
 PV = "${RPIFW_DATE}"

--- a/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -1,7 +1,7 @@
-LINUX_VERSION ?= "5.10.13"
+LINUX_VERSION ?= "5.10.17"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
 
-SRCREV_machine = "34263dc81a12862c66e2593bb26c09d5fd20f46d"
+SRCREV_machine = "ec967eb45f8d4ed59bebafb5748da38118383be7"
 SRCREV_meta = "5833ca701711d487c9094bd1efc671e8ef7d001e"
 
 KMETA = "kernel-meta"


### PR DESCRIPTION
**- What I did**

Fixes issues with the ARM-based KMS driver on the RPi4

**- How I did it**

Upgrade kernel and firmware to the current state of affairs to fix regression in the I2C controller.
Add missing overlay files to the boot partition. In particular "overlay_map" needed to be in the overlays folder.