### PR TITLE
Disable Weston packageconfig options that fail to build with userland drivers

### DIFF
--- a/recipes-graphics/wayland/weston_%.bbappend
+++ b/recipes-graphics/wayland/weston_%.bbappend
@@ -1,4 +1,4 @@
-PACKAGECONFIG:remove:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'fbdev', '', d)}"
+PACKAGECONFIG:remove:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'fbdev', 'egl clients', d)}"
 
 EXTRA_OECONF:append:rpi = " \
     --disable-xwayland-test \


### PR DESCRIPTION
* Weston 10 (Yocto Langdale) fails to build with userland drivers when the packageconfig options `egl` or `clients` are enabled, and those are enabled by default. So disable them by default when building with `DISABLE_VC4GRAPHICS=1`

This is the build failure that happens without this patch:

```
| [105/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/launcher-direct.c
| [106/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/launcher-weston-launch.c
| [107/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/bindings.c
| [108/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/drm-formats.c
| [109/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/color-noop.c
| [110/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/log.c
| [111/470] rm -f libweston/libsession-helper.a && arm-poky-linux-gnueabi-gcc-ar csrDT libweston/libsession-helper.a libweston/libsession-helper.a.p/launcher-direct.c.o libweston/libsession-helper.a.p/launcher-util.c.o libweston/libsession-helper.a.p/launcher-weston-launch.c.o libweston/libsession-helper.a.p/dbus.c.o libweston/libsession-helper.a.p/launcher-logind.c.o
| [112/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/shared/matrix.c
| [113/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/noop-renderer.c
| [114/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/linux-sync-file.c
| [115/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c protocol/linux-dmabuf-unstable-v1-protocol.c
| [116/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/zoom.c
| [117/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/plugin-registry.c
| [118/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/weston-log-file.c
| [119/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/backend-drm/state-helpers.c
| [120/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/renderer-gl/gl-shader-config-color-transformation.c
| FAILED: libweston/renderer-gl/gl-renderer.so.p/gl-shader-config-color-transformation.c.o
| arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/renderer-gl/gl-shader-config-color-transformation.c
| ../weston-10.0.2/libweston/renderer-gl/gl-shader-config-color-transformation.c:28:10: fatal error: GLES3/gl3.h: No such file or directory
|    28 | #include <GLES3/gl3.h>
|       |          ^~~~~~~~~~~~~
| compilation terminated.
| [121/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/weston-log.c
| [122/470] rm -f libweston/backend-drm/libbacklight.a && arm-poky-linux-gnueabi-gcc-ar csrDT libweston/backend-drm/libbacklight.a libweston/backend-drm/libbacklight.a.p/libbacklight.c.o
| [123/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/content-protection.c
| [124/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/renderer-gl/gl-renderer.c
| FAILED: libweston/renderer-gl/gl-renderer.so.p/gl-renderer.c.o
| arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/renderer-gl/gl-renderer.c
| ../weston-10.0.2/libweston/renderer-gl/gl-renderer.c:32:10: fatal error: GLES3/gl3.h: No such file or directory
|    32 | #include <GLES3/gl3.h>
|       |          ^~~~~~~~~~~~~
| compilation terminated.
| [125/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/weston-log-flight-rec.c
| [126/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/weston-direct-display.c
| [127/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/libinput-device.c
| [128/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/renderer-gl/egl-glue.c
| FAILED: libweston/renderer-gl/gl-renderer.so.p/egl-glue.c.o
| arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/renderer-gl/egl-glue.c
| In file included from ../weston-10.0.2/shared/platform.h:37,
|                  from ../weston-10.0.2/libweston/renderer-gl/egl-glue.c:33:
| ../weston-10.0.2/shared/weston-egl-ext.h:153:106: error: unknown type name 'EGLAttrib'
|   153 | typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDEVICEATTRIBEXTPROC) (EGLDeviceEXT device, EGLint attribute, EGLAttrib *value);
|       |                                                                                                          ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:156:102: error: unknown type name 'EGLAttrib'
|   156 | typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDISPLAYATTRIBEXTPROC) (EGLDisplay dpy, EGLint attribute, EGLAttrib *value);
|       |                                                                                                      ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:158:95: error: unknown type name 'EGLAttrib'
|   158 | EGLAPI EGLBoolean EGLAPIENTRY eglQueryDeviceAttribEXT (EGLDeviceEXT device, EGLint attribute, EGLAttrib *value);
|       |                                                                                               ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:161:91: error: unknown type name 'EGLAttrib'
|   161 | EGLAPI EGLBoolean EGLAPIENTRY eglQueryDisplayAttribEXT (EGLDisplay dpy, EGLint attribute, EGLAttrib *value);
|       |                                                                                           ^~~~~~~~~
| In file included from ../weston-10.0.2/libweston/renderer-gl/egl-glue.c:36:
| ../weston-10.0.2/libweston/renderer-gl/gl-renderer-internal.h:170:9: error: unknown type name 'PFNEGLQUERYDISPLAYATTRIBEXTPROC'
|   170 |         PFNEGLQUERYDISPLAYATTRIBEXTPROC query_display_attrib;
|       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| ../weston-10.0.2/libweston/renderer-gl/egl-glue.c: In function 'gl_renderer_set_egl_device':
| ../weston-10.0.2/libweston/renderer-gl/egl-glue.c:461:9: error: unknown type name 'EGLAttrib'
|   461 |         EGLAttrib attrib;
|       |         ^~~~~~~~~
| ../weston-10.0.2/libweston/renderer-gl/egl-glue.c:466:14: error: called object is not a function or function pointer
|   466 |         if (!gr->query_display_attrib(gr->egl_display, EGL_DEVICE_EXT, &attrib)) {
|       |              ^~
| ../weston-10.0.2/libweston/renderer-gl/egl-glue.c: In function 'gl_renderer_setup_egl_client_extensions':
| ../weston-10.0.2/libweston/renderer-gl/egl-glue.c:580:42: warning: assignment to 'int' from 'void *' makes integer from pointer without a cast [-Wint-conversion]
|   580 |                 gr->query_display_attrib =
|       |                                          ^
| [129/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/linux-explicit-synchronization.c
| [130/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/backend-drm/kms.c
| [131/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/vertex-clipping.c
| [132/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/touch-calibration.c
| [133/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/pixel-formats.c
| FAILED: libweston/libweston-10.so.0.0.2.p/pixel-formats.c.o
| arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/pixel-formats.c
| In file included from ../weston-10.0.2/libweston/pixel-formats.c:70:
| ../weston-10.0.2/shared/weston-egl-ext.h:153:106: error: unknown type name 'EGLAttrib'
|   153 | typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDEVICEATTRIBEXTPROC) (EGLDeviceEXT device, EGLint attribute, EGLAttrib *value);
|       |                                                                                                          ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:156:102: error: unknown type name 'EGLAttrib'
|   156 | typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDISPLAYATTRIBEXTPROC) (EGLDisplay dpy, EGLint attribute, EGLAttrib *value);
|       |                                                                                                      ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:158:95: error: unknown type name 'EGLAttrib'
|   158 | EGLAPI EGLBoolean EGLAPIENTRY eglQueryDeviceAttribEXT (EGLDeviceEXT device, EGLint attribute, EGLAttrib *value);
|       |                                                                                               ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:161:91: error: unknown type name 'EGLAttrib'
|   161 | EGLAPI EGLBoolean EGLAPIENTRY eglQueryDisplayAttribEXT (EGLDisplay dpy, EGLint attribute, EGLAttrib *value);
|       |                                                                                           ^~~~~~~~~
| [134/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/backend-drm/drm-gbm.c
| FAILED: libweston/backend-drm/drm-backend.so.p/drm-gbm.c.o
| arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/backend-drm/drm-gbm.c
| In file included from ../weston-10.0.2/libweston/backend-drm/drm-gbm.c:43:
| ../weston-10.0.2/shared/weston-egl-ext.h:153:106: error: unknown type name 'EGLAttrib'
|   153 | typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDEVICEATTRIBEXTPROC) (EGLDeviceEXT device, EGLint attribute, EGLAttrib *value);
|       |                                                                                                          ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:156:102: error: unknown type name 'EGLAttrib'
|   156 | typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDISPLAYATTRIBEXTPROC) (EGLDisplay dpy, EGLint attribute, EGLAttrib *value);
|       |                                                                                                      ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:158:95: error: unknown type name 'EGLAttrib'
|   158 | EGLAPI EGLBoolean EGLAPIENTRY eglQueryDeviceAttribEXT (EGLDeviceEXT device, EGLint attribute, EGLAttrib *value);
|       |                                                                                               ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:161:91: error: unknown type name 'EGLAttrib'
|   161 | EGLAPI EGLBoolean EGLAPIENTRY eglQueryDisplayAttribEXT (EGLDisplay dpy, EGLint attribute, EGLAttrib *value);
|       |                                                                                           ^~~~~~~~~
| [135/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/weston-log-wayland.c
| [136/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/timeline.c
| [137/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/clipboard.c
| [138/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/color.c
| [139/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/backend-drm/fb.c
| [140/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/renderer-gl/gl-shaders.c
| FAILED: libweston/renderer-gl/gl-renderer.so.p/gl-shaders.c.o
| arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/renderer-gl/gl-shaders.c
| In file included from ../weston-10.0.2/libweston/renderer-gl/gl-renderer-internal.h:37,
|                  from ../weston-10.0.2/libweston/renderer-gl/gl-shaders.c:43:
| ../weston-10.0.2/shared/weston-egl-ext.h:153:106: error: unknown type name 'EGLAttrib'
|   153 | typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDEVICEATTRIBEXTPROC) (EGLDeviceEXT device, EGLint attribute, EGLAttrib *value);
|       |                                                                                                          ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:156:102: error: unknown type name 'EGLAttrib'
|   156 | typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDISPLAYATTRIBEXTPROC) (EGLDisplay dpy, EGLint attribute, EGLAttrib *value);
|       |                                                                                                      ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:158:95: error: unknown type name 'EGLAttrib'
|   158 | EGLAPI EGLBoolean EGLAPIENTRY eglQueryDeviceAttribEXT (EGLDeviceEXT device, EGLint attribute, EGLAttrib *value);
|       |                                                                                               ^~~~~~~~~
| ../weston-10.0.2/shared/weston-egl-ext.h:161:91: error: unknown type name 'EGLAttrib'
|   161 | EGLAPI EGLBoolean EGLAPIENTRY eglQueryDisplayAttribEXT (EGLDisplay dpy, EGLint attribute, EGLAttrib *value);
|       |                                                                                           ^~~~~~~~~
| ../weston-10.0.2/libweston/renderer-gl/gl-renderer-internal.h:170:9: error: unknown type name 'PFNEGLQUERYDISPLAYATTRIBEXTPROC'
|   170 |         PFNEGLQUERYDISPLAYATTRIBEXTPROC query_display_attrib;
|       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| [141/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/shared/cairo-util.c
| [142/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/animation.c
| [143/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/backend-drm/modes.c
| [144/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/pixman-renderer.c
| [145/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/screenshooter.c
| [146/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/data-device.c
| [147/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/linux-dmabuf.c
| [148/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/backend-drm/drm.c
| [149/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/backend-drm/state-propose.c
| [150/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/input.c
| [151/470] arm-poky-linux-gnueabi-gcc [...gcc-parameters-edited-for-clarity...] -c ../weston-10.0.2/libweston/compositor.c
| ninja: build stopped: subcommand failed.
| WARNING: exit code 1 from a shell command.
ERROR: Task (/home/clopez/webkit/webkit/WebKitBuild/CrossToolChains/rpi3-dispmanx/sources/poky/meta/recipes-graphics/wayland/weston_10.0.2.bb:do_compile) failed with exit code '1'
NOTE: Tasks Summary: Attempted 2154 tasks of which 2148 didn't need to be rerun and 1 failed.

Summary: 1 task failed:

```