### PR TITLE
kas: remove 'image-mklibs' from USER_CLASSES list

### DIFF
--- a/kas-poky-rpi.yml
+++ b/kas-poky-rpi.yml
@@ -45,7 +45,7 @@ local_conf_header:
     CONF_VERSION = "1"
     PACKAGE_CLASSES = "package_rpm"
     SDKMACHINE = "x86_64"
-    USER_CLASSES = "buildstats image-mklibs image-prelink"
+    USER_CLASSES = "buildstats image-prelink"
     PATCHRESOLVE = "noop"
   debug-tweaks: |
     EXTRA_IMAGE_FEATURES = "debug-tweaks"


### PR DESCRIPTION
mklibs is no longer supported, see [1]

[1] - http://git.openembedded.org/openembedded-core/commit/meta/classes?id=908df863b419d1cad7317153101fc827e7e3a354

Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>