### PR TITLE
layers: Bump to use kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "raspberrypi"
 BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
-LAYERSERIES_COMPAT_raspberrypi = "honister"
+LAYERSERIES_COMPAT_raspberrypi = "kirkstone"
 LAYERDEPENDS_raspberrypi = "core"
 
 # Additional license directories.


### PR DESCRIPTION
its not going to be backward ABI compatible with honister due to variable renaming.

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
