### PR TITLE
userland: package man pages in PN-doc

### DIFF
--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -88,6 +88,10 @@ do_install:append () {
                 ln -sf brcmegl.pc ${D}${libdir}/pkgconfig/egl.pc
                 ln -sf brcmvg.pc ${D}${libdir}/pkgconfig/vg.pc
 	fi
+	# Currently man files are installed in /usr/man instead of /usr/share/man, see comments in:
+	# https://github.com/raspberrypi/userland/commit/45a0022ac64b4d0788def3c5230c972430f6fc23
+	mkdir -pv ${D}${datadir}
+	mv -v ${D}${prefix}/man ${D}${mandir}
 }
 
 # Shared libs from userland package  build aren't versioned, so we need


### PR DESCRIPTION
* last userland upgrade in:
  https://github.com/agherzan/meta-raspberrypi/commit/2a25b7ef8bb7b366a93dbe42d40ebf3923d1fccc
  brings this upstream commit:
  https://github.com/raspberrypi/userland/commit/45a0022ac64b4d0788def3c5230c972430f6fc23

  which results in:
  ERROR: userland-20210623-r0 do_package: QA Issue: userland: Files/directories were installed but not shipped in any package:
    /usr/man
    /usr/man/man1
    /usr/man/man7
    /usr/man/man1/raspistill.1
    /usr/man/man1/raspividyuv.1
    /usr/man/man1/dtparam.1
    /usr/man/man1/raspivid.1
    /usr/man/man1/tvservice.1
    /usr/man/man1/vcmailbox.1
    /usr/man/man1/raspiyuv.1
    /usr/man/man1/dtoverlay.1
    /usr/man/man1/vcgencmd.1
    /usr/man/man1/dtmerge.1
    /usr/man/man7/raspicam.7
    /usr/man/man7/raspirev.7
    /usr/man/man7/raspiotp.7
    /usr/man/man7/vcmailbox.7
  Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
  userland: 17 installed and not shipped files. [installed-vs-shipped]

  it's incorrectly installed in /usr/man by CMake as discussed in upstream
  move it to /usr/share/man where it's picked by default FILES:${PN}-doc