### PR TITLE
linux-raspberrypi: Upgrade to 5.10.83

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -1,8 +1,8 @@
-LINUX_VERSION ?= "5.10.81"
+LINUX_VERSION ?= "5.10.83"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-5.10"
 
-SRCREV_machine = "f9bd396cd0f5f8c2026473f1e570deed3d08d350"
+SRCREV_machine = "111a297d94e361de88d04b574acbca1bd5858cdb"
 SRCREV_meta = "e1979ceb171bc91ef2cb71cfcde548a101dab687"
 
 KMETA = "kernel-meta"


### PR DESCRIPTION
Upgrade linux-raspberrypi to 5.10.83.

Fixes #957.
