### PR TITLE
python3-adafruit-blinka: Disable on musl

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "raspberrypi"
 BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
-LAYERSERIES_COMPAT_raspberrypi = "honister"
+LAYERSERIES_COMPAT_raspberrypi = "kirkstone"
 LAYERDEPENDS_raspberrypi = "core"
 
 # Additional license directories.

--- a/conf/machine/include/rpi-default-versions.inc
+++ b/conf/machine/include/rpi-default-versions.inc
@@ -1,3 +1,3 @@
 # RaspberryPi BSP default versions
 
-PREFERRED_VERSION_linux-raspberrypi ??= "5.10.%"
+PREFERRED_VERSION_linux-raspberrypi ??= "5.15.%"

--- a/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
+++ b/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
@@ -28,3 +28,6 @@ RDEPENDS:${PN} += " \
 "
 
 RDEPENDS:${PN}:append:rpi = " rpi-gpio"
+
+COMPATIBLE_HOST:libc-musl:class-target = "null"
+

--- a/recipes-devtools/python/python3-adafruit-circuitpython-busdevice_5.0.5.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-busdevice_5.0.5.bb
@@ -16,3 +16,4 @@ RDEPENDS:${PN} += " \
     python3-adafruit-blinka \
     python3-core \
 "
+COMPATIBLE_HOST:libc-musl:class-target = "null"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-motor_3.2.6.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-motor_3.2.6.bb
@@ -16,3 +16,4 @@ RDEPENDS:${PN} += " \
     python3-adafruit-blinka \
     python3-core \
 "
+COMPATIBLE_HOST:libc-musl:class-target = "null"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-motorkit_1.6.1.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-motorkit_1.6.1.bb
@@ -20,3 +20,4 @@ RDEPENDS:${PN} += " \
     python3-adafruit-circuitpython-register \
     python3-core \
 "
+COMPATIBLE_HOST:libc-musl:class-target = "null"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-pca9685_3.3.4.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-pca9685_3.3.4.bb
@@ -18,3 +18,4 @@ RDEPENDS:${PN} += " \
     python3-adafruit-circuitpython-register \
     python3-core \
 "
+COMPATIBLE_HOST:libc-musl:class-target = "null"

--- a/recipes-kernel/linux/linux-raspberrypi_5.15.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.15.bb
@@ -1,0 +1,19 @@
+LINUX_VERSION ?= "5.15.24"
+LINUX_RPI_BRANCH ?= "rpi-5.15.y"
+LINUX_RPI_KMETA_BRANCH ?= "yocto-5.15"
+
+SRCREV_machine = "770d94882ac145c81af72e9a37180806c3f70bbd"
+SRCREV_meta = "e1b976ee4fb5af517cf01a9f2dd4a32f560ca894"
+
+KMETA = "kernel-meta"
+
+SRC_URI = " \
+    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH};protocol=https \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
+    file://powersave.cfg \
+    file://android-drivers.cfg \
+    "
+
+require linux-raspberrypi.inc
+
+KERNEL_DTC_FLAGS += "-@ -H epapr"


### PR DESCRIPTION
it provides prebuilts which are linked against glibc. so disable it for
musl

Fixes
microcontroller/bcm283x/pulseio/libgpiod_pulsein contained in package python3-adafruit-blinka requires libc.so.6(GLIBC_2.4), but no providers found in RDEPENDS:python3-adafruit-blinka? [file-rdeps]

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
