### PR TITLE
Link to the latest version of Kas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ local_conf_header:
 To configure the machine, you have to update the `machine` variable.
 And the same for the `distro`.
 
-For further information, you can read more at <https://kas.readthedocs.io/en/1.0/index.html>
+For further information, you can read more at <https://kas.readthedocs.io/en/latest/>
 
 ## Maintainers
 


### PR DESCRIPTION
Original code was pointing to 1.0.  Current version is 2.4.
