### PR TITLE
machine: add Pi Zero 2 W 32bits

### DIFF
--- a/conf/machine/raspberrypi0-2w.conf
+++ b/conf/machine/raspberrypi0-2w.conf
@@ -1,0 +1,17 @@
+#@TYPE: Machine
+#@NAME: RaspberryPi0 2 Wifi Development Board
+#@DESCRIPTION: Machine configuration for the RaspberryPi0 2 Wifi in 32 bits mode
+
+include conf/machine/raspberrypi3.conf
+
+MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberrypi3:${MACHINE}')}"
+
+MACHINE_EXTRA_RRECOMMENDS += "\
+    linux-firmware-rpidistro-bcm43436 \
+    linux-firmware-rpidistro-bcm43436s \
+    bluez-firmware-rpidistro-bcm43430b0-hcd \
+"
+
+RPI_KERNEL_DEVICETREE = " \
+    bcm2710-rpi-zero-2.dtb \
+    "


### PR DESCRIPTION
Added new machine configuration for Raspberry Pi Zero 2 W in 32bit mode.

Signed-off-by: Mauro Anjo <maurosanjo@gmail.com>