### PR TITLE
[kirkstone] rpi-cmdline: do_compile: Use pure Python syntax to get `CMDLINE`

### DIFF
--- a/recipes-bsp/bootfiles/rpi-cmdline.bb
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bb
@@ -62,7 +62,7 @@ CMDLINE = " \
     "
 
 do_compile() {
-    echo "${@' '.join('${CMDLINE}'.split())}" > "${WORKDIR}/cmdline.txt"
+    echo "${@' '.join(d.getVar('CMDLINE').split())}" > "${WORKDIR}/cmdline.txt"
 }
 
 do_deploy() {


### PR DESCRIPTION
Cherry-pick of #1080 