### PR TITLE
layer.conf: Drop gatesgarth and add honister to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "raspberrypi"
 BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
-LAYERSERIES_COMPAT_raspberrypi = "gatesgarth hardknott"
+LAYERSERIES_COMPAT_raspberrypi = "hardknott honister"
 
 # Additional license directories.
 LICENSE_PATH += "${LAYERDIR}/files/custom-licenses"


### PR DESCRIPTION
master can only be validated with latest WIP oe-core releases so drop
gatesgrath which is now a dedicated release, soon hardknott will be out
too but for master needs its fine, while hear add honister ( fall 2021 )
release too

Signed-off-by: Khem Raj <raj.khem@gmail.com>

