### PR TITLE
parselogs: Update the error regexps to 5.10 kernel

### DIFF
--- a/lib/oeqa/runtime/cases/parselogs_rpi.py
+++ b/lib/oeqa/runtime/cases/parselogs_rpi.py
@@ -1,12 +1,6 @@
 from oeqa.runtime.cases.parselogs import *
 
 rpi_errors = [
-    'bcmgenet fd580000.genet: failed to get enet-eee clock',
-    'bcmgenet fd580000.genet: failed to get enet-wol clock',
-    'bcmgenet fd580000.genet: failed to get enet clock',
-    'bcmgenet fd580000.ethernet: failed to get enet-eee clock',
-    'bcmgenet fd580000.ethernet: failed to get enet-wol clock',
-    'bcmgenet fd580000.ethernet: failed to get enet clock',
 ]
 
 ignore_errors['raspberrypi4'] = rpi_errors + common_errors

--- a/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -1,8 +1,8 @@
-LINUX_VERSION ?= "5.10.78"
+LINUX_VERSION ?= "5.10.81"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-5.10"
 
-SRCREV_machine = "b2c047ab7e17a4ed702d313581620e826c58cc3c"
+SRCREV_machine = "f9bd396cd0f5f8c2026473f1e570deed3d08d350"
 SRCREV_meta = "e1979ceb171bc91ef2cb71cfcde548a101dab687"
 
 KMETA = "kernel-meta"


### PR DESCRIPTION
The old messages are no longer necessary and there is a new error
regarding sda and sda1 not being able to open blockdev this seems a
kernel problem which has been reported [1], until its understood better
lets ignore it.

[1] https://github.com/raspberrypi/linux/issues/4722

Signed-off-by: Khem Raj <raj.khem@gmail.com>
