### PR TITLE
rpidistro-vlc: update PACKAGECONFIG

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.12.bb
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.12.bb
@@ -51,8 +51,10 @@ EXTRA_OECONF = "\
 
 PACKAGECONFIG ?= "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', 'wayland x11', 'notify', '', d)} \
     ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'mmal', d)} \
-    live555 dv1394 notify fontconfig fluidsynth freetype dvdread png udev \
+    live555 dv1394 fontconfig fluidsynth freetype dvdread png udev \
     x264 alsa harfbuzz jack neon fribidi dvbpsi a52 v4l2 gles2 \
 "
 


### PR DESCRIPTION
Connected to [VLC on RaspberryPI0w2 with framebuffer only](https://github.com/agherzan/meta-raspberrypi/issues/1117)

**Problem:**

ERROR: Nothing PROVIDES 'gtk+3' (but rpidistro-vlc_3.0.12.bb DEPENDS on or otherwise requires it)
gtk+3 was skipped: one of 'wayland x11' needs to be in DISTRO_FEATURES

If neither are included gtk+3 wont be included in sysroot of recipe.

**Solution:**

Update PACKAGECONFIG to only --enable-notify if either wayland or x11 are present in DISTRO_FEATURES.