### PR TITLE
rpi-cmdline: do_compile: Use pure Python syntax to get `CMDLINE`

### DIFF
--- a/recipes-bsp/bootfiles/rpi-cmdline.bb
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bb
@@ -62,7 +62,7 @@ CMDLINE = " \
     "
 
 do_compile() {
-    echo "${@' '.join('${CMDLINE}'.split())}" > "${WORKDIR}/cmdline.txt"
+    echo "${@' '.join(d.getVar('CMDLINE').split())}" > "${WORKDIR}/cmdline.txt"
 }
 
 do_deploy() {


### PR DESCRIPTION
Otherwise the shell snippet fails with `bad syntax` when `CMDLINE`
contains special characters like `${...}` (useful to insert a U-Boot
variable in `cmdline.txt`).

**- What I did**

Modify `do_compile` so that special characters `${...}` are accepted for `CMDLINE`.

**- How I did it**

Getting `CMDLINE` variable through Python with `d.getVar()`