### PR TITLE
dunfell: 99-com.rules: fix error invalid substitution type

### DIFF
--- a/recipes-core/udev/udev-rules-rpi/99-com.rules
+++ b/recipes-core/udev/udev-rules-rpi/99-com.rules
@@ -1,8 +1,8 @@
 KERNEL=="ttyAMA[01]", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
-	if cmp -s $ALIASES/uart0 $ALIASES/serial0; then \
+	if cmp -s $$ALIASES/uart0 $$ALIASES/serial0; then \
 		echo 0;\
-	elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then \
+	elif cmp -s $$ALIASES/uart0 $$ALIASES/serial1; then \
 		echo 1; \
 	else \
 		exit 1; \
@@ -11,9 +11,9 @@ KERNEL=="ttyAMA[01]", PROGRAM="/bin/sh -c '\
 
 KERNEL=="ttyS0", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
-	if cmp -s $ALIASES/uart1 $ALIASES/serial0; then \
+	if cmp -s $$ALIASES/uart1 $$ALIASES/serial0; then \
 		echo 0; \
-	elif cmp -s $ALIASES/uart1 $ALIASES/serial1; then \
+	elif cmp -s $$ALIASES/uart1 $$ALIASES/serial1; then \
 		echo 1; \
 	else \
 		exit 1; \


### PR DESCRIPTION
fix below error:
/etc/udev/rules.d/99-com.rules:10 Invalid value "/bin/sh -c
'ALIASES=/proc/device-tree/aliases; if cmp -s $ALIASES/uart0
$ALIASES/serial0; then echo 0;elif cmp -s $ALIASES/uart0
$ALIASES/serial1; then echo 1; else exit 1; fi'" for PROGRAM (char 58:
invalid substitution type)


