### PR TITLE
Added a line to rpi-base.inc to get gpio-poweroff overlay.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,6 +10,7 @@ BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
 LAYERSERIES_COMPAT_raspberrypi = "hardknott honister"
+LAYERDEPENDS_raspberrypi = "core"
 
 # Additional license directories.
 LICENSE_PATH += "${LAYERDIR}/files/custom-licenses"

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -22,6 +22,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/gpio-ir.dtbo \
     overlays/gpio-ir-tx.dtbo \
     overlays/gpio-key.dtbo \
+    overlays/gpio-poweroff.dtbo \
     overlays/hifiberry-amp.dtbo \
     overlays/hifiberry-dac.dtbo \
     overlays/hifiberry-dacplus.dtbo \

--- a/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
+++ b/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_Blinka"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=660e614bc7efb0697cc793d8a22a55c2"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_Blinka.git"
+SRC_URI = "git://github.com/adafruit/Adafruit_Blinka.git;branch=main"
 SRCREV = "dc688f354fe779c9267c208b99f310af87e79272"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-busdevice_5.0.5.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-busdevice_5.0.5.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_BusDevice"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=6ec69d6e9e6c85adfb7799d7f8cf044e"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_BusDevice.git"
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_BusDevice.git;branch=main"
 SRCREV = "1bfe8005293205e2f7b2cc498ab5a946f1133b40"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-motor_3.2.6.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-motor_3.2.6.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_Motor"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b72678307cc7c10910b5ef460216af07"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Motor.git"
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Motor.git;branch=main"
 SRCREV = "2251bfc0501d0acfb96c0a43f4f2b4c6a10ca14e"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-motorkit_1.6.1.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-motorkit_1.6.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_MotorKit"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=6ad4a8854b39ad474755ef1aea813bac"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_MotorKit.git"
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_MotorKit.git;branch=main"
 SRCREV = "8c1462b4129b21f6db156d1517abb017bb74b982"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-pca9685_3.3.4.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-pca9685_3.3.4.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_PCA9685"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e7eb6b599fb0cfb06485c64cd4242f62"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_PCA9685.git"
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_PCA9685.git;branch=main"
 SRCREV = "2780c4102f4c23fbab252aa1198b61ba7e2d1b2c"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.4.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.4.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_Register"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=6ec69d6e9e6c85adfb7799d7f8cf044e"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Register.git;branch=main"
 
 S = "${WORKDIR}/git"
 SRCREV = "5fee6e0c3878110844bc51e16063eeae7d94c457"

--- a/recipes-devtools/python/python3-adafruit-platformdetect_3.1.1.bb
+++ b/recipes-devtools/python/python3-adafruit-platformdetect_3.1.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_Python_PlatformDetect"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fccd531dce4b989c05173925f0bbb76c"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_Python_PlatformDetect.git"
+SRC_URI = "git://github.com/adafruit/Adafruit_Python_PlatformDetect.git;branch=main"
 SRCREV = "e0fe1b012898fa824944d6805ca74be0fa027968"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-pureio_1.1.8.bb
+++ b/recipes-devtools/python/python3-adafruit-pureio_1.1.8.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_Python_PureIO"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=2a21fcca821a506d4c36f7bbecc0d009"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_Python_PureIO.git"
+SRC_URI = "git://github.com/adafruit/Adafruit_Python_PureIO.git;branch=main"
 SRCREV = "f4d0973da05b8b21905ff6bab69cdb652128f342"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -7,6 +7,7 @@ python __anonymous() {
 
 LINUX_VERSION ?= "5.10.y"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
+LINUX_RPI_KMETA_BRANCH ?= "master"
 
 SRCREV_machine = "${AUTOREV}"
 SRCREV_meta = "${AUTOREV}"
@@ -14,8 +15,8 @@ SRCREV_meta = "${AUTOREV}"
 KMETA = "kernel-meta"
 
 SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;name=machine;protocol=git;branch=${LINUX_RPI_BRANCH} \
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=master;destsuffix=${KMETA} \
+    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
     file://powersave.cfg \
     file://android-drivers.cfg \
     "

--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -7,10 +7,15 @@ python __anonymous() {
 
 LINUX_VERSION ?= "5.10.y"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
-LINUX_RPI_KMETA_BRANCH ?= "master"
+LINUX_RPI_KMETA_BRANCH ?= "yocto-5.10"
 
-SRCREV_machine = "${AUTOREV}"
-SRCREV_meta = "${AUTOREV}"
+# Set default SRCREVs. Both the machine and meta SRCREVs are statically set
+# to the as in 5.10 recipe, and hence prevent network access during parsing. If
+# linux-yocto-dev is the preferred provider, they will be overridden to
+# AUTOREV in following anonymous python routine and resolved when the
+# variables are finalized.
+SRCREV_machine ?= '${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-raspberrypi-dev", "${AUTOREV}", "89399e6e7e33d6260a954603ca03857df594ffd3", d)}'
+SRCREV_meta ?= '${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-raspberrypi-dev", "${AUTOREV}", "a19886b00ea7d874fdd60d8e3435894bb16e6434", d)}'
 
 KMETA = "kernel-meta"
 

--- a/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -1,5 +1,6 @@
 LINUX_VERSION ?= "5.10.31"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
+LINUX_RPI_KMETA_BRANCH ?= "yocto-5.10"
 
 SRCREV_machine = "89399e6e7e33d6260a954603ca03857df594ffd3"
 SRCREV_meta = "a19886b00ea7d874fdd60d8e3435894bb16e6434"
@@ -8,7 +9,7 @@ KMETA = "kernel-meta"
 
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH} \
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.10;destsuffix=${KMETA} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
     file://powersave.cfg \
     file://android-drivers.cfg \
     "

--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -1,5 +1,6 @@
 LINUX_VERSION ?= "5.4.83"
 LINUX_RPI_BRANCH ?= "rpi-5.4.y"
+LINUX_RPI_KMETA_BRANCH ?= "yocto-5.4"
 
 SRCREV_machine = "08ae2dd9e7dc89c20bff823a3ef045de09bfd090"
 SRCREV_meta = "d676bf5ff7b7071e14f44498d2482c0a596f14cd"
@@ -8,7 +9,7 @@ KMETA = "kernel-meta"
 
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH} \
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.4;destsuffix=${KMETA} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
     file://0001-Revert-selftests-bpf-Skip-perf-hw-events-test-if-the.patch \
     file://0002-Revert-selftests-bpf-Fix-perf_buffer-test-on-systems.patch \
     file://powersave.cfg \


### PR DESCRIPTION
/conf/machine/include/rpi-base.inc: Added gpio-poweroff.dtbo so that this overlay may be used in config.txt

Some systems need to use gpi-poweroff so that a gpio line can be used to control power on the device.
This 1 line patch makes it possible to do it in hardknott.  There doesn't seem to be a way to add an overlay
without modifying this file.

Signed-off-by: Cameron Kellough <cameron@telemetrak.com>
