### PR TITLE
weston-init: Add --continue-without-input option to weston

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+do_install:append:rpi() {
+    if [ -e ${D}/${sysconfdir}/init.d/weston ]; then
+        sed -i 's#weston-start --#weston-start -- --continue-without-input#' ${D}/${sysconfdir}/init.d/weston
+    fi
+    if [ -e ${D}${systemd_system_unitdir}/weston.service ]; then
+        sed -i 's#ExecStart=/usr/bin/weston#ExecStart=/usr/bin/weston --continue-without-input#' ${D}${systemd_system_unitdir}/weston.service
+    fi
+}


### PR DESCRIPTION
launching with --continue-without-input helps starting weston
without keyboard/mouse

Signed-off-by: Khem Raj <raj.khem@gmail.com>

