### PR TITLE
rpi-config: warn on config.txt lines exceeding 80 bytes

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -278,6 +278,12 @@ do_deploy:append:raspberrypi3-64() {
     echo "dtparam=audio=on" >> $CONFIG
 }
 
+do_deploy:append() {
+    if grep -q -E '^.{80}.$' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt; then
+        bbwarn "config.txt contains lines longer than 80 characters, this is not supported"
+    fi
+}
+
 addtask deploy before do_build after do_install
 do_deploy[dirs] += "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}"
 


### PR DESCRIPTION
The Raspberry Pi firmware does not support lines exceeding 80 bytes.
This is documented at https://www.raspberrypi.com/documentation/computers/config_txt.html#file-format

It seems that comments can be longer but it's still best to avoid this
problem instead of debug it. Detect the situation in do_deploy_append
and bbwarn if the limit is exceeded.

Connected to #917

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
