### PR TITLE
bootfiles: allow i2c-gpio overlay

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -31,6 +31,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/justboom-both.dtbo \
     overlays/justboom-dac.dtbo \
     overlays/justboom-digi.dtbo \
+    overlays/i2c-gpio.dtbo \
     overlays/i2c-rtc.dtbo \
     overlays/imx219.dtbo \
     overlays/imx477.dtbo \


### PR DESCRIPTION
Hi all,
this is a RFC to be able to add i2c-gpio overlays.

Defining I2C_GPIO_CONFIG = "bus=7,i2c_gpio_sda=6,i2c_gpio_scl=5"
Will configure i2c-7 bus to use gpio 6 as SDA and gpio 5 as SCL

This way of configuration has the drawback to not be able to define more then one bus. Should we define an array? I saw some other defines using _X so we could use e.g

I2C_GPIO_CONFIG_X = "i2c_gpio_sda=6,i2c_gpio_scl=5" to define bus X and check a fix list of such variables?

I'm also not sure if we should abstract the command line even further?

I2C_GPIO_CONFIG_X_SCL=6
I2C_GPIO_CONFIG_X_SDA=5

Or something like that?