### PR TITLE
Support OTG via config.txt

### DIFF
--- a/recipes-bsp/bootfiles/rpi-cmdline.bb
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bb
@@ -29,6 +29,13 @@ CMDLINE_LOGO ?= '${@oe.utils.conditional("DISABLE_RPI_BOOT_LOGO", "1", "logo.nol
 # to enable kernel debugging.
 CMDLINE_DEBUG ?= ""
 
+# Add RNDIS capabilities (must be after rootwait)
+# example: 
+# CMDLINE_RNDIS = "modules-load=dwc2,g_ether g_ether.host_addr=<some MAC 
+# address> g_ether.dev_addr=<some MAC address>"
+# if the MAC addresses are omitted, random values will be used
+CMDLINE_RNDIS ?= ""
+
 CMDLINE = " \
     ${CMDLINE_DWC_OTG} \
     ${CMDLINE_SERIAL} \
@@ -38,6 +45,7 @@ CMDLINE = " \
     ${CMDLINE_LOGO} \
     ${CMDLINE_PITFT} \
     ${CMDLINE_DEBUG} \
+    ${CMDLINE_RNDIS} \
     "
 
 do_compile() {

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -215,7 +215,7 @@ do_deploy() {
     fi
 
     # DWC2 USB peripheral support
-    if [ "${ENABLE_DWC2_PERIPHERAL}" = "1" ]; then
+    if ([ "${ENABLE_DWC2_PERIPHERAL}" = "1" ] && [ "${ENABLE_DWC2_OTG}" != "1" ]); then
         echo "# Enable USB peripheral mode" >> $CONFIG
         echo "dtoverlay=dwc2,dr_mode=peripheral" >> $CONFIG
     fi
@@ -224,6 +224,12 @@ do_deploy() {
     if [ "${ENABLE_DWC2_HOST}" = "1" ]; then
         echo "# Enable USB host mode" >> $CONFIG
         echo "dtoverlay=dwc2,dr_mode=host" >> $CONFIG
+    fi
+    
+    # DWC2 USB OTG support
+    if ([ "${ENABLE_DWC2_OTG}" = "1" ] && [ "${ENABLE_DWC2_PERIPHERAL}" != "1" ]); then
+        echo "# Enable USB OTG mode" >> $CONFIG
+        echo "dtoverlay=dwc2,dr_mode=otg" >> $CONFIG
     fi
 
     # AT86RF23X support


### PR DESCRIPTION
Support Ethernet over USB

This is my first contribution to a yocto main project, so if I am missing anything please do let me know I am happy to resubmit with any missing data.

**- What I did**
I added support for "on the go" via both config.txt and cmdline.txt
 
**- How I did it**
In both cases I use new configuration variables (ENABLE_DWC2_OTG, and CMDLINE_RNDIS) which is expected to be supplied in the main project's conf/local.conf. These modify the boot setup for the raspberry pi, in alignment with the recommended practise for the same setup when using Rasbian.