### PR TITLE
Revert "linux-raspberry: Drop 64-bit specific do_compile_append()"

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -35,3 +35,10 @@ KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", 
 # set by default in rpi-4.8.y and later branches so we need to provide it
 # manually. This value unused if KERNEL_IMAGETYPE is not uImage.
 KERNEL_EXTRA_ARGS += "LOADADDR=0x00008000"
+
+do_compile_append() {
+    if [ "${SITEINFO_BITS}" = "64" ]; then
+        cc_extra=$(get_cc_option)
+        oe_runmake dtbs CC="${KERNEL_CC} $cc_extra " LD="${KERNEL_LD}" ${KERNEL_EXTRA_ARGS}
+    fi
+}


### PR DESCRIPTION
This reverts commit a7cc636d4ef0ed7ddabf5785463dbb5c79633b1e which broke
loading overlays. The behaviour is that, as per the comments in
6c4de0b5fe44b8e661f1391ee8540a7f04d75315, the device tree blobs
generated on 64 bits lack the symbols and thus no overlays can be
loaded (checked with running "vcdbg log msg"):

005284.623: dtb_file 'bcm2711-rpi-4-b.dtb'
005289.625: brfs: File read: /mfs/sd/bcm2711-rpi-4-b.dtb
005289.641: Loading 'bcm2711-rpi-4-b.dtb' to 0x100 size 0x8c60
005302.330: brfs: File read: 35936 bytes
005310.499: brfs: File read: /mfs/sd/overlays/overlay_map.dtb
005358.309: brfs: File read: 1559 bytes
005360.894: brfs: File read: /mfs/sd/config.txt
005361.275: brfs: File read: 143 bytes
005372.465: brfs: File read: /mfs/sd/overlays/vc4-fkms-v3d.dtbo
005375.749: dterror: no symbols found
005375.760: Failed to resolve overlay 'vc4-fkms-v3d'
005376.120: brfs: File read: 1446 bytes
005385.470: brfs: File read: /mfs/sd/overlays/disable-wifi.dtbo
005388.352: dterror: no symbols found
005388.361: Failed to resolve overlay 'disable-wifi'

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
