### PR TITLE
rpi-config: don't trigger bbfatal for empty ENABLE_UART

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -30,6 +30,8 @@ GPIO_IR_TX ?= "17"
 
 CAN_OSCILLATOR ?= "16000000"
 
+ENABLE_UART ??= ""
+
 WM8960="${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "1", "0", d)}"
 
 inherit deploy nopackages
@@ -177,7 +179,7 @@ do_deploy() {
     if [ "${ENABLE_UART}" = "1" ] || [ "${ENABLE_UART}" = "0" ] ; then
         echo "# Enable UART" >>$CONFIG
         echo "enable_uart=${ENABLE_UART}" >>$CONFIG
-    else
+    elif [ -n "${ENABLE_UART}" ]; then
         bbfatal "Invalid value for ENABLE_UART [${ENABLE_UART}]. The value for ENABLE_UART can be 0 or 1."
     fi
 


### PR DESCRIPTION
Fixes https://github.com/agherzan/meta-raspberrypi/pull/941 not to show fatal error for default configuration with ENABLE_UART being empty.