### PR TITLE
Split rpi include file

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-common.inc
+++ b/recipes-kernel/linux/linux-raspberrypi-common.inc
@@ -1,0 +1,24 @@
+SRC_URI += " \
+    ${@bb.utils.contains("INITRAMFS_IMAGE_BUNDLE", "1", "file://initramfs-image-bundle.cfg", "", d)} \
+    ${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "file://vc4graphics.cfg", "", d)} \
+    ${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "file://wm8960.cfg", "", d)} \
+    "
+
+KCONFIG_MODE = "--alldefconfig"
+KBUILD_DEFCONFIG:raspberrypi0-wifi ?= "bcmrpi_defconfig"
+KBUILD_DEFCONFIG:raspberrypi ?= "bcmrpi_defconfig"
+KBUILD_DEFCONFIG:raspberrypi-cm3 ?= "bcm2709_defconfig"
+KBUILD_DEFCONFIG:raspberrypi2 ?= "bcm2709_defconfig"
+KBUILD_DEFCONFIG:raspberrypi3 ?= "bcm2709_defconfig"
+KBUILD_DEFCONFIG:raspberrypi3-64 ?= "bcmrpi3_defconfig"
+KBUILD_DEFCONFIG:raspberrypi4 ?= "bcm2711_defconfig"
+KBUILD_DEFCONFIG:raspberrypi4-64 ?= "bcm2711_defconfig"
+
+LINUX_VERSION_EXTENSION ?= ""
+
+KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "stmpe-ts", "", d)}"
+
+# A LOADADDR is needed when building a uImage format kernel. This value is not
+# set by default in rpi-4.8.y and later branches so we need to provide it
+# manually. This value unused if KERNEL_IMAGETYPE is not uImage.
+KERNEL_EXTRA_ARGS += "LOADADDR=0x00008000"

--- a/recipes-kernel/linux/linux-raspberrypi-common.inc
+++ b/recipes-kernel/linux/linux-raspberrypi-common.inc
@@ -1,10 +1,10 @@
-SRC_URI += " \
+SRC_URI:rpi += " \
     ${@bb.utils.contains("INITRAMFS_IMAGE_BUNDLE", "1", "file://initramfs-image-bundle.cfg", "", d)} \
     ${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "file://vc4graphics.cfg", "", d)} \
     ${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "file://wm8960.cfg", "", d)} \
     "
 
-KCONFIG_MODE = "--alldefconfig"
+KCONFIG_MODE:rpi = "--alldefconfig"
 KBUILD_DEFCONFIG:raspberrypi0-wifi ?= "bcmrpi_defconfig"
 KBUILD_DEFCONFIG:raspberrypi ?= "bcmrpi_defconfig"
 KBUILD_DEFCONFIG:raspberrypi-cm3 ?= "bcm2709_defconfig"
@@ -14,11 +14,11 @@ KBUILD_DEFCONFIG:raspberrypi3-64 ?= "bcmrpi3_defconfig"
 KBUILD_DEFCONFIG:raspberrypi4 ?= "bcm2711_defconfig"
 KBUILD_DEFCONFIG:raspberrypi4-64 ?= "bcm2711_defconfig"
 
-LINUX_VERSION_EXTENSION ?= ""
+LINUX_VERSION_EXTENSION:rpi ?= ""
 
-KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "stmpe-ts", "", d)}"
+KERNEL_MODULE_AUTOLOAD:rpi += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "stmpe-ts", "", d)}"
 
 # A LOADADDR is needed when building a uImage format kernel. This value is not
 # set by default in rpi-4.8.y and later branches so we need to provide it
 # manually. This value unused if KERNEL_IMAGETYPE is not uImage.
-KERNEL_EXTRA_ARGS += "LOADADDR=0x00008000"
+KERNEL_EXTRA_ARGS:rpi += "LOADADDR=0x00008000"

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -10,28 +10,4 @@ PV = "${LINUX_VERSION}+git${SRCPV}"
 
 inherit siteinfo
 require recipes-kernel/linux/linux-yocto.inc
-
-SRC_URI += " \
-    ${@bb.utils.contains("INITRAMFS_IMAGE_BUNDLE", "1", "file://initramfs-image-bundle.cfg", "", d)} \
-    ${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "file://vc4graphics.cfg", "", d)} \
-    ${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "file://wm8960.cfg", "", d)} \
-    "
-
-KCONFIG_MODE = "--alldefconfig"
-KBUILD_DEFCONFIG:raspberrypi0-wifi ?= "bcmrpi_defconfig"
-KBUILD_DEFCONFIG:raspberrypi ?= "bcmrpi_defconfig"
-KBUILD_DEFCONFIG:raspberrypi-cm3 ?= "bcm2709_defconfig"
-KBUILD_DEFCONFIG:raspberrypi2 ?= "bcm2709_defconfig"
-KBUILD_DEFCONFIG:raspberrypi3 ?= "bcm2709_defconfig"
-KBUILD_DEFCONFIG:raspberrypi3-64 ?= "bcmrpi3_defconfig"
-KBUILD_DEFCONFIG:raspberrypi4 ?= "bcm2711_defconfig"
-KBUILD_DEFCONFIG:raspberrypi4-64 ?= "bcm2711_defconfig"
-
-LINUX_VERSION_EXTENSION ?= ""
-
-KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "stmpe-ts", "", d)}"
-
-# A LOADADDR is needed when building a uImage format kernel. This value is not
-# set by default in rpi-4.8.y and later branches so we need to provide it
-# manually. This value unused if KERNEL_IMAGETYPE is not uImage.
-KERNEL_EXTRA_ARGS += "LOADADDR=0x00008000"
+require linux-raspberrypi-common.inc


### PR DESCRIPTION
**- What I did**

Split include file to allow easier inclusion and overriding and make the variables RPi-specific

The -common bits can be easily included in new recipes, for example, with a different SRC_URI. This allows more of the meta-raspberrypi infrastructure to be reused in custom kernels.

**- How I did it**

Move the common parts to a -common include file and include this new file into all the recipes.