### PR TITLE
raspberrypi4-64: Switch to using cortexa72-crc default tune

### DIFF
--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -12,6 +12,8 @@ MACHINE_EXTRA_RRECOMMENDS += "\
     bluez-firmware-rpidistro-bcm4345c5-hcd \
 "
 
+DEFAULTTUNE = "cortexa72-crc"
+
 require conf/machine/include/arm/armv8a/tune-cortexa72.inc
 include conf/machine/include/rpi-base.inc
 


### PR DESCRIPTION
rpi4 SOC does not have AES Crypto in H/W

Fixes Issue #964

Signed-off-by: Khem Raj <raj.khem@gmail.com>
