### PR TITLE
A set of various updates and fixes

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -115,7 +115,6 @@ def make_dtb_boot_files(d):
     # Generate IMAGE_BOOT_FILES entries for device tree files listed in
     # KERNEL_DEVICETREE.
     alldtbs = d.getVar('KERNEL_DEVICETREE')
-    imgtyp = d.getVar('KERNEL_IMAGETYPE')
 
     def transform(dtb):
         base = os.path.basename(dtb)

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -29,7 +29,7 @@ Accommodate the values above to your own needs (ex: ext3 / ext4).
 * `GPU_MEM_1024`: GPU memory in megabyte for the 1024MB Raspberry Pi. Ignored by
   the 256MB/512MB RP. Overrides gpu_mem. Max 944. Default not set.
 
-See: <https://www.raspberrypi.org/documentation/configuration/config-txt/memory.md>
+See: <https://www.raspberrypi.com/documentation/computers/config_txt.html#memory-options>
 
 ## VC4
 
@@ -47,7 +47,7 @@ You can supply more licenses separated by comma. Example:
 
     KEY_DECODE_WVC1 = "0x12345678,0xabcdabcd,0x87654321"
 
-See: <https://www.raspberrypi.org/documentation/configuration/config-txt/codeclicence.md>
+See: <https://www.raspberrypi.com/documentation/computers/config_txt.html#licence-key-and-codec-options>
 
 ## Disable overscan
 
@@ -89,7 +89,7 @@ Example official settings for Turbo Mode in Raspberry Pi 2:
     SDRAM_FREQ = "500"
     OVER_VOLTAGE = "6"
 
-See: <https://www.raspberrypi.org/documentation/configuration/config-txt/overclocking.md>
+See: <https://www.raspberrypi.com/documentation/computers/config_txt.html#overclocking-options>
 
 ## HDMI and composite video options
 
@@ -106,7 +106,7 @@ Example to force HDMI output to 720p in CEA mode:
     HDMI_GROUP = "1"
     HDMI_MODE = "4"
 
-See: <https://www.raspberrypi.org/documentation/configuration/config-txt/video.md>
+See: <https://www.raspberrypi.com/documentation/computers/configuration.html#hdmi-configuration>
 
 ## Video camera support with V4L2 drivers
 

--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,9 +1,9 @@
 RPIFW_DATE ?= "20211007"
-SRCREV ?= "0c4fc71befd228419a225c84d316cabbda8633a7"
-RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz;downloadfilename=raspberrypi-firmware-${SRCREV}.tar.gz"
-RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
+
+RPIFW_SRC_URI ?= "https://archive.raspberrypi.com/debian/pool/main/r/raspberrypi-firmware/raspberrypi-firmware_1.${RPIFW_DATE}.orig.tar.xz"
+RPIFW_S ?= "${WORKDIR}/raspberrypi-firmware-1.${RPIFW_DATE}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[sha256sum] = "2502930165328be3b292389b1f7e25365c724000d6c404b63a5a0ba7af120aa7"
+SRC_URI[sha256sum] = "cb08f4679ab9928f89b2b73bbd92dace84dd692e1e1722f373eebd350f0c058f"
 
 PV = "${RPIFW_DATE}"

--- a/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -1,8 +1,8 @@
-LINUX_VERSION ?= "5.10.83"
+LINUX_VERSION ?= "5.10.95"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-5.10"
 
-SRCREV_machine = "111a297d94e361de88d04b574acbca1bd5858cdb"
+SRCREV_machine = "a538fd26f82b101cb6fb963042f3242768e628d4"
 SRCREV_meta = "e1979ceb171bc91ef2cb71cfcde548a101dab687"
 
 KMETA = "kernel-meta"

--- a/recipes-kernel/linux/linux-raspberrypi_5.15.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.15.bb
@@ -2,7 +2,7 @@ LINUX_VERSION ?= "5.15.24"
 LINUX_RPI_BRANCH ?= "rpi-5.15.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-5.15"
 
-SRCREV_machine = "770d94882ac145c81af72e9a37180806c3f70bbd"
+SRCREV_machine = "ac66b3f757a3a6c84c6641356fb81c9fce3e89e9"
 SRCREV_meta = "e1b976ee4fb5af517cf01a9f2dd4a32f560ca894"
 
 KMETA = "kernel-meta"


### PR DESCRIPTION
* bump both 5.10 and 5.15 kernel recipes
* use a stable release tarball from raspberrypi deb repository for the raspberrypi firmware recipe
* ~~include support for bcm2711-rpi-cm4s (superseeds https://github.com/agherzan/meta-raspberrypi/pull/995)~~ Dropped as it doesn't support 64bit (as the initial PR proposed it).
* fix inconsistency between wic and sdimg images (partially fixes https://github.com/agherzan/meta-raspberrypi/issues/1013)
