### PR TITLE
Add picamera support

### DIFF
--- a/recipes-multimedia/picamera-libs/picamera-libs.bb
+++ b/recipes-multimedia/picamera-libs/picamera-libs.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Raspberrypi firmware libraries which are required by picamera library"
+DESCRIPTION = "Raspberrypi firmware libraries required by picamera library"
+LICENSE = "Broadcom-RPi"
+
+LIC_FILES_CHKSUM = "file://opt/vc/LICENCE;md5=86e53f5f5909ee66900418028de11780"
+
+include recipes-bsp/common/raspberrypi-firmware.inc
+
+S = "${WORKDIR}/firmware-${SRCREV}"
+
+do_install(){
+    install -m 0755 -d ${D}${libdir}
+    install -m 0755 ${S}/opt/vc/lib/*.so ${D}${libdir}
+}
+
+FILES:${PN} = "${libdir}"
+
+#skipping the QA error since we are directly copying precompiled binaries
+INSANE_SKIP:${PN} = "ldflags"
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+SOLIBS = ".so"
+FILES_SOLIBSDEV = ""

--- a/recipes-multimedia/python3-picamera/python3-picamera_git.bb
+++ b/recipes-multimedia/python3-picamera/python3-picamera_git.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Python interface to the Raspberry Pi camera module"
+DESCRIPTION = "This package provides a pure Python interface to the Raspberry Pi camera module for Python 2.7 (or above) or Python 3.2 (or above)."
+HOMEPAGE = "https://github.com/waveform80/picamera" 
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=4de8aab427192e4a8322a71375d20e21"
+
+RDEPENDS:${PN} = "python3-numbers   \
+                  python3-ctypes    \
+                  python3-colorzero \
+                  picamera-libs     \
+"
+
+SRC_URI = "git://git@github.com/waveform80/picamera.git;protocol=ssh;branch=master"
+SRCREV = "7e4f1d379d698c44501fb84b886fadf3fc164b70"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools3


### PR DESCRIPTION
python3-picamera : recipe for python picamera library.
python3-colorzero: recipe for python colorzero library, required by picamera
picamera-libs    : recipe raspberry pi firmware which are required by picamera.

Closes: #959
Signed-off-by: bhargavthriler <bhargavthriler@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
Created recipe for python picamera library. Along with it created 2 more, python colorzero and picamera-libs.
