### PR TITLE
python: Unbolt wheel packaging PIP_INSTALL_PACKAGE band-aids

### DIFF
--- a/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.4.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.4.bb
@@ -11,6 +11,5 @@ SRCREV = "5fee6e0c3878110844bc51e16063eeae7d94c457"
 DEPENDS += "python3-setuptools-scm-native"
 
 inherit setuptools3
-PIP_INSTALL_PACKAGE = "adafruit_circuitpython_register"
 
 RDEPENDS:${PN} += "python3-core"

--- a/recipes-devtools/python/python3-adafruit-platformdetect_3.1.1.bb
+++ b/recipes-devtools/python/python3-adafruit-platformdetect_3.1.1.bb
@@ -10,8 +10,6 @@ S = "${WORKDIR}/git"
 
 inherit setuptools3
 
-PIP_INSTALL_PACKAGE = "Adafruit_PlatformDetect"
-
 DEPENDS += "python3-setuptools-scm-native"
 
 RDEPENDS:${PN} += "python3-core"

--- a/recipes-devtools/python/python3-adafruit-pureio_1.1.8.bb
+++ b/recipes-devtools/python/python3-adafruit-pureio_1.1.8.bb
@@ -9,7 +9,7 @@ SRCREV = "f4d0973da05b8b21905ff6bab69cdb652128f342"
 S = "${WORKDIR}/git"
 
 inherit setuptools3
-PIP_INSTALL_PACKAGE = "Adafruit_PureIO"
+
 DEPENDS += "python3-setuptools-scm-native"
 
 RDEPENDS:${PN} += " \

--- a/recipes-devtools/python/python3-rtimu_git.bb
+++ b/recipes-devtools/python/python3-rtimu_git.bb
@@ -12,5 +12,4 @@ SRC_URI = "git://github.com/RPi-Distro/RTIMULib.git;protocol=http;branch=master;
 SRCREV = "b949681af69b45f0f7f4bb53b6770037b5b02178"
 
 S = "${WORKDIR}/git/Linux/python"
-PYPA_WHEEL = "${B}/dist/RTIMULib-7.2.1-*.whl"
 inherit setuptools3

--- a/recipes-devtools/python/rpi-gpio_0.7.0.bb
+++ b/recipes-devtools/python/rpi-gpio_0.7.0.bb
@@ -5,9 +5,8 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENCE.txt;md5=9b95630a648966b142f1a0dcea001cb7"
 
 PYPI_PACKAGE = "RPi.GPIO"
-inherit pypi setuptools3
 
-PIP_INSTALL_PACKAGE = "RPi.GPIO"
+inherit pypi setuptools3
 
 SRC_URI += "file://0001-Remove-nested-functions.patch \
             file://0001-setup.py-Use-setuptools-instead-of-distutils.patch \


### PR DESCRIPTION
OE-Core has improved packaging the whl files therefore remove the
band-aids.

Signed-off-by: Khem Raj <raj.khem@gmail.com>

