### PR TITLE
rpidistro-vlc,rpidistro-ffmpeg: Limit scope to just rpi machines

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.12.bb
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.12.bb
@@ -51,8 +51,9 @@ EXTRA_OECONF = "\
 
 PACKAGECONFIG ?= "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'mmal', d)} \
     live555 dv1394 notify fontconfig fluidsynth freetype dvdread png udev \
-    x264 alsa mmal harfbuzz jack neon fribidi dvbpsi a52 v4l2 gles2 \
+    x264 alsa harfbuzz jack neon fribidi dvbpsi a52 v4l2 gles2 \
 "
 
 PACKAGECONFIG[mmal] = "--enable-omxil --enable-omxil-vout --enable-rpi-omxil --enable-mmal --enable-mmal-avcodec,,userland"
@@ -150,5 +151,9 @@ FILES:${PN}-staticdev += "\
     ${libdir}/vlc/plugins/*/*.a \
     ${libdir}/vlc/libcompat.a \
 "
+
+# Only enable it for rpi class of machines
+COMPATIBLE_HOST = "null"
+COMPATIBLE_HOST:rpi = "'(.*)'"
 
 INSANE_SKIP:${PN} = "dev-so"

--- a/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_4.3.2.bb
+++ b/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_4.3.2.bb
@@ -35,7 +35,8 @@ DEPENDS = "nasm-native"
 inherit autotools pkgconfig
 PACKAGECONFIG ??= "avdevice avfilter avcodec avformat swresample swscale postproc avresample \
                    opengl udev sdl2 ffplay alsa bzlib lzma pic pthreads shared theora zlib \
-                   libvorbis x264 gpl mmal sand rpi vout-drm vout-egl \
+                   libvorbis x264 gpl sand rpi vout-drm vout-egl \
+                   ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'mmal', d)} \
                    ${@bb.utils.contains('AVAILTUNES', 'mips32r2', 'mips32r2', '', d)} \
                    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xv xcb', '', d)}"
 
@@ -186,3 +187,8 @@ INSANE_SKIP:${MLPREFIX}libavresample = "textrel"
 INSANE_SKIP:${MLPREFIX}libswscale = "textrel"
 INSANE_SKIP:${MLPREFIX}libswresample = "textrel"
 INSANE_SKIP:${MLPREFIX}libpostproc = "textrel"
+
+# Only enable it for rpi class of machines
+COMPATIBLE_HOST = "null"
+COMPATIBLE_HOST:rpi = "'(.*)'"
+


### PR DESCRIPTION
enable mmal only when using userland graphics

Fixes builds on non-rpi machines e.g.
ERROR: Nothing PROVIDES 'userland' (but /mnt/jenkins/workspace/yocto-world-glibc/sources/meta-raspberrypi/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_4.3.2.bb DEPENDS on or otherwise requires it) userland was skipped: incompatible with machine qemumips (not in COMPATIBLE_MACHINE) NOTE: Runtime target 'rpidistro-ffmpeg' is unbuildable, removing...

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
