### PR TITLE
libwpe: Migrate build workaround from oe-core

### DIFF
--- a/recipes-sato/libwpe_%.bbappend
+++ b/recipes-sato/libwpe_%.bbappend
@@ -1,0 +1,2 @@
+# Workaround build issue with RPi userland EGL libraries.
+CFLAGS:append:rpi = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', '-D_GNU_SOURCE', d)}"


### PR DESCRIPTION
This was removed from oe-core[1] so we pull in the change here where it
should have been in the first place.

Fixes: https://github.com/agherzan/meta-raspberrypi/issues/893

[1] https://lists.openembedded.org/g/openembedded-core/topic/84653556