### PR TITLE
Include the device tree for Raspberry Pi CM4S

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -74,6 +74,7 @@ RPI_KERNEL_DEVICETREE ?= " \
     bcm2708-rpi-cm.dtb \
     bcm2710-rpi-cm3.dtb \
     bcm2711-rpi-cm4.dtb \
+    bcm2711-rpi-cm4s.dtb \
     "
 
 KERNEL_DEVICETREE ??= " \

--- a/conf/machine/raspberrypi-armv8.conf
+++ b/conf/machine/raspberrypi-armv8.conf
@@ -31,6 +31,7 @@ RPI_KERNEL_DEVICETREE = " \
     broadcom/bcm2711-rpi-4-b.dtb \
     broadcom/bcm2711-rpi-400.dtb \
     broadcom/bcm2711-rpi-cm4.dtb \
+    broadcom/bcm2711-rpi-cm4s.dtb \
 "
 
 SDIMG_KERNELIMAGE ?= "kernel8.img"

--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -21,6 +21,7 @@ RPI_KERNEL_DEVICETREE = " \
     broadcom/bcm2711-rpi-4-b.dtb \
     broadcom/bcm2711-rpi-400.dtb \
     broadcom/bcm2711-rpi-cm4.dtb \
+    broadcom/bcm2711-rpi-cm4s.dtb \
 "
 
 SDIMG_KERNELIMAGE ?= "kernel8.img"


### PR DESCRIPTION
**- What I did**

- Added `(broadcom/)bcm2711-rpi-cm4s.dtb` to `RPI_KERNEL_DEVICETREE` as preparation for https://github.com/balena-os/balena-raspberrypi/pull/913.