### PR TITLE
kas: local.conf: bump CONF_VERSION variable

### DIFF
--- a/kas-poky-rpi.yml
+++ b/kas-poky-rpi.yml
@@ -42,7 +42,7 @@ local_conf_header:
   reduce_diskspace: |
     INHERIT += "rm_work_and_downloads"
   standard: |
-    CONF_VERSION = "1"
+    CONF_VERSION = "2"
     PACKAGE_CLASSES = "package_rpm"
     SDKMACHINE = "x86_64"
     USER_CLASSES = "buildstats image-prelink"


### PR DESCRIPTION
Since commit 5452f1ba337685cf89d3429e08255450ab90b96f ("local.conf.sample: Bump version so users update their config") in OE-Core,
we need to update the default local.conf due to the new syntax.

Fixes:

ERROR: Error executing a python function in exec_python_func() autogenerated:

The stack trace of python calls that resulted in this exception/failure was:
File: 'exec_python_func() autogenerated', lineno: 2, function: <module>
     0001:
 *** 0002:oecore_update_localconf(d)
     0003:
File: '/work/poky/meta/classes/sanity.bbclass', lineno: 56, function: oecore_update_localconf
     0052:
     0053:is a good way to visualise the changes."""
     0054:    failmsg = d.expand(failmsg)
     0055:
 *** 0056:    raise NotImplementedError(failmsg)
     0057:}
     0058:
     0059:SANITY_SITECONF_SAMPLE ?= "${COREBASE}/meta*/conf/site.conf.sample"
     0060:python oecore_update_siteconf() {
Exception: NotImplementedError: Your version of local.conf was generated from an older/newer version of
local.conf.sample and there have been updates made to this file. Please compare the two
files and merge any changes before continuing.

Matching the version numbers will remove this message.

"meld conf/local.conf /work/poky/meta*/conf/local.conf.sample"

is a good way to visualise the changes.

Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>