### PR TITLE
raspberrypi4-64: drop DEFAULTTUNE assignment

### DIFF
--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -12,8 +12,6 @@ MACHINE_EXTRA_RRECOMMENDS += "\
     bluez-firmware-rpidistro-bcm4345c5-hcd \
 "
 
-DEFAULTTUNE = "cortexa72"
-
 require conf/machine/include/arm/armv8a/tune-cortexa72.inc
 include conf/machine/include/rpi-base.inc
 


### PR DESCRIPTION
* it matches the default from tune-cortexa72.inc: $ grep DEFAULTTUNE openembedded-core/meta/conf/machine/include/arm/armv8a/tune-cortexa72.inc DEFAULTTUNE ?= "cortexa72"

* the assignment was introduced in: https://github.com/agherzan/meta-raspberrypi/commit/cd234925fa59197a52f4cb5011902ab5867c684f to switch to cortexa72-crc, but this change was effectively reverted in: https://github.com/agherzan/meta-raspberrypi/commit/42ef0f504604a4ba1dcad689de804ee8bf8a7afe by setting it back to default "cortexa72".