### PR TITLE
picamera-libs,python3-picamera: Limit visibility to rpi machines

### DIFF
--- a/recipes-devtools/python/rpi-gpio_0.7.0.bb
+++ b/recipes-devtools/python/rpi-gpio_0.7.0.bb
@@ -5,7 +5,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENCE.txt;md5=9b95630a648966b142f1a0dcea001cb7"
 
 PYPI_PACKAGE = "RPi.GPIO"
-inherit pypi distutils3
+inherit pypi setuptools3
 
 SRC_URI += "file://0001-Remove-nested-functions.patch"
 SRC_URI[md5sum] = "777617f9dea9a1680f9af43db0cf150e"

--- a/recipes-multimedia/picamera-libs/picamera-libs.bb
+++ b/recipes-multimedia/picamera-libs/picamera-libs.bb
@@ -21,3 +21,6 @@ INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_SYSROOT_STRIP = "1"
 SOLIBS = ".so"
 FILES_SOLIBSDEV = ""
+
+COMPATIBLE_HOST = "null"
+COMPATIBLE_HOST:rpi:libc-glibc = "(arm.*)-linux"

--- a/recipes-multimedia/python3-picamera/python3-picamera_git.bb
+++ b/recipes-multimedia/python3-picamera/python3-picamera_git.bb
@@ -17,3 +17,6 @@ SRCREV = "7e4f1d379d698c44501fb84b886fadf3fc164b70"
 S = "${WORKDIR}/git"
 
 inherit setuptools3
+
+COMPATIBLE_HOST = "null"
+COMPATIBLE_HOST:rpi:libc-glibc = "(arm.*)-linux"


### PR DESCRIPTION
https://github.com/agherzan/meta-raspberrypi/pull/983 introduced these
recipes however these are not generic packages that can be used on non-rpi machines
therefore mark them so. It helps in using this SOC layer with other SOC
layers in a distro

Signed-off-by: Khem Raj <raj.khem@gmail.com>

