### PR TITLE
linux-firmware-rpidistro: set branch to buster

### DIFF
--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -34,7 +34,7 @@ LIC_FILES_CHKSUM = "\
 NO_GENERIC_LICENSE[Firmware-broadcom_bcm43xx-rpidistro] = "LICENCE.broadcom_bcm43xx"
 NO_GENERIC_LICENSE[WHENCE] = "WHENCE"
 
-SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree"
+SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree;branch=buster;protocol=https"
 
 SRCREV = "83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5"
 PV = "20190114-1+rpt11"


### PR DESCRIPTION
Branch has been renamed to buster in source repo.

Also setting protocol to https as GitHub is migrating
away from unencrypted git protocol
