### PR TITLE
[gatesgarth] Backports from master

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "raspberrypi"
 BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
-LAYERSERIES_COMPAT_raspberrypi = "sumo thud warrior zeus dunfell gatesgarth"
+LAYERSERIES_COMPAT_raspberrypi = "dunfell gatesgarth"
 LAYERDEPENDS_raspberrypi = "core"
 
 # Additional license directories.

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,6 +10,7 @@ BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
 LAYERSERIES_COMPAT_raspberrypi = "sumo thud warrior zeus dunfell gatesgarth"
+LAYERDEPENDS_raspberrypi = "core"
 
 # Additional license directories.
 LICENSE_PATH += "${LAYERDIR}/files/custom-licenses"

--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -7,6 +7,7 @@ python __anonymous() {
 
 LINUX_VERSION ?= "5.10.y"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
+LINUX_RPI_KMETA_BRANCH ?= "master"
 
 SRCREV_machine = "${AUTOREV}"
 SRCREV_meta = "${AUTOREV}"
@@ -14,8 +15,8 @@ SRCREV_meta = "${AUTOREV}"
 KMETA = "kernel-meta"
 
 SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;name=machine;protocol=git;branch=${LINUX_RPI_BRANCH} \
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=master;destsuffix=${KMETA} \
+    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
     file://powersave.cfg \
     file://android-drivers.cfg \
     "

--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -7,10 +7,15 @@ python __anonymous() {
 
 LINUX_VERSION ?= "5.10.y"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
-LINUX_RPI_KMETA_BRANCH ?= "master"
+LINUX_RPI_KMETA_BRANCH ?= "yocto-5.10"
 
-SRCREV_machine = "${AUTOREV}"
-SRCREV_meta = "${AUTOREV}"
+# Set default SRCREVs. Both the machine and meta SRCREVs are statically set
+# to the as in 5.10 recipe, and hence prevent network access during parsing. If
+# linux-yocto-dev is the preferred provider, they will be overridden to
+# AUTOREV in following anonymous python routine and resolved when the
+# variables are finalized.
+SRCREV_machine ?= '${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-raspberrypi-dev", "${AUTOREV}", "89399e6e7e33d6260a954603ca03857df594ffd3", d)}'
+SRCREV_meta ?= '${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-raspberrypi-dev", "${AUTOREV}", "a19886b00ea7d874fdd60d8e3435894bb16e6434", d)}'
 
 KMETA = "kernel-meta"
 

--- a/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -1,5 +1,6 @@
 LINUX_VERSION ?= "5.10.17"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
+LINUX_RPI_KMETA_BRANCH ?= "yocto-5.10"
 
 SRCREV_machine = "ec967eb45f8d4ed59bebafb5748da38118383be7"
 SRCREV_meta = "5833ca701711d487c9094bd1efc671e8ef7d001e"
@@ -8,7 +9,7 @@ KMETA = "kernel-meta"
 
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH} \
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.10;destsuffix=${KMETA} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
     file://powersave.cfg \
     file://android-drivers.cfg \
     "

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -1,5 +1,6 @@
 LINUX_VERSION ?= "5.4.83"
 LINUX_RPI_BRANCH ?= "rpi-5.4.y"
+LINUX_RPI_KMETA_BRANCH ?= "yocto-5.4"
 
 SRCREV_machine = "08ae2dd9e7dc89c20bff823a3ef045de09bfd090"
 SRCREV_meta = "d676bf5ff7b7071e14f44498d2482c0a596f14cd"
@@ -8,7 +9,7 @@ KMETA = "kernel-meta"
 
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH} \
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.4;destsuffix=${KMETA} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
     file://0001-Revert-selftests-bpf-Skip-perf-hw-events-test-if-the.patch \
     file://0002-Revert-selftests-bpf-Fix-perf_buffer-test-on-systems.patch \
     file://powersave.cfg \


### PR DESCRIPTION
Tested by building virtual/kernel with and without
`PREFERRED_PROVIDER_virtual/kernel = "linux-raspberrypi-dev"`