### PR TITLE
rpi-base.inc: Added gpio-poweroff overlay.

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -22,6 +22,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/gpio-ir.dtbo \
     overlays/gpio-ir-tx.dtbo \
     overlays/gpio-key.dtbo \
+    overlays/gpio-poweroff.dtbo \
     overlays/hifiberry-amp.dtbo \
     overlays/hifiberry-dac.dtbo \
     overlays/hifiberry-dacplus.dtbo \


### PR DESCRIPTION
Some machines need to have the kernel toggle a gpio when an external
power source needs to shut off power to complete a shutdown and de-energize
the processor.  gpio-poweroff provides this functionality but was omitted
from the kernel overlays brought over by the rpi-layer from the kernel.
Signed-off-by: Cameron Kellough <cameron@telemetrak.com>

