### PR TITLE
raspberrypi-firmware: Update to 20220830 snapshot

### DIFF
--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,9 +1,9 @@
-RPIFW_DATE ?= "20220331"
+RPIFW_DATE ?= "20220830"
 
 RPIFW_SRC_URI ?= "https://archive.raspberrypi.com/debian/pool/main/r/raspberrypi-firmware/raspberrypi-firmware_1.${RPIFW_DATE}.orig.tar.xz"
 RPIFW_S ?= "${WORKDIR}/raspberrypi-firmware-1.${RPIFW_DATE}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[sha256sum] = "8758f10797bd52a7373cc5b39bd46d0d9f882d501ccb9535a72a3fe8a8d329c3"
+SRC_URI[sha256sum] = "2b27e4b3c4d2664a0a1d0dd8602bd80ea41dd006eb0ad9c67d7b659c9c8bb4e5"
 
 PV = "${RPIFW_DATE}"


### PR DESCRIPTION
Please make backport to Kirkstone branch

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>


**- What I did**
Updated the Firmware RaspberryPi version.
**- How I did it**
Changing the version to fetch and adapting the sha256sum to the new version.