### PR TITLE
Use buster branch instead of master

### DIFF
--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -33,7 +33,7 @@ LIC_FILES_CHKSUM = "\
 NO_GENERIC_LICENSE[Firmware-broadcom_bcm43xx-rpidistro] = "LICENCE.broadcom_bcm43xx"
 NO_GENERIC_LICENSE[WHENCE] = "WHENCE"
 
-SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree;branch=master;protocol=https"
+SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree;branch=buster;protocol=https"
 
 SRCREV = "98e815735e2c805d65994ccc608f399595b74438"
 PV = "20190114-1+rpt8"


### PR DESCRIPTION
    Master branch has been renamed to buster.
    This change is dunfell-specific because master follows bullseye which
    diverted from ex-master quite a lot.
    
    Related: https://github.com/RPi-Distro/firmware-nonfree/issues/20
    Signed-off-by: Pavel Zhukov <pavel.zhukov@huawei.com>
