### PR TITLE
kmod: Enable xz compression

### DIFF
--- a/recipes-kernel/kmod/kmod_%.bbappend
+++ b/recipes-kernel/kmod/kmod_%.bbappend
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Andrei Gherzan <andrei@gherzan.com>
+#
+# SPDX-License-Identifier: MIT
+
+PACKAGECONFIG:append:rpi = " xz"


### PR DESCRIPTION
The RaspberryPi default Linux kernel configuration uses xz for
compressing kernel modules[1]. This was introduced in 5.15. We need the
respective support in kmod too.

[1]https://github.com/raspberrypi/linux/pull/4991

Fixes: https://github.com/agherzan/meta-raspberrypi/issues/1054
