### PR TITLE
pi-bluetooth: Add compatibility with non-systemd builds

### DIFF
--- a/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.17.bb
+++ b/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.17.bb
@@ -14,12 +14,14 @@ SRCREV = "fd4775bf90e037551532fc214a958074830bb80d"
 
 S = "${WORKDIR}/git"
 
+inherit ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', 'update-rc.d', d)}
 # hciuart.service replaces what was brcm43438.service 
-inherit systemd
 SYSTEMD_SERVICE:${PN} = "\
     hciuart.service \
     bthelper@.service \
 "
+INITSCRIPT_NAME = "btuart"
+INITSCRIPT_PARAMS = "start 18 2 3 4 5 ."
 
 do_install() {
     install -d ${D}${sysconfdir}/udev/rules.d
@@ -33,6 +35,14 @@ do_install() {
         install -d ${D}${systemd_system_unitdir}
         install -m 0644 ${S}/debian/pi-bluetooth.bthelper@.service ${D}${systemd_system_unitdir}/bthelper@.service
         install -m 0644 ${S}/debian/pi-bluetooth.hciuart.service ${D}${systemd_system_unitdir}/hciuart.service
+    else
+        install -d ${D}${sysconfdir}/init.d/
+        cat > ${WORKDIR}/btuart.init << EOF
+#!/bin/sh
+/usr/bin/btuart
+EOF
+        install -m 0755 ${WORKDIR}/btuart.init ${D}${sysconfdir}/init.d/btuart
+        sed -i -e 's:TAG+="systemd".*$:RUN+="/usr/bin/bthelper %k":' ${D}${sysconfdir}/udev/rules.d/90-pi-bluetooth.rules
     fi
 }
 


### PR DESCRIPTION
Signed-off-by: Marcus Comstedt <marcus@mc.pp.se>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Fix the pi-bluetooth recipe to work without systemd

**- How I did it**

Added a good old initscript for `btinit`, and changed the udev rule to run `bthelper` directly instead of trying to involve systemd (only when `systemd` is not in `DISTRO_FEATURES`).