### PR TITLE
Revert "kmod: Enable xz compression"

### DIFF
--- a/recipes-kernel/kmod/kmod_%.bbappend
+++ b/recipes-kernel/kmod/kmod_%.bbappend
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: Andrei Gherzan <andrei@gherzan.com>
-#
-# SPDX-License-Identifier: MIT
-
-PACKAGECONFIG:append:rpi = " xz"


### PR DESCRIPTION
This reverts commit c97a9e34abf23d871903481ac1867efec9abf090 as it was fixed properly in oe-core.
