### PR TITLE
Make rpi-cmdline package machine-specific

### DIFF
--- a/recipes-bsp/bootfiles/rpi-cmdline.bb
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bb
@@ -49,3 +49,5 @@ do_deploy() {
 
 addtask deploy before do_build after do_install
 do_deploy[dirs] += "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
The cmdline.txt file generated by this recipe includes machine-specific information so we should set PACKAGE_ARCH appropriately.