### PR TITLE
rpidistro-vlc,rpidistro-ffmpeg: update COMPATIBLE_HOST regex

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.12.bb
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.12.bb
@@ -154,6 +154,6 @@ FILES:${PN}-staticdev += "\
 
 # Only enable it for rpi class of machines
 COMPATIBLE_HOST = "null"
-COMPATIBLE_HOST:rpi = "'(.*)'"
+COMPATIBLE_HOST:rpi = "(.*)"
 
 INSANE_SKIP:${PN} = "dev-so"

--- a/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_4.3.2.bb
+++ b/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_4.3.2.bb
@@ -190,5 +190,5 @@ INSANE_SKIP:${MLPREFIX}libpostproc = "textrel"
 
 # Only enable it for rpi class of machines
 COMPATIBLE_HOST = "null"
-COMPATIBLE_HOST:rpi = "'(.*)'"
+COMPATIBLE_HOST:rpi = "(.*)"
 


### PR DESCRIPTION
Connected to [VLC on RaspberryPI0w2 with framebuffer only](https://github.com/agherzan/meta-raspberrypi/issues/1117)

**- What I did**
From [VLC on RaspberryPI0w2 with framebuffer only](https://github.com/agherzan/meta-raspberrypi/issues/1117) fixes

```
ERROR: Nothing PROVIDES 'rpidistro-ffmpeg'
rpidistro-ffmpeg was skipped: incompatible with host arm-project-linux-gnueabi (not in COMPATIBLE_HOST)
```

**- How I did it**
Removed single quotes from regex string as it appears to make the expression invalid. Thus, leading to above error.