### PR TITLE
gstreamer1.0-plugins-bad: remove libmms PACKAGECONFIG and add gpl

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,2 +1,2 @@
-PACKAGECONFIG:append:rpi = " hls libmms \
-                   ${@bb.utils.contains('LICENSE_FLAGS_WHITELIST', 'commercial', 'faad', '', d)}"
+PACKAGECONFIG:append:rpi = " hls \
+                   ${@bb.utils.contains('LICENSE_FLAGS_WHITELIST', 'commercial', 'gpl faad', '', d)}"


### PR DESCRIPTION
* libmms was removed with 1.20.0 upgrade in:
  https://git.openembedded.org/openembedded-core/commit/?id=76433d3628cbad311b428a57b25b4e2701ee513b

* fixes:
```
  ERROR: gstreamer1.0-plugins-bad-1.20.0-r0 do_configure: QA Issue: gstreamer1.0-plugins-bad: invalid PACKAGECONFIG: libmms [invalid-packageconfig]
```

* faad now requires gpl to be enabled:
```
  | ../gst-plugins-bad-1.20.0/ext/faad/meson.build:1:0: ERROR: Feature faad cannot be enabled:
  |   Plugin faad explicitly required via options but GPL-licensed plugins disabled via options.
  |   Pass option -Dgpl=enabled to Meson to allow GPL-licensed plugins to be built.
```