### PR TITLE
rpi-base.inc: handle empty/undefined KERNEL_DEVICETREE

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -119,6 +119,10 @@ def make_dtb_boot_files(d):
     # KERNEL_DEVICETREE.
     alldtbs = d.getVar('KERNEL_DEVICETREE')
 
+    # DTBs may be built out of kernel with devicetree.bbclass
+    if not alldtbs:
+        return ''
+
     def transform(dtb):
         base = os.path.basename(dtb)
         if dtb.endswith('dtbo') or base == 'overlay_map.dtb':


### PR DESCRIPTION
This patch is based on an analog patch from Christopher Boyd <xpboyd@gmail.com> committed at meta-freescale. (see https://github.com/Freescale/meta-freescale/commit/954d7a7d7afc3ad4950eb0fd354a6f4bd06d911a)

Signed-off-by: Oliver Lang <quantenkeks@gmail.com>