### PR TITLE
Fix build of mesa-gl 22 with userland graphics

### DIFF
--- a/recipes-graphics/mesa/mesa-gl_%.bbappend
+++ b/recipes-graphics/mesa/mesa-gl_%.bbappend
@@ -1,4 +1,4 @@
-PACKAGECONFIG:append:rpi = " gbm"
+PACKAGECONFIG:append:rpi = " gbm ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'gallium', d)}"
 PROVIDES:append:rpi = " virtual/libgbm"
 
 GALLIUMDRIVERS:append:rpi = ",swrast"


### PR DESCRIPTION
mesa-gl 22.2.2 from Yocto Langdale fails to build when the userland graphics are enabled (`DISABLE_VC4GRAPHICS=1`) with this error:

```
| Target machine cpu family: arm
| Target machine cpu: arm
| Checking if "-mtls-dialect=gnu2" runs: YES
| 
| ../mesa-22.2.2/meson.build:555:6: ERROR: Problem encountered: xlib based GLX requires at least one gallium driver
| 
```

Fix the problem by ensuring to enable the gallium packageconfig option by default
