### PR TITLE
rpi-cmdline: Add option to append isolcpus to cmdline.txt

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -278,6 +278,18 @@ the header extension should set the following in local.conf:
 
     ENABLE_DWC2_HOST = "1"
 
+## Set CPUs to be isolated from the standard Linux scheduler
+
+By default Linux will use all available CPUs for scheduling tasks. For real time
+purposes there can be an advantage to isolating one or more CPUs from the
+standard scheduler. It should be noted that CPU 0 is special, it is the only CPU
+available during the early stages of the boot process and cannot be isolated.
+
+The string assigned to this variable may be a single CPU number, a comma
+separated list ("1,2"), a range("1-3"), or a mixture of these ("1,3-5")
+
+    ISOLATED_CPUS = "1-2"
+
 ## Enable Openlabs 802.15.4 radio module
 
 When using device tree kernels, set this variable to enable the 802.15.4 hat:

--- a/recipes-bsp/bootfiles/rpi-cmdline.bb
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bb
@@ -29,6 +29,18 @@ CMDLINE_LOGO ?= '${@oe.utils.conditional("DISABLE_RPI_BOOT_LOGO", "1", "logo.nol
 # to enable kernel debugging.
 CMDLINE_DEBUG ?= ""
 
+# Add a request to isolate processors from the Linux scheduler. ISOLATED_CPUS
+# may have the form of a comma separated list of processor numbers "0,1,3", a
+# range "0-2", a combination of the two "0-1,3", or a single processor you may
+# not specify ALL processors simultaneously
+def setup_isolcpus(d):
+    string = ""
+    if d.getVar('ISOLATED_CPUS'):
+        string = 'isolcpus=' + d.getVar('ISOLATED_CPUS')
+    return string
+
+CMDLINE_ISOL_CPUS ?= "${@setup_isolcpus(d)}"
+
 # Add RNDIS capabilities (must be after rootwait)
 # example: 
 # CMDLINE_RNDIS = "modules-load=dwc2,g_ether g_ether.host_addr=<some MAC 
@@ -37,6 +49,7 @@ CMDLINE_DEBUG ?= ""
 CMDLINE_RNDIS ?= ""
 
 CMDLINE = " \
+    ${CMDLINE_ISOL_CPUS} \
     ${CMDLINE_DWC_OTG} \
     ${CMDLINE_SERIAL} \
     ${CMDLINE_ROOTFS} \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
I have added a new variable to be parsed and added to cmdline.txt that allows us to take advantage of the isolcpus capabilities typically used for real time tasks

**- How I did it**
I added a new variable to be read from conf/local.conf and added to cmdline.txt via the rpi-cmdline.bb recipe