### PR TITLE
rng-tools: disable libjitterentropy due to cpu usage

### DIFF
--- a/recipes-support/rng-tools/rng-tools_%.bbappend
+++ b/recipes-support/rng-tools/rng-tools_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# disable libjitterentropy because of sustained cpu use after boot
+# instead we depend on /dev/hwrng via config
+PACKAGECONFIG = ""


### PR DESCRIPTION
Since updating to kirkstone from hardknott, after boot rngd maxes out my rpi4's processor for minutes initializing JITTER. The sustained CPU usage was triggering my resource monitoring alerts. Changing config to disable jitter with `-x jitter` stops the initialization process and uses just the pi's hardware rng source. Since that solved the problem I disabled building rng-tools with libjitterentropy enabled.

If this is a problem for other users devices I thought this simple change could be helpful.

**- What I did**
Disable libjitterentropy in rng-tools.

**- How I did it**
Set `PACKAGECONFIG` to override the default poky setting which is `libjitterentropy`.