### PR TITLE
xserver-xf86-config: Correctly append to FILES:${PN}

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
@@ -13,4 +13,4 @@ do_install:append:rpi () {
     fi
 }
 
-FILES:${PN}:rpi += "${sysconfdir}/X11/xorg.conf ${sysconfdir}/X11/xorg.conf.d/*"
+FILES:${PN}:append:rpi = " ${sysconfdir}/X11/xorg.conf.d/*"


### PR DESCRIPTION
When updating FILES:${PN} based on an override you must use
FILES:${PN}:append:OVERRIDE as the syntax otherwise you will end up
replacing the contents of FILES:${PN} entirely.  Update to use this
syntax correctly and then only add "${sysconfdir}/X11/xorg.conf.d/*"

Reported-by: Quentin Schulz <quentin.schulz@theobroma-systems.com>
Signed-off-by: Tom Rini <trini@konsulko.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
