### PR TITLE
[dunfell] Cherry-pick github change in master

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 COMPATIBLE_MACHINE = "^rpi$"
 
 SRCREV = "648ffc470824c43eb0d16c485f4c24816b32cd6f"
-SRC_URI = "git://github.com/Evilpaul/RPi-config.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/Evilpaul/RPi-config.git;protocol=https;branch=master \
           "
 
 S = "${WORKDIR}/git"

--- a/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.12.bb
+++ b/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.12.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "\
 "
 
 SRC_URI = "\
-    git://github.com/RPi-Distro/pi-bluetooth \
+    git://github.com/RPi-Distro/pi-bluetooth;branch=master;protocol=https \
     file://0001-bthelper-correct-path-for-hciconfig-under-Yocto.patch \
 "
 SRCREV = "cbdbcb66bcc5b9af05f1a9fffe2254c872bb0ace"

--- a/recipes-devtools/pi-blaster/pi-blaster_git.bb
+++ b/recipes-devtools/pi-blaster/pi-blaster_git.bb
@@ -4,7 +4,7 @@ SECTION = "devel/libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://README.md;beginline=268;endline=292;md5=86d10e4bcf4b4014d306dde7c1d2a80d"
 
-SRC_URI = "git://github.com/sarfata/pi-blaster \
+SRC_URI = "git://github.com/sarfata/pi-blaster;branch=master;protocol=https \
            file://remove-initscript-lsb-dependency.patch \
            "
 

--- a/recipes-devtools/python/python3-rtimu_git.bb
+++ b/recipes-devtools/python/python3-rtimu_git.bb
@@ -5,7 +5,7 @@ SECTION = "devel/python"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://../../LICENSE;md5=96cdecb41125f498958e09b72faf318e"
 
-SRC_URI = "git://github.com/RPi-Distro/RTIMULib.git;protocol=http;branch=master \
+SRC_URI = "git://github.com/RPi-Distro/RTIMULib.git;protocol=http;branch=master;protocol=https \
            file://0001-include-asm-ioctl.h-for-ioctl-define.patch;patchdir=../.. \
           "
 SRCREV = "b949681af69b45f0f7f4bb53b6770037b5b02178"

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -20,7 +20,7 @@ SRCREV = "188d3bfe4a0ac36b119a2cee35a6be8d0c68e09e"
 PV = "20200624"
 
 SRC_URI = "\
-    git://github.com/${SRCFORK}/userland.git;protocol=git;branch=${SRCBRANCH} \
+    git://github.com/${SRCFORK}/userland.git;protocol=https;branch=${SRCBRANCH} \
     file://0001-Allow-applications-to-set-next-resource-handle.patch \
     file://0002-wayland-Add-support-for-the-Wayland-winsys.patch \
     file://0003-wayland-Add-Wayland-example.patch \

--- a/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
+++ b/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
@@ -23,7 +23,7 @@ LIC_FILES_CHKSUM = "\
 # so that the license files will be copied from fetched source
 NO_GENERIC_LICENSE[Firmware-cypress-rpidistro] = "LICENCE.cypress-rpidistro"
 
-SRC_URI = "git://github.com/RPi-Distro/bluez-firmware"
+SRC_URI = "git://github.com/RPi-Distro/bluez-firmware;branch=master;protocol=https"
 SRCREV = "96eefffcccc725425fd83be5e0704a5c32b79e54"
 PV = "0.0+git${SRCPV}"
 

--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -33,7 +33,7 @@ LIC_FILES_CHKSUM = "\
 NO_GENERIC_LICENSE[Firmware-broadcom_bcm43xx-rpidistro] = "LICENCE.broadcom_bcm43xx"
 NO_GENERIC_LICENSE[WHENCE] = "WHENCE"
 
-SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree"
+SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree;branch=master;protocol=https"
 
 SRCREV = "98e815735e2c805d65994ccc608f399595b74438"
 PV = "20190114-1+rpt8"

--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -20,7 +20,7 @@ SRCREV_meta ?= '${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "li
 KMETA = "kernel-meta"
 
 SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH} \
+    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH};protocol=https \
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
     file://powersave.cfg \
     file://android-drivers.cfg \

--- a/recipes-multimedia/omxplayer/omxplayer_git.bb
+++ b/recipes-multimedia/omxplayer/omxplayer_git.bb
@@ -22,8 +22,8 @@ SRCREV_default = "f543a0d0e707ab56415f17b0ca6d397394ee8b63"
 # This SRCREV corresponds to the v4.0.3 release of ffmpeg.
 SRCREV_ffmpeg = "fcbd117df3077bad495e99e20f01cf93737bce76"
 
-SRC_URI = "git://github.com/popcornmix/omxplayer.git;protocol=git;branch=master \
-           git://github.com/FFmpeg/FFmpeg;branch=release/4.0;protocol=git;depth=1;name=ffmpeg;destsuffix=git/ffmpeg \
+SRC_URI = "git://github.com/popcornmix/omxplayer.git;protocol=https;branch=master \
+           git://github.com/FFmpeg/FFmpeg;branch=release/4.0;protocol=https;depth=1;name=ffmpeg;destsuffix=git/ffmpeg \
            file://0002-Libraries-and-headers-from-ffmpeg-are-installed-in-u.patch \
            file://0003-Remove-strip-step-in-Makefile.patch \
            file://0004-Add-FFMPEG_EXTRA_CFLAGS-and-FFMPEG_EXTRA_LDFLAGS.patch \


### PR DESCRIPTION
THis cherrypicks and adapts on `dunfell` the GitHub protocol change done in master:

```
commit e31fba4c96cdf819958d05875fb8733481997806
Author: Marcel Hamer <marcel@solidxs.se>
Date:   Fri Nov 5 12:18:39 2021 +0100

    recipes: Update SRC_URI protocols for github

    Use protocols=https for GitHub SRC_URIs using the conversion script in
    openembedded-core.

    Signed-off-by: Marcel Hamer <marcel@solidxs.se>
```