### PR TITLE
conf/machine: add variant Wi-Fi/BT drivers for CM4 and Pi 400

### DIFF
--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -8,6 +8,8 @@ MACHINE_FEATURES += "pci"
 MACHINE_EXTRA_RRECOMMENDS += "\
     linux-firmware-rpidistro-bcm43455 \
     bluez-firmware-rpidistro-bcm4345c0-hcd \
+    linux-firmware-rpidistro-bcm43456 \
+    bluez-firmware-rpidistro-bcm4345c5-hcd \
 "
 
 require conf/machine/include/arm/armv8a/tune-cortexa72.inc

--- a/conf/machine/raspberrypi4.conf
+++ b/conf/machine/raspberrypi4.conf
@@ -10,6 +10,8 @@ MACHINE_FEATURES += "pci"
 MACHINE_EXTRA_RRECOMMENDS += "\
     linux-firmware-rpidistro-bcm43455 \
     bluez-firmware-rpidistro-bcm4345c0-hcd \
+    linux-firmware-rpidistro-bcm43456 \
+    bluez-firmware-rpidistro-bcm4345c5-hcd \
 "
 
 # 'l' stands for LPAE


### PR DESCRIPTION
These boards use a slightly different chip which requires additional firmware to be present.

See: https://github.com/agherzan/meta-raspberrypi/issues/793#issuecomment-972959002