### PR TITLE
kas: local.conf: disable prelink

### DIFF
--- a/kas-poky-rpi.yml
+++ b/kas-poky-rpi.yml
@@ -45,7 +45,7 @@ local_conf_header:
     CONF_VERSION = "2"
     PACKAGE_CLASSES = "package_rpm"
     SDKMACHINE = "x86_64"
-    USER_CLASSES = "buildstats image-prelink"
+    USER_CLASSES = "buildstats"
     PATCHRESOLVE = "noop"
   debug-tweaks: |
     EXTRA_IMAGE_FEATURES = "debug-tweaks"


### PR DESCRIPTION
Keep configuration synchronized with OE-Core, see [1].

[1] - http://git.openembedded.org/openembedded-core/commit/?id=f9719cc1c3fe9d380336e7af418daf27473b2e8b

Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>