### PR TITLE
recipes: Update SRC_URI protocols for github

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 COMPATIBLE_MACHINE = "^rpi$"
 
 SRCREV = "648ffc470824c43eb0d16c485f4c24816b32cd6f"
-SRC_URI = "git://github.com/Evilpaul/RPi-config.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/Evilpaul/RPi-config.git;protocol=https;branch=master \
           "
 
 S = "${WORKDIR}/git"

--- a/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.17.bb
+++ b/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.17.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "\
 "
 
 SRC_URI = "\
-    git://github.com/RPi-Distro/pi-bluetooth \
+    git://github.com/RPi-Distro/pi-bluetooth;branch=master;protocol=https \
     file://0001-bthelper-correct-path-for-hciconfig-under-Yocto.patch \
 "
 SRCREV = "fd4775bf90e037551532fc214a958074830bb80d"

--- a/recipes-devtools/pi-blaster/pi-blaster_git.bb
+++ b/recipes-devtools/pi-blaster/pi-blaster_git.bb
@@ -4,7 +4,7 @@ SECTION = "devel/libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://README.md;beginline=268;endline=292;md5=86d10e4bcf4b4014d306dde7c1d2a80d"
 
-SRC_URI = "git://github.com/sarfata/pi-blaster \
+SRC_URI = "git://github.com/sarfata/pi-blaster;branch=master;protocol=https \
            file://remove-initscript-lsb-dependency.patch \
            "
 

--- a/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
+++ b/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_Blinka"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=660e614bc7efb0697cc793d8a22a55c2"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_Blinka.git;branch=main"
+SRC_URI = "git://github.com/adafruit/Adafruit_Blinka.git;branch=main;protocol=https"
 SRCREV = "dc688f354fe779c9267c208b99f310af87e79272"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-busdevice_5.0.5.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-busdevice_5.0.5.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_BusDevice"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=6ec69d6e9e6c85adfb7799d7f8cf044e"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_BusDevice.git;branch=main"
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_BusDevice.git;branch=main;protocol=https"
 SRCREV = "1bfe8005293205e2f7b2cc498ab5a946f1133b40"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-motor_3.2.6.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-motor_3.2.6.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_Motor"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b72678307cc7c10910b5ef460216af07"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Motor.git;branch=main"
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Motor.git;branch=main;protocol=https"
 SRCREV = "2251bfc0501d0acfb96c0a43f4f2b4c6a10ca14e"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-motorkit_1.6.1.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-motorkit_1.6.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_MotorKit"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=6ad4a8854b39ad474755ef1aea813bac"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_MotorKit.git;branch=main"
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_MotorKit.git;branch=main;protocol=https"
 SRCREV = "8c1462b4129b21f6db156d1517abb017bb74b982"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-pca9685_3.3.4.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-pca9685_3.3.4.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_PCA9685"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e7eb6b599fb0cfb06485c64cd4242f62"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_PCA9685.git;branch=main"
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_PCA9685.git;branch=main;protocol=https"
 SRCREV = "2780c4102f4c23fbab252aa1198b61ba7e2d1b2c"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.4.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.4.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_Register"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=6ec69d6e9e6c85adfb7799d7f8cf044e"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Register.git;branch=main"
+SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Register.git;branch=main;protocol=https"
 
 S = "${WORKDIR}/git"
 SRCREV = "5fee6e0c3878110844bc51e16063eeae7d94c457"

--- a/recipes-devtools/python/python3-adafruit-platformdetect_3.1.1.bb
+++ b/recipes-devtools/python/python3-adafruit-platformdetect_3.1.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_Python_PlatformDetect"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fccd531dce4b989c05173925f0bbb76c"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_Python_PlatformDetect.git;branch=main"
+SRC_URI = "git://github.com/adafruit/Adafruit_Python_PlatformDetect.git;branch=main;protocol=https"
 SRCREV = "e0fe1b012898fa824944d6805ca74be0fa027968"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-adafruit-pureio_1.1.8.bb
+++ b/recipes-devtools/python/python3-adafruit-pureio_1.1.8.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_Python_PureIO"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=2a21fcca821a506d4c36f7bbecc0d009"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_Python_PureIO.git;branch=main"
+SRC_URI = "git://github.com/adafruit/Adafruit_Python_PureIO.git;branch=main;protocol=https"
 SRCREV = "f4d0973da05b8b21905ff6bab69cdb652128f342"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python3-rtimu_git.bb
+++ b/recipes-devtools/python/python3-rtimu_git.bb
@@ -5,7 +5,7 @@ SECTION = "devel/python"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://../../LICENSE;md5=96cdecb41125f498958e09b72faf318e"
 
-SRC_URI = "git://github.com/RPi-Distro/RTIMULib.git;protocol=http;branch=master \
+SRC_URI = "git://github.com/RPi-Distro/RTIMULib.git;protocol=http;branch=master;protocol=https \
            file://0001-include-asm-ioctl.h-for-ioctl-define.patch;patchdir=../.. \
           "
 SRCREV = "b949681af69b45f0f7f4bb53b6770037b5b02178"

--- a/recipes-graphics/raspidmx/raspidmx_git.bb
+++ b/recipes-graphics/raspidmx/raspidmx_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=52962875ab02c36df6cde47b1f463024"
 COMPATIBLE_HOST = "null"
 COMPATIBLE_HOST:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'null', '(.*)', d)}"
 
-SRC_URI = "git://github.com/AndrewFromMelbourne/raspidmx;protocol=https \
+SRC_URI = "git://github.com/AndrewFromMelbourne/raspidmx;protocol=https;branch=master \
            file://0001-gitignore-add-archives-from-lib-directory.patch \
            file://0002-add-install-targets-to-Makefiles.patch \
            file://0003-switch-to-pkg-config.patch \

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -20,7 +20,7 @@ SRCREV = "97bc8180ad682b004ea224d1db7b8e108eda4397"
 PV = "20210623"
 
 SRC_URI = "\
-    git://github.com/${SRCFORK}/userland.git;protocol=git;branch=${SRCBRANCH} \
+    git://github.com/${SRCFORK}/userland.git;protocol=https;branch=${SRCBRANCH} \
     file://0001-Allow-applications-to-set-next-resource-handle.patch \
     file://0002-wayland-Add-support-for-the-Wayland-winsys.patch \
     file://0003-wayland-Add-Wayland-example.patch \

--- a/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
+++ b/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
@@ -23,7 +23,7 @@ LIC_FILES_CHKSUM = "\
 # so that the license files will be copied from fetched source
 NO_GENERIC_LICENSE[Firmware-cypress-rpidistro] = "LICENCE.cypress-rpidistro"
 
-SRC_URI = "git://github.com/RPi-Distro/bluez-firmware"
+SRC_URI = "git://github.com/RPi-Distro/bluez-firmware;branch=master;protocol=https"
 SRCREV = "e7fd166981ab4bb9a36c2d1500205a078a35714d"
 PV = "1.2-4+rpt8"
 

--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -34,7 +34,7 @@ LIC_FILES_CHKSUM = "\
 NO_GENERIC_LICENSE[Firmware-broadcom_bcm43xx-rpidistro] = "LICENCE.broadcom_bcm43xx"
 NO_GENERIC_LICENSE[WHENCE] = "WHENCE"
 
-SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree"
+SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree;branch=master;protocol=https"
 
 SRCREV = "83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5"
 PV = "20190114-1+rpt11"

--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -20,7 +20,7 @@ SRCREV_meta ?= '${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "li
 KMETA = "kernel-meta"
 
 SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH} \
+    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH};protocol=https \
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
     file://powersave.cfg \
     file://android-drivers.cfg \

--- a/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -8,7 +8,7 @@ SRCREV_meta = "e1979ceb171bc91ef2cb71cfcde548a101dab687"
 KMETA = "kernel-meta"
 
 SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH} \
+    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH};protocol=https \
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
     file://powersave.cfg \
     file://android-drivers.cfg \

--- a/recipes-multimedia/omxplayer/omxplayer_git.bb
+++ b/recipes-multimedia/omxplayer/omxplayer_git.bb
@@ -22,8 +22,8 @@ SRCREV_default = "f543a0d0e707ab56415f17b0ca6d397394ee8b63"
 # This SRCREV corresponds to the v4.0.3 release of ffmpeg.
 SRCREV_ffmpeg = "fcbd117df3077bad495e99e20f01cf93737bce76"
 
-SRC_URI = "git://github.com/popcornmix/omxplayer.git;protocol=git;branch=master \
-           git://github.com/FFmpeg/FFmpeg;branch=release/4.0;protocol=git;depth=1;name=ffmpeg;destsuffix=git/ffmpeg \
+SRC_URI = "git://github.com/popcornmix/omxplayer.git;protocol=https;branch=master \
+           git://github.com/FFmpeg/FFmpeg;branch=release/4.0;protocol=https;depth=1;name=ffmpeg;destsuffix=git/ffmpeg \
            file://0002-Libraries-and-headers-from-ffmpeg-are-installed-in-u.patch \
            file://0003-Remove-strip-step-in-Makefile.patch \
            file://0004-Add-FFMPEG_EXTRA_CFLAGS-and-FFMPEG_EXTRA_LDFLAGS.patch \


### PR DESCRIPTION
Use protocols=https for GitHub SRC_URIs using the conversion script in
openembedded-core.

Signed-off-by: Marcel Hamer <marcel@solidxs.se>