### PR TITLE
raspberrypi4-64: Switch to cortexa72 tune

### DIFF
--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -12,7 +12,7 @@ MACHINE_EXTRA_RRECOMMENDS += "\
     bluez-firmware-rpidistro-bcm4345c5-hcd \
 "
 
-DEFAULTTUNE = "cortexa72-crc"
+DEFAULTTUNE = "cortexa72"
 
 require conf/machine/include/arm/armv8a/tune-cortexa72.inc
 include conf/machine/include/rpi-base.inc


### PR DESCRIPTION
After commits ca50267ab568 & 03cebdd7ef92 in openembedded-core, the `cortexa72-crc` tune is no longer available and the `cortexa72` tune includes the crc extension by default. Update the raspberrypi4-64 machine config to handle these changes.