### PR TITLE
linux-firmware-rpidistro: Use bullseye branch

### DIFF
--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -6,12 +6,12 @@ HOMEPAGE = "https://github.com/RPi-Distro/firmware-nonfree"
 SECTION = "kernel"
 
 # In maintained upstream linux-firmware:
-# * brcmfmac43430-sdio falls under LICENCE.cypress
-# * brcmfmac43455-sdio falls under LICENCE.broadcom_bcm43xx
-# * brcmfmac43456-sdio falls under LICENCE.broadcom_bcm43xx
+# * brcmfmac43430-sdio falls under LICENSE.cypress
+# * brcmfmac43455-sdio falls under LICENSE.broadcom_bcm43xx
+# * brcmfmac43456-sdio falls under LICENSE.broadcom_bcm43xx
 #
-# It is likely[^1] that both of these should be under LICENCE.cypress.
-# Further, at this time the text of LICENCE.broadcom_bcm43xx is the same
+# It is likely[^1] that both of these should be under LICENSE.cypress.
+# Further, at this time the text of LICENSE.broadcom_bcm43xx is the same
 # in linux-firmware and RPi-Distro/firmware-nonfree, but this may
 # change.
 #
@@ -22,22 +22,19 @@ SECTION = "kernel"
 # [^1]: https://github.com/RPi-Distro/bluez-firmware/issues/1
 LICENSE = "\
     Firmware-broadcom_bcm43xx-rpidistro \
-    & WHENCE \
 "
 LIC_FILES_CHKSUM = "\
-    file://LICENCE.broadcom_bcm43xx;md5=3160c14df7228891b868060e1951dfbc \
-    file://WHENCE;md5=7b12b2224438186e4c97c4c7f3a5cc28 \
+    file://debian/config/brcm80211/LICENSE;md5=8cba1397cda6386db37210439a0da3eb \
 "
 
 # These are not common licenses, set NO_GENERIC_LICENSE for them
 # so that the license files will be copied from fetched source
-NO_GENERIC_LICENSE[Firmware-broadcom_bcm43xx-rpidistro] = "LICENCE.broadcom_bcm43xx"
-NO_GENERIC_LICENSE[WHENCE] = "WHENCE"
+NO_GENERIC_LICENSE[Firmware-broadcom_bcm43xx-rpidistro] = "debian/config/brcm80211/LICENSE"
 
-SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree;branch=master;protocol=https"
+SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree;branch=bullseye;protocol=https"
 
-SRCREV = "54ffdd6e2ea6055d46656b78e148fe7def3ec9d8"
-PV = "20190114-2+rpt4"
+SRCREV = "b3eec612566ca08913f0830d299f4df70297428f"
+PV = "20210315-3+rpt3"
 
 S = "${WORKDIR}/git"
 
@@ -50,23 +47,20 @@ do_compile() {
 }
 
 do_install() {
-    install -d ${D}${nonarch_base_libdir}/firmware/brcm
+    install -d ${D}${nonarch_base_libdir}/firmware/brcm ${D}${nonarch_base_libdir}/firmware/cypress
 
-    cp ./LICENCE.broadcom_bcm43xx ${D}${nonarch_base_libdir}/firmware/LICENCE.broadcom_bcm43xx-rpidistro
+    cp debian/config/brcm80211/LICENSE ${D}${nonarch_base_libdir}/firmware/LICENSE.broadcom_bcm43xx-rpidistro
 
     # Replace outdated linux-firmware files with updated ones from
     # raspbian firmware-nonfree. Raspbian adds blobs and nvram
     # definitions that are also necessary so copy those too.
     for fw in brcmfmac43430-sdio brcmfmac43436-sdio brcmfmac43436s-sdio brcmfmac43455-sdio brcmfmac43456-sdio ; do
-        install -m 0644 brcm/${fw}.* ${D}${nonarch_base_libdir}/firmware/brcm/
+        cp -R --no-dereference --preserve=mode,links -v debian/config/brcm80211/brcm/${fw}.* ${D}${nonarch_base_libdir}/firmware/brcm/
     done
+    cp -R --no-dereference --preserve=mode,links -v debian/config/brcm80211/cypress/* ${D}${nonarch_base_libdir}/firmware/cypress/
     # add compat links. Fixes errors like
-    # brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.txt failed with error -2
-    ln -s brcmfmac43455-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.txt
+    # brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43455-sdio.raspberrypi,4-model-compute-module.txt failed with error -2
     ln -s brcmfmac43455-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.txt
-    ln -s brcmfmac43455-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43455-sdio.raspberrypi,3-model-b-plus.txt
-    ln -s brcmfmac43430-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.raspberrypi,3-model-b.txt
-    ln -s brcmfmac43430-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.raspberrypi,model-zero-w.txt
 }
 
 PACKAGES = "\
@@ -84,11 +78,11 @@ LICENSE:${PN}-bcm43436s = "Firmware-broadcom_bcm43xx-rpidistro"
 LICENSE:${PN}-bcm43455 = "Firmware-broadcom_bcm43xx-rpidistro"
 LICENSE:${PN}-bcm43456 = "Firmware-broadcom_bcm43xx-rpidistro"
 LICENSE:${PN}-broadcom-license = "Firmware-broadcom_bcm43xx-rpidistro"
-FILES:${PN}-broadcom-license = "${nonarch_base_libdir}/firmware/LICENCE.broadcom_bcm43xx-rpidistro"
-FILES:${PN}-bcm43430 = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43430*"
+FILES:${PN}-broadcom-license = "${nonarch_base_libdir}/firmware/LICENSE.broadcom_bcm43xx-rpidistro"
+FILES:${PN}-bcm43430 = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43430* ${nonarch_base_libdir}/firmware/cypress/cyfmac43430-sdio.bin"
 FILES:${PN}-bcm43436 = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43436-*"
 FILES:${PN}-bcm43436s = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43436s*"
-FILES:${PN}-bcm43455 = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43455*"
+FILES:${PN}-bcm43455 = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43455* ${nonarch_base_libdir}/firmware/cypress/cyfmac43455-sdio.*"
 FILES:${PN}-bcm43456 = "${nonarch_base_libdir}/firmware/brcm/brcmfmac43456*"
 RDEPENDS:${PN}-bcm43430 += "${PN}-broadcom-license"
 RDEPENDS:${PN}-bcm43436 += "${PN}-broadcom-license"


### PR DESCRIPTION
Switch to using bullseye release 20210315-3+rpt3 License is pointed in different location in new repo structure WHENCE file is gone too.

Fixes https://github.com/YoeDistro/yoe-distro/issues/617

Signed-off-by: Khem Raj <raj.khem@gmail.com>

**- What I did**

Backported 4c76dab6f04efcb97a6923b0587d56343912f5b5 commit from master.

