### PR TITLE
raspberrypi-firmware: Update to 2021-02-25

### DIFF
--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,9 +1,9 @@
-RPIFW_DATE ?= "20201002"
-SRCREV ?= "11e3c314bc2b64f7d862bac00ff3d9f42f3c5a50"
+RPIFW_DATE ?= "20210225"
+SRCREV ?= "5985247fb75681985547641d66196c77499f26b9"
 RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz;downloadfilename=raspberrypi-firmware-${SRCREV}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[sha256sum] = "b8c9f5a3e987f418f11526cbf59f6a6c8103e8f5e94bccffb9ef3fd7ae834f98"
+SRC_URI[sha256sum] = "3e2c00e1473bd70e808134925e1b25cd765789d9f0e0683749135b124d835000"
 
 PV = "${RPIFW_DATE}"


### PR DESCRIPTION
This version is compatible with the 5.10.17 kernel
https://github.com/raspberrypi/firmware/commit/5985247fb75681985547641d66196c77499f26b9

Signed-off-by: Minjae Kim <flowergom@gmail.com>

**- What I did**
Updated latest raspberrypi-firmware from master branch

**- How I did it**
This firmware can possible webRTC feature with dunfell branch on rpi.