### PR TITLE
rpi-default-providers: add libav and libpostproc

### DIFF
--- a/conf/machine/include/rpi-default-providers.inc
+++ b/conf/machine/include/rpi-default-providers.inc
@@ -9,6 +9,8 @@ PREFERRED_PROVIDER_virtual/mesa ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc
 PREFERRED_PROVIDER_virtual/libgbm ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "mesa", "mesa-gl", d)}"
 PREFERRED_PROVIDER_vlc ?= "rpidistro-vlc"
 PREFERRED_PROVIDER_ffmpeg ?= "rpidistro-ffmpeg"
+PREFERRED_PROVIDER_libav ?= "rpidistro-ffmpeg"
+PREFERRED_PROVIDER_libpostproc ?= "rpidistro-ffmpeg"
 PREFERRED_PROVIDER_jpeg ?= "jpeg"
 
 PREFERRED_PROVIDER_virtual/libomxil ?= "userland"


### PR DESCRIPTION
**The Error**

ERROR: Multiple .bb files are due to be built which each provide libav/libpostproc:
  /../../meta-raspberrypi/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_4.3.4.bb
  /../../openembedded-core/meta/recipes-multimedia/ffmpeg/ffmpeg_5.1.2.bb

**How I solved it**

Ensures bitbake understands which recipe to utilize by specifying
rpidistro-ffmpeg as the preferred provider.
