### PR TITLE
linux-raspberrypi: add UBOOT_ENTRYPOINT to match LOADADDR

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -34,4 +34,7 @@ KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", 
 # A LOADADDR is needed when building a uImage format kernel. This value is not
 # set by default in rpi-4.8.y and later branches so we need to provide it
 # manually. This value unused if KERNEL_IMAGETYPE is not uImage.
-KERNEL_EXTRA_ARGS += "LOADADDR=0x00008000"
+KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
+
+UBOOT_ENTRYPOINT =       "0x00008000"
+UBOOT_LOADADDRESS =      "0x00008000"


### PR DESCRIPTION
This is so that uboot fit images have an entry point that matches the
LOADADDR that everything is expecting.