### PR TITLE
libva: Fix for when using `userland`

### DIFF
--- a/recipes-graphics/libva/libva_%.bbappend
+++ b/recipes-graphics/libva/libva_%.bbappend
@@ -1,0 +1,3 @@
+# when using userland graphic KHR/khrplatform.h is provided by userland but virtual/libgl is provided by mesa-gl where
+# we explicitly delete KHR/khrplatform.h since its already coming from userland package
+DEPENDS_append_rpi = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'userland', d)}"


### PR DESCRIPTION
libva: Fix for when using `userland`

Fixes #842 - failing build of libva when using `userland` recipe.
Fix is same as: https://github.com/agherzan/meta-raspberrypi/commit/ac16b0e9d713bcc4ee0e976259064d1a318a5aac

Signed-off-by: Matt Hammond <matt.hammond@bbc.co.uk>


