### PR TITLE
rpi-cmdline: Allow user to configure the raspberry pi in gadget mode

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -269,6 +269,18 @@ local.conf:
 
     ENABLE_DWC2_PERIPHERAL = "1"
 
+Note: This setting is incompatible with the ENABLE_DWC2_OTG and ENABLE_DWC2_HOST
+
+## Enable USB OTG (on the go) support
+
+The standard USB driver only supports host mode operations.  Users who
+want to use gadget modules like g_ether and support host mode should set the 
+following in local.conf:
+
+    ENABLE_DWC2_OTG = "1"
+
+Note: This setting is incompatible with the ENABLE_DWC2_PERIPHERAL and ENABLE_DWC2_HOST
+
 ## Enable USB host support
 
 By default in case of the Compute Module 4 IO Board the standard USB driver
@@ -277,6 +289,34 @@ Users who want to use the 2 USB built-in ports or the other ports provided via
 the header extension should set the following in local.conf:
 
     ENABLE_DWC2_HOST = "1"
+
+Note: This setting is incompatible with the ENABLE_DWC2_PERIPHERAL and ENABLE_DWC2_OTG
+
+## Enable gadget modes
+
+Enable the use of ethernet over USB
+
+    ENABLE_ETHERNET_GADGET = "1"
+
+Enable the use of serial over USB
+
+    ENABLE_SERIAL_GADGET = "1"
+
+Enable the use of ethernet and serial over USB
+
+    ENABLE_CDC_GADGET = "1"
+
+Enable the use of ethernet and mass storage over USB
+
+    ENABLE_MULTI_GADGET = "1"
+
+Set the host MAC address when using RNDIS, only used when a gadget mode is enabled
+
+    GADGET_HOST_MAC_ADDR = "de:ad:be:ef:12"
+
+Set the dev MAC address when using RNDIS, only used when a gadget mode is enabled
+
+    GADGET_DEV_MAC_ADDR = "fe:eb:da:ed:12"
 
 ## Enable Openlabs 802.15.4 radio module
 

--- a/recipes-bsp/bootfiles/rpi-cmdline.bb
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bb
@@ -29,12 +29,65 @@ CMDLINE_LOGO ?= '${@oe.utils.conditional("DISABLE_RPI_BOOT_LOGO", "1", "logo.nol
 # to enable kernel debugging.
 CMDLINE_DEBUG ?= ""
 
-# Add RNDIS capabilities (must be after rootwait)
-# example: 
-# CMDLINE_RNDIS = "modules-load=dwc2,g_ether g_ether.host_addr=<some MAC 
-# address> g_ether.dev_addr=<some MAC address>"
+# Add gadget capabilities (must be after rootwait)
 # if the MAC addresses are omitted, random values will be used
-CMDLINE_RNDIS ?= ""
+def setup_gadget_mac(d, gadget_type):
+    string = ""
+    if d.getVar('GADGET_HOST_MAC_ADDR'):
+        string += " " + gadget_type + ".host_addr="\
+          + d.getVar('GADGET_HOST_MAC_ADDR')
+    if d.getVar('GADGET_DEV_MAC_ADDR'):
+        string += " " + gadget_type + ".dev_addr="\
+          + d.getVar('GADGET_DEV_MAC_ADDR')
+    return string
+
+def setup_mass_storage(d, gadget_type):
+    string = ""
+    if d.getVar('GADGET_MASS_STORAGE_NAME'):
+        string += " " + gadget_type + ".file="\
+          + d.getVar('GADGET_MASS_STORAGE_NAME')
+    return string
+
+# Setup the gadget configuration
+def setup_gadget_mode(d):
+    string = ""
+    if not bb.utils.contains('DISTRO_FEATURES', 'systemd', True, False, d)\
+        or d.getVar('ENABLE_DWC2_PERIPHERAL') != "1":
+            return string
+
+    if d.getVar('ENABLE_ETHER_GADGET') == "1":
+        string += "modules-load=dwc2,g_ether"
+
+        # If the user supplies a host or a dev mac address, use it
+        string += setup_gadget_mac(d, "g_ether")
+
+    elif d.getVar('ENABLE_CDC_GADGET') == "1":
+        string += "modules-load=dwc2,g_cdc"
+
+        # If the user supplies a host or a dev mac address, use it
+        string += setup_gadget_mac(d, "g_cdc")
+
+    elif d.getVar('ENABLE_SERIAL_GADGET') == "1":
+        string += "modules-load=dwc2,g_serial"
+
+    elif d.getVar('ENABLE_MULTI_GADGET') == "1":
+        string += "modules-load=dwc2,g_multi"
+
+        # If the user supplies a mass storage name use it
+        string += setup_mass_storage(d, 'g_multi')
+
+        # If the user supplies a host or a dev mac address, use it
+        string += setup_gadget_mac(d, "g_multi")
+
+    elif d.getVar('ENABLE_MASS_STORAGE_GADGET') == "1":
+        string += "modules-load=dwc2,g_mass_storage"
+
+        # If the user supplies a mass storage name use it
+        string += setup_mass_storage(d, 'g_mass_storage')
+
+    return string
+
+CMDLINE_GADGET_MODE ?= "${@setup_gadget_mode(d)}"
 
 CMDLINE = " \
     ${CMDLINE_DWC_OTG} \


### PR DESCRIPTION
Signed-off-by: Andrew Penner <andrew.penner@protonmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
I added several new configuration options to allow users to enable different gadget modes. These include:
g_serial, g_ether, g_cdc, and c_multi.

**- How I did it**
I modified the existing cmdline recipe to use new configuration variables to modify the text in cmdline.txt so the booted device will load the correct modules that enable the Raspberry Pi to operate as a gadget.