### PR TITLE
python3-sense-hat: Use specific BSD license

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/python/python3-sense-hat_2.2.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/python/python3-sense-hat_2.2.0.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Python module to control the Raspberry Pi Sense HAT used in the Astro Pi mission"
 HOMEPAGE = "https://github.com/RPi-Distro/python-sense-hat"
 SECTION = "devel/python"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENCE.txt;md5=d80fe312e1ff5fbd97369b093bf21cda"
 
 inherit setuptools3 pypi


### PR DESCRIPTION
Fixes
WARNING: python3-sense-hat-2.2.0-r0 do_populate_lic: QA Issue: python3-sense-hat: No generic license file exists for: BSD in any provider [license-exists]

Signed-off-by: Khem Raj <raj.khem@gmail.com>
