### PR TITLE
sdcard_image-rpi.bbclass: shorten the default BOOTDD_VOLUME_ID

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -31,7 +31,9 @@ SDIMG_KERNELIMAGE_raspberrypi2 ?= "kernel7.img"
 SDIMG_KERNELIMAGE_raspberrypi3-64 ?= "kernel8.img"
 
 # Boot partition volume id
-BOOTDD_VOLUME_ID ?= "${MACHINE}"
+# Shorten raspberrypi to just rpi to keep it under 11 characters
+# now enforced by mkfs.vfat from dosfstools-4.2
+BOOTDD_VOLUME_ID ?= "${@d.getVar('MACHINE').replace('raspberrypi', 'rpi')}"
 
 # Boot partition size [in KiB] (will be rounded up to IMAGE_ROOTFS_ALIGNMENT)
 BOOT_SPACE ?= "49152"


### PR DESCRIPTION
* raspberrypi4-64 is 15 characters and with dosfstools-4.2 it breaks rootfs.rpi-sdimg with:
  mkfs.vfat: Label can be no longer than 11 characters
  mkfs.fat 4.2 (2021-01-31)

* introduced in:
  https://github.com/dosfstools/dosfstools/commit/c598354