### PR TITLE
rpi-ssh: Add configuration option to enable ssh on first boot

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -278,6 +278,14 @@ the header extension should set the following in local.conf:
 
     ENABLE_DWC2_HOST = "1"
 
+## Enable SSH support
+
+By default the raspberry pi's disable ssh. By setting the following variable
+we create the empty file "ssh" in the /boot/ directory which is used to enable
+the ssh capabilities on first boot. Note: This file will be deleted when used.
+
+    ENABLE_SSH = "1"
+
 ## Enable Openlabs 802.15.4 radio module
 
 When using device tree kernels, set this variable to enable the 802.15.4 hat:

--- a/recipes-bsp/bootfiles/rpi-bootfiles.bb
+++ b/recipes-bsp/bootfiles/rpi-bootfiles.bb
@@ -9,7 +9,7 @@ include recipes-bsp/common/raspberrypi-firmware.inc
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-DEPENDS = "rpi-config rpi-cmdline"
+DEPENDS = "rpi-config rpi-cmdline rpi-ssh"
 
 COMPATIBLE_MACHINE = "^rpi$"
 
@@ -34,7 +34,11 @@ do_deploy() {
     touch ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/${PN}-${PV}.stamp
 }
 
-do_deploy[depends] += "rpi-config:do_deploy rpi-cmdline:do_deploy"
+do_deploy[depends] += "\
+    rpi-config:do_deploy\
+    rpi-cmdline:do_deploy\
+    rpi-ssh:do_deploy\
+"
 
 addtask deploy before do_build after do_install
 do_deploy[dirs] += "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}"

--- a/recipes-bsp/bootfiles/rpi-ssh.bb
+++ b/recipes-bsp/bootfiles/rpi-ssh.bb
@@ -1,0 +1,30 @@
+DESCRIPTION = "ssh file for the Raspberry Pi. \
+               by adding this file we enable ssh connections."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+COMPATIBLE_MACHINE = "^rpi$"
+
+SRCREV = "648ffc470824c43eb0d16c485f4c24816b32cd6f"
+SRC_URI = "git://github.com/Evilpaul/RPi-config.git;protocol=https;branch=master \
+          "
+
+S = "${WORKDIR}/git"
+
+PR = "r5"
+
+inherit deploy nopackages
+
+do_deploy() {
+    install -d ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}
+
+    # Create the empty ssh file to allow for ssh connections
+    if ([ "${ENABLE_SSH}" = "1" ]); then
+        touch ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/ssh
+    fi
+}
+
+addtask deploy before do_build after do_install
+do_deploy[dirs] += "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Signed-off-by: Andrew Penner <andrew.penner@protonmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
I added a new configuration option ENABLE_SSH to create the empty ssh file in /boot so the system will be able to enable ssh on first boot.

**- How I did it**
I created a new recipe in recipese-bsp/bootfiles that reads conf/local.conf for ENABLE_SSH. If ENABLE_SSH is set to "1" we touch the file /boot/ssh which is added to the final image.