### PR TITLE
Follow-up REUSE specifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 build*
 *~
 .*.swp

--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,156 @@
+Creative Commons Attribution 4.0 International
+
+ Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+
+Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
+
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+Section 1 – Definitions.
+
+     a.	Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+     b.	Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+     c.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+     d.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+     e.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+     f.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+     g.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+     h.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+
+     i.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+     j.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+     k.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+     a.	License grant.
+
+          1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+               A. reproduce and Share the Licensed Material, in whole or in part; and
+
+               B. produce, reproduce, and Share Adapted Material.
+
+          2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+          3. Term. The term of this Public License is specified in Section 6(a).
+
+          4. Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+          5. Downstream recipients.
+
+               A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+               B. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+          6.  No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+b. Other rights.
+
+          1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+          2. Patent and trademark rights are not licensed under this Public License.
+
+          3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+     a.	Attribution.
+
+          1. If You Share the Licensed Material (including in modified form), You must:
+
+               A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+                    i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+                    ii. a copyright notice;
+
+                    iii. a notice that refers to this Public License;
+
+                    iv.	a notice that refers to the disclaimer of warranties;
+
+                    v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+               B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+               C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+          2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+          3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+          4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+
+     b.	if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+
+     c.	You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+     a.	Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
+
+     b.	To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
+
+     c.	The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+     a.	This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+     b.	Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+          1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+          2. upon express reinstatement by the Licensor.
+
+     c.	For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+     d.	For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+     e.	Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+     a.	The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+     b.	Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+     a.	For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+     b.	To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+     c.	No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+     d.	Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 inherit image_types
 
 #

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,10 @@
+<<<<<<< HEAD
+=======
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
+>>>>>>> 064cbc9 (changing license for two doc files)
 # Makefile for Sphinx documentation
 #
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
+<<<<<<< HEAD
+=======
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+#
+>>>>>>> 064cbc9 (changing license for two doc files)
 # meta-raspberrypi documentation build configuration file, created by
 # sphinx-quickstart on Tue May 23 09:51:24 2017.
 #

--- a/dynamic-layers/meta-python/recipes-connectivity/lirc/lirc_0.10.%.bbappend
+++ b/dynamic-layers/meta-python/recipes-connectivity/lirc/lirc_0.10.%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:rpi = " \

--- a/dynamic-layers/meta-python/recipes-core/packagegroups/packagegroup-rpi-test.bbappend
+++ b/dynamic-layers/meta-python/recipes-core/packagegroups/packagegroup-rpi-test.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 RDEPENDS:${PN} += "python3-sense-hat"

--- a/dynamic-layers/meta-python/recipes-devtools/python/python3-sense-hat_2.2.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/python/python3-sense-hat_2.2.0.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Python module to control the Raspberry Pi Sense HAT used in the Astro Pi mission"
 HOMEPAGE = "https://github.com/RPi-Distro/python-sense-hat"
 SECTION = "devel/python"

--- a/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera/libcamera.bbappend
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera/libcamera.bbappend
@@ -1,2 +1,5 @@
 PACKAGECONFIG[raspberrypi] = "-Dpipelines=raspberrypi -Dipas=raspberrypi -Dcpp_args=-Wno-unaligned-access"
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
 PACKAGECONFIG:append:rpi = " raspberrypi"

--- a/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.12.bb
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.12.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "Video player and streamer - davinci edition"
 HOMEPAGE = "http://www.videolan.org"
 SECTION = "multimedia"

--- a/dynamic-layers/networking-layer/recipes-support/drbd/drbd_%.bbappend
+++ b/dynamic-layers/networking-layer/recipes-support/drbd/drbd_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 COMPATIBLE_MACHINE:rpi = "(null)"

--- a/dynamic-layers/openembedded-layer/recipes-core/packagegroups/packagegroup-meta-oe.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-core/packagegroups/packagegroup-meta-oe.bbappend
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 RDEPENDS:packagegroup-meta-oe-kernel:remove:rpi = "bpftool"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-blinka_6.2.2.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-blinka_6.2.2.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "CircuitPython APIs for non-CircuitPython versions of Python such as CPython on Linux and MicroPython."
 HOMEPAGE = "https://github.com/adafruit/Adafruit_Blinka"
 LICENSE = "MIT"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-busdevice_5.0.5.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-busdevice_5.0.5.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "CircuitPython bus device classes to manage bus sharing."
 HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_BusDevice"
 LICENSE = "MIT"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-motor_3.2.6.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-motor_3.2.6.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "CircuitPython helper library provides higher level objects to control motors and servos."
 HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_Motor"
 LICENSE = "MIT"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-motorkit_1.6.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-motorkit_1.6.1.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "CircuitPython helper library for DC & Stepper Motor FeatherWing, Shield, and Pi Hat kits."
 HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_MotorKit"
 LICENSE = "MIT"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-pca9685_3.3.4.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python3-adafruit-circuitpython-pca9685_3.3.4.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "CircuitPython driver for motor, stepper, and servo based on PCA9685."
 HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_PCA9685"
 LICENSE = "MIT"

--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 PACKAGECONFIG_GL:rpi = "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'gl', \
                         bb.utils.contains('DISTRO_FEATURES',     'opengl', 'eglfs gles2', \
                                                                        '', d), d)}"

--- a/kas-poky-rpi.yml
+++ b/kas-poky-rpi.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 header:
   version: 8
 

--- a/lib/oeqa/runtime/cases/parselogs_rpi.py
+++ b/lib/oeqa/runtime/cases/parselogs_rpi.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 from oeqa.runtime.cases.parselogs import *
 
 rpi_errors = [

--- a/recipes-bsp/armstubs/armstubs.bb
+++ b/recipes-bsp/armstubs/armstubs.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "Boot strap code that the GPU puts on memory to start running the boot loader"
 LICENSE = "BSD-3-Clause"
 

--- a/recipes-bsp/bootfiles/rpi-cmdline.bb
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "cmdline.txt file used to boot the kernel on a Raspberry Pi device"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "Commented config.txt file for the Raspberry Pi. \
                The Raspberry Pi config.txt file is read by the GPU before \
                the ARM core is initialised. It can be used to set various \

--- a/recipes-bsp/formfactor/formfactor_%.bbappend
+++ b/recipes-bsp/formfactor/formfactor_%.bbappend
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"

--- a/recipes-bsp/gpio-shutdown/files/gpio-shutdown-keymap.sh
+++ b/recipes-bsp/gpio-shutdown/files/gpio-shutdown-keymap.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 ##
 # Bind the gpio-shutdown keycode as Keyboard signal and load it to the
 # keymap during startup.

--- a/recipes-bsp/gpio-shutdown/gpio-shutdown.bb
+++ b/recipes-bsp/gpio-shutdown/gpio-shutdown.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "GPIO shutdown bindings for SysV init"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"

--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "U-boot boot scripts for Raspberry Pi"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI:append:rpi = " \

--- a/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 FILESEXTRAPATHS:prepend:rpi := "${THISDIR}/${PN}:"
 
 SRC_URI:append:rpi = "\

--- a/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.17.bb
+++ b/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.17.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Script to properly configure BT-HCI on Raspberry Pi"
 HOMEPAGE = "https://github.com/RPi-Distro/pi-bluetooth"
 SECTION = "kernel"

--- a/recipes-core/images/rpi-test-image.bb
+++ b/recipes-core/images/rpi-test-image.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 # Base this image on core-image-base
 include recipes-core/images/core-image-base.bb
 

--- a/recipes-core/packagegroups/packagegroup-core-tools-testapps.bbappend
+++ b/recipes-core/packagegroups/packagegroup-core-tools-testapps.bbappend
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 # mesa-demos needs gles1 and userland driver does not have it, works ok with vc4 graphics driver
 X11GLTOOLS:remove:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'mesa-demos', d)}"

--- a/recipes-core/packagegroups/packagegroup-rpi-test.bb
+++ b/recipes-core/packagegroups/packagegroup-rpi-test.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "RaspberryPi Test Packagegroup"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"

--- a/recipes-core/psplash/psplash_%.bbappend
+++ b/recipes-core/psplash/psplash_%.bbappend
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SPLASH_IMAGES:rpi = "file://psplash-raspberrypi-img.h;outsuffix=raspberrypi"

--- a/recipes-core/udev/udev-rules-rpi.bb
+++ b/recipes-core/udev/udev-rules-rpi.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "udev rules for Raspberry Pi Boards"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"

--- a/recipes-core/udev/udev-rules-udisks-rpi_1.0.bb
+++ b/recipes-core/udev/udev-rules-udisks-rpi_1.0.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "add udisk/udev rule to hide boot partition from udev"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"

--- a/recipes-devtools/bcm2835/bcm2835_1.71.bb
+++ b/recipes-devtools/bcm2835/bcm2835_1.71.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "Package that provides access to GPIO and other IO\
 functions on the Broadcom BCM 2835 chip, allowing access to the\
 GPIO pins on the 26 pin IDE plug on the RPi board"

--- a/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.10.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.10.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "CircuitPython data descriptor classes to represent hardware registers on I2C and SPI devices."
 HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_Register"
 LICENSE = "MIT"

--- a/recipes-devtools/python/python3-adafruit-platformdetect_3.27.0.bb
+++ b/recipes-devtools/python/python3-adafruit-platformdetect_3.27.0.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Platform detection for use by libraries like Adafruit-Blinka."
 HOMEPAGE = "https://github.com/adafruit/Adafruit_Python_PlatformDetect"
 LICENSE = "MIT"

--- a/recipes-devtools/python/python3-adafruit-pureio_1.1.9.bb
+++ b/recipes-devtools/python/python3-adafruit-pureio_1.1.9.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Pure python (i.e. no native extensions) access to Linux IO    including I2C and SPI. Drop in replacement for smbus and spidev modules."
 HOMEPAGE = "https://github.com/adafruit/Adafruit_Python_PureIO"
 LICENSE = "MIT"

--- a/recipes-devtools/python/python3-rtimu_7.2.1.bb
+++ b/recipes-devtools/python/python3-rtimu_7.2.1.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "RTIMULib is a C++ and Python library that makes it easy to use 9-dof and \
 10-dof IMUs with embedded Linux systems"
 HOMEPAGE = "https://github.com/RPi-Distro/RTIMULib/"

--- a/recipes-devtools/python/rpi-gpio_0.7.1.bb
+++ b/recipes-devtools/python/rpi-gpio_0.7.1.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "A module to control Raspberry Pi GPIO channels"
 HOMEPAGE = "https://sourceforge.net/projects/raspberry-gpio-python/"
 SECTION = "devel/python"

--- a/recipes-devtools/python/rpio_0.10.1.bb
+++ b/recipes-devtools/python/rpio_0.10.1.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "Advanced GPIO for the Raspberry Pi. Extends RPi.GPIO with PWM, \
 GPIO interrups, TCP socket interrupts, command line tools and more"
 HOMEPAGE = "https://github.com/metachris/RPIO"

--- a/recipes-devtools/raspi-gpio/raspi-gpio_git.bb
+++ b/recipes-devtools/raspi-gpio/raspi-gpio_git.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "Tool to help debug / hack at the BCM283x GPIO"
 HOMEPAGE = "https://github.com/RPi-Distro/raspi-gpio"
 SECTION = "devel/libs"

--- a/recipes-graphics/cairo/cairo_%.bbappend
+++ b/recipes-graphics/cairo/cairo_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 PACKAGECONFIG_GLESV2 = " ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'glesv2', d)}"
 
 PACKAGECONFIG:append:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' egl ${PACKAGECONFIG_GLESV2}', d)}"

--- a/recipes-graphics/kmscube/kmscube_%.bbappend
+++ b/recipes-graphics/kmscube/kmscube_%.bbappend
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 # userland driver EGL implementation does not have all needed bits for it so remove it from build
 COMPATIBLE_HOST:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '(.*)', 'null', d)}"

--- a/recipes-graphics/libsdl2/libsdl2_%.bbappend
+++ b/recipes-graphics/libsdl2/libsdl2_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 # when using userland graphic KHR/khrplatform.h is provided by userland but virtual/libgl is provided by mesa-gl where

--- a/recipes-graphics/libva/libva_%.bbappend
+++ b/recipes-graphics/libva/libva_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 # when using userland graphic KHR/khrplatform.h is provided by userland but virtual/libgl is provided by mesa-gl where
 # we explicitly delete KHR/khrplatform.h since its already coming from userland package
 DEPENDS:append:rpi = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'userland', d)}"

--- a/recipes-graphics/mesa/libglu_%.bbappend
+++ b/recipes-graphics/mesa/libglu_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 # when using userland graphic KHR/khrplatform.h is provided by userland but virtual/libgl is provided by mesa-gl where
 # we explicitly delete KHR/khrplatform.h since its already coming from userland package
 DEPENDS:append:rpi = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'userland', d)}"

--- a/recipes-graphics/mesa/mesa-demos_%.bbappend
+++ b/recipes-graphics/mesa/mesa-demos_%.bbappend
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 # mesa-demos need libgles1 and userland driver does not have it
 COMPATIBLE_HOST:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '(.*)', 'null', d)}"

--- a/recipes-graphics/mesa/mesa-gl_%.bbappend
+++ b/recipes-graphics/mesa/mesa-gl_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 PACKAGECONFIG:append:rpi = " gbm"
 PROVIDES:append:rpi = " virtual/libgbm"
 

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 # DRI3 note:
 # With oe-core commit 8509e2e1a87578882b71948ccef3b50ccf1228b3 dri3 is set
 # as default. To state out clearly that Raspi needs dri3 and to avoid surprises

--- a/recipes-graphics/piglit/piglit_%.bbappend
+++ b/recipes-graphics/piglit/piglit_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 # mesa-demos need libgles1 and userland driver does not have it so remove it from piglit rdeps
 RDEPENDS:${PN}:remove:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'mesa-demos', d)}"
 # it needs EGL >= 11 but userland says it provided version 10, remove it from build

--- a/recipes-graphics/raspidmx/raspidmx_git.bb
+++ b/recipes-graphics/raspidmx/raspidmx_git.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Some examples using the DispmanX API on the Raspberry Pi"
 HOMEPAGE = "https://github.com/AndrewFromMelbourne/raspidmx"
 SECTION = "graphics"

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "This repository contains the source code for the ARM side \
 libraries used on Raspberry Pi. These typically are installed in /opt/vc/lib \
 and includes source for the ARM side code to interface to: EGL, mmal, GLESv2,\

--- a/recipes-graphics/vc-graphics/files/vchiq.sh
+++ b/recipes-graphics/vc-graphics/files/vchiq.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 ### BEGIN INIT INFO
 # Provides:          vchiq.sh
 # Required-Start:    $remote_fs rmnologin

--- a/recipes-graphics/vc-graphics/vc-graphics-hardfp.bb
+++ b/recipes-graphics/vc-graphics/vc-graphics-hardfp.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 CONFLICTS = "vc-graphics"
 
 VCDIR = "hardfp/opt/vc"

--- a/recipes-graphics/vc-graphics/vc-graphics.bb
+++ b/recipes-graphics/vc-graphics/vc-graphics.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 CONFLICTS = "vc-graphics-hardfp"
 
 VCDIR = "opt/vc"

--- a/recipes-graphics/wayland/wayland_%.bbappend
+++ b/recipes-graphics/wayland/wayland_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 # until fully tested, prefer `libwayland-egl` provided by `userland` instead of `wayland` when not using vc4graphics
 do_install:append:rpi () {
     if [ "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}" = "0" ]; then

--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 do_install:append:rpi() {

--- a/recipes-graphics/wayland/weston_%.bbappend
+++ b/recipes-graphics/wayland/weston_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 PACKAGECONFIG:remove:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'fbdev', '', d)}"
 
 EXTRA_OECONF:append:rpi = " \

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:rpi = " \

--- a/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 OPENGL_PKGCONFIGS:rpi = "dri glx ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'dri3 glamor', '', d)}"
 
 # when using userland graphic KHR/khrplatform.h is provided by userland but virtual/libgl is provided by mesa-gl where

--- a/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
+++ b/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Linux kernel Bluetooth firmware files from Raspbian distribution"
 DESCRIPTION = "Updated Bluetooth firmware files for RaspberryPi hardware. \
 RPi-Distro obtains these directly from Cypress; they are not submitted \

--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 python __anonymous() {
     if "linux-raspberrypi-dev" not in d.getVar("PREFERRED_PROVIDER_virtual/kernel"):
         msg = "Skipping linux-raspberrypi-dev as it is not the preferred " + \

--- a/recipes-kernel/linux/linux-raspberrypi-v7_5.10.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-v7_5.10.bb
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: Andrei Gherzan <andrei.gherzan@huawei.com>
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
 #
 # SPDX-License-Identifier: MIT
 

--- a/recipes-kernel/linux/linux-raspberrypi-v7_5.15.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-v7_5.15.bb
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: Andrei Gherzan <andrei.gherzan@huawei.com>
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
 #
 # SPDX-License-Identifier: MIT
 

--- a/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 LINUX_VERSION ?= "5.10.110"
 LINUX_RPI_BRANCH ?= "rpi-5.10.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-5.10"

--- a/recipes-kernel/linux/linux-raspberrypi_5.15.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.15.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 LINUX_VERSION ?= "5.15.56"
 LINUX_RPI_BRANCH ?= "rpi-5.15.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-5.15"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 FILESEXTRAPATHS:prepend:rpi := "${THISDIR}/${PN}:"
 
 SRC_URI:append:rpi = " \

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 PACKAGECONFIG:append:rpi = " hls \
                    ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gpl faad', '', d)}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 # if using bcm driver enable dispmanx not when using VC4 driver
 PACKAGECONFIG:append:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' dispmanx', d)}"
 DEPENDS:append:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' userland', d)}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.20.%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.20.%.bbappend
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 PACKAGECONFIG:append:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' rpi', d)}"

--- a/recipes-multimedia/omxplayer/omxplayer_git.bb
+++ b/recipes-multimedia/omxplayer/omxplayer_git.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "A commandline OMX player for the Raspberry Pi"
 DESCRIPTION = "This player was developed as a testbed for the XBMC \
 Raspberry PI implementation and is quite handy to use standalone"

--- a/recipes-multimedia/picamera-libs/picamera-libs.bb
+++ b/recipes-multimedia/picamera-libs/picamera-libs.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Raspberrypi firmware libraries which are required by picamera library"
 DESCRIPTION = "Raspberrypi firmware libraries required by picamera library"
 LICENSE = "Broadcom-RPi"

--- a/recipes-multimedia/python3-picamera/python3-picamera_git.bb
+++ b/recipes-multimedia/python3-picamera/python3-picamera_git.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Python interface to the Raspberry Pi camera module"
 DESCRIPTION = "This package provides a pure Python interface to the Raspberry Pi camera module for Python 2.7 (or above) or Python 3.2 (or above)."
 HOMEPAGE = "https://github.com/waveform80/picamera" 

--- a/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_4.3.2.bb
+++ b/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_4.3.2.bb
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "A complete, cross-platform solution to record, convert and stream audio and video."
 DESCRIPTION = "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, \
                mux, demux, stream, filter and play pretty much anything that humans and machines \

--- a/recipes-multimedia/x264/x264_%.bbappend
+++ b/recipes-multimedia/x264/x264_%.bbappend
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 EXTRA_OECONF:append:raspberrypi = " --disable-asm"
 EXTRA_OECONF:append:raspberrypi0-wifi = " --disable-asm"

--- a/recipes-sato/libwpe_%.bbappend
+++ b/recipes-sato/libwpe_%.bbappend
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: meta-raspberrypi contributors
+#
+# SPDX-License-Identifier: MIT
+
 # Workaround build issue with RPi userland EGL libraries.
 CFLAGS:append:rpi = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', '-D_GNU_SOURCE', d)}"


### PR DESCRIPTION
Hi 

I'm Lina Ceballos from the [Free Software Foundation Europe,](https://fsfe.org/) and the REUSE Booster program. As promised, here it's a cleaner and more updated merge request which suggests the [REUSE specifications](https://reuse.software/spec/) that make licensing and copyright information unambiguous and perfectly human- and machine-readable [^0]. This MR is a follow-up from the [one](https://github.com/agherzan/meta-raspberrypi/pull/916) I closed some weeks ago.

Some important notes in this regard:

- Following our discussion I didn't include the year in the headers, as well as they should all be uniform now.
- I kept insignificant files such as .gitignore under MIT, in line with our earlier discussion, and documentation files are now under CC-BY-4.0.
- I have also created a[ dep5 file ](https://reuse.software/spec/#dep5)in the `.reuse` folder that includes patch and conf files, keeping in mind that creating a separate .license file for each of them is not ideal. However, if you prefer to proceed with the latter, please feel free to do so.

There are still **some files that I didn't touch**:
The imagine files `img/LF_17_02_Yocto-Badge-Update_Compatible_Final_Blank.png` and` img/balena.png,` since I don't know who the copyright holder is and under what license they are. Please feel free to add this information by creating a .license file for those two image files.


For the files:
`recipes-bsp/bootfiles/rpi-bootfiles.bb`
`recipes-graphics/vc-graphics/vc-graphics.inc`


Keeping in mind that they have a special license situation,  my suggestions here remain as follows:

You can keep the license MIT for those files since they are licensed under MIT although the components they build are under the custom license: Broadcom-RPi license.

In this regard, I noticed that the text of the custom license makes it a proprietary license. This apart, to be more precise:

_"This software may only be used for the purposes of developing for, running, or using a Raspberry Pi device."_

The custom license still has to be part of the `LICENSE` directory, you can add it following [these steps](https://reuse.software/faq/#custom-license), but in this case, I would suggest you make sure to clarify in the `README `file the context where this license is used and applied and that it refers to the binary component involved in booting Raspberry Pi devices. Something like "_The custom proprietary license in the LICENSES directory is part of the build system functionality and refers to closed source components involved in running or using a Raspberry Pi device"_

The copyright tag in the text file of this custom license itself refers only to the license text, so no other action is required.

Please bear in mind that this is meant to be a practical example of how the REUSE specifications would look like, feel free to implement them or some, but also feel free to proceed to do so on your own. 

I would like to note that while reaching REUSE compliance is a larger one-time chunk, maintaining this status is fairly simple: inclusion in CI pipelines, pre-commit hooks, badges, you-name-it, everything possible [^1].

Please also note that REUSE is an established practice with a lot of organisations using it, among them the KDE community, curl, GNUHealth (in progress), Linux kernel, companies such as Siemens, SAP, and LGE, as well as numerous smaller and larger projects. We would be happy to have you on board as well!

If there is something we can help with, feel free to reach out, we are more than happy to help!

[^0]: https://reuse.software/
[^1]: https://reuse.software/dev/


