### PR TITLE
recipes-bsp: Add support for gpio-shutdown

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -23,6 +23,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/gpio-ir-tx.dtbo \
     overlays/gpio-key.dtbo \
     overlays/gpio-poweroff.dtbo \
+    overlays/gpio-shutdown.dtbo \
     overlays/hifiberry-amp.dtbo \
     overlays/hifiberry-dac.dtbo \
     overlays/hifiberry-dacplus.dtbo \
@@ -97,6 +98,7 @@ MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
 MACHINE_EXTRA_RRECOMMENDS += "kernel-modules udev-rules-rpi"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "${@oe.utils.conditional('ENABLE_I2C', '1', 'kernel-module-i2c-dev kernel-module-i2c-bcm2708', '', d)}"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "${@oe.utils.conditional('ENABLE_IR', '1', 'kernel-module-gpio-ir kernel-module-gpio-ir-tx', '', d)}"
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "${@oe.utils.conditional('ENABLE_GPIO_SHUTDOWN', '1', 'gpio-shutdown kernel-module-gpio-keys', '', d)}"
 
 SERIAL_CONSOLES_CHECK ??= "${SERIAL_CONSOLES}"
 

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -320,6 +320,24 @@ Appropriate kernel modules will be also included in the image. By default the
 GPIO pin for gpio-ir is set to 18 and the pin for gpio-ir-tx is 17. Both pins
 can be easily changed by modifying variables `GPIO_IR` and `GPIO_IR_TX`.
 
+## Enable gpio-shutdown
+
+When using device tree kernels, set this variable to enable gpio-shutdown:
+
+    ENABLE_GPIO_SHUTDOWN = "1"
+
+This will add the corresponding device tree overlay to config.txt and include
+the gpio-keys kernel module in the image. If System V init is used, additional
+mapping is applied to bind the button event to shutdown command. Systemd init
+should handle the event out of the box.
+
+By default the feature uses gpio pin 3 (except RPi 1 Model B rev 1 enumerates
+the pin as gpio 1). This conflicts with the I2C bus. If you set `ENABLE_I2C`
+to `1` or enabled `PiTFT` support, or otherwise want to use another pin, use
+`GPIO_SHUTDOWN_PIN` to assign another pin. Example using gpio pin 25:
+
+     GPIO_SHUTDOWN_PIN = "25"
+
 ## Manual additions to config.txt
 
 The `RPI_EXTRA_CONFIG` variable can be used to manually add additional lines to

--- a/recipes-bsp/gpio-shutdown/files/bind_gpio_shutdown.tab
+++ b/recipes-bsp/gpio-shutdown/files/bind_gpio_shutdown.tab
@@ -1,0 +1,2 @@
+# Action on special keypress (Key Power)
+kb::kbrequest:/sbin/shutdown -t1 -a -h -P now

--- a/recipes-bsp/gpio-shutdown/files/gpio-shutdown-keymap.sh
+++ b/recipes-bsp/gpio-shutdown/files/gpio-shutdown-keymap.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+##
+# Bind the gpio-shutdown keycode as Keyboard signal and load it to the
+# keymap during startup.
+##
+case "$1" in
+    start)
+    # Inject the gpio keycode to keymap
+    echo "keycode 116 = KeyboardSignal" | loadkeys
+    ;;
+    *)
+    ;;
+esac

--- a/recipes-bsp/gpio-shutdown/gpio-shutdown.bb
+++ b/recipes-bsp/gpio-shutdown/gpio-shutdown.bb
@@ -1,0 +1,31 @@
+SUMMARY = "GPIO shutdown bindings for SysV init"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+SRC_URI = "file://bind_gpio_shutdown.tab \
+    file://gpio-shutdown-keymap.sh \
+"
+
+inherit  update-rc.d
+
+INITSCRIPT_NAME = "gpio-shutdown-keymap.sh"
+# Run only once during startup
+INITSCRIPT_PARAMS = "start 99 S ."
+
+do_install() {
+    # The files are only needed if using SysV init.
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'true', 'false', d)}; then
+        install -d ${D}${sysconfdir} \
+            ${D}${sysconfdir}/inittab.d \
+            ${D}${sysconfdir}/init.d
+
+        install -m 0755 ${WORKDIR}/gpio-shutdown-keymap.sh ${D}${sysconfdir}/init.d/
+        install -m 0755 ${WORKDIR}/bind_gpio_shutdown.tab ${D}${sysconfdir}/inittab.d/
+    elif ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        # Systemd init does not require any configuration.
+        # Note: cannot have an empty branch, hence the redundant dir install.
+        install -d ${D}${sysconfdir}
+    else
+        bbwarn "Not using sysvinit or systemd. The gpio-shutdown may require additional configuration."
+    fi
+}


### PR DESCRIPTION
**- What I did**
Enable gpio-shutdown functionality, see https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README for reference.

**- How I did it**
In short, this feature includes the gpio-shutdown.dtbo. If systemd init is enabled, no futher configuration is needed. However if (the default) SysV init is used, the GPIO input requires additional binding which is handled by recipes-bsp/gpio-shutdown/gpio-shutdown.bb:
1. gpio-shutdown sends key code 116 which is bound to KeyboardSignal and injected into the keymap in gpio-shutdown-keymap.sh. This init script is executed at runlevel S
2. SysV inittab needs instructions what to do when KeyboardSignal is received. This is implemented by bind_gpio_shutdown.tab which is deployed to /etc/inittab.d/

The feature is enabled by variable ENABLE_GPIO_SHUTDOWN. Additionally an alternative GPIO pin can be specified using variable GPIO_SHUTDOWN_PIN. Since the gpio-shutdown by default uses the same pins as the master I2C bus, rpi-config_git.bb includes a rudimentary sanity check for a configuration conflict.

I mainly tested this with core-image-full-cmdline, with both SysV init and systemd init on Raspberry Pi 1 Model B.

