### PR TITLE
python3-adafruit-blinka: Disable on musl

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-blinka_6.2.2.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-blinka_6.2.2.bb
@@ -28,3 +28,6 @@ RDEPENDS:${PN} += " \
 "
 
 RDEPENDS:${PN}:append:rpi = " rpi-gpio"
+
+COMPATIBLE_HOST:libc-musl:class-target = "null"
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-busdevice_5.0.5.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-busdevice_5.0.5.bb
@@ -16,3 +16,4 @@ RDEPENDS:${PN} += " \
     python3-adafruit-blinka \
     python3-core \
 "
+COMPATIBLE_HOST:libc-musl:class-target = "null"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-motor_3.2.6.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-motor_3.2.6.bb
@@ -16,3 +16,4 @@ RDEPENDS:${PN} += " \
     python3-adafruit-blinka \
     python3-core \
 "
+COMPATIBLE_HOST:libc-musl:class-target = "null"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-motorkit_1.6.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-motorkit_1.6.1.bb
@@ -20,3 +20,4 @@ RDEPENDS:${PN} += " \
     python3-adafruit-circuitpython-register \
     python3-core \
 "
+COMPATIBLE_HOST:libc-musl:class-target = "null"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-pca9685_3.3.4.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-pca9685_3.3.4.bb
@@ -18,3 +18,4 @@ RDEPENDS:${PN} += " \
     python3-adafruit-circuitpython-register \
     python3-core \
 "
+COMPATIBLE_HOST:libc-musl:class-target = "null"


### PR DESCRIPTION
it provides prebuilts which are linked against glibc. so disable it for
musl

Fixes
microcontroller/bcm283x/pulseio/libgpiod_pulsein contained in package python3-adafruit-blinka requires libc.so.6(GLIBC_2.4), but no providers found in RDEPENDS:python3-adafruit-blinka? [file-rdeps]

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
