### PR TITLE
layer.conf: update LAYERSERIES_COMPAT for mickledore

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "raspberrypi"
 BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
-LAYERSERIES_COMPAT_raspberrypi = "kirkstone langdale"
+LAYERSERIES_COMPAT_raspberrypi = "mickledore"
 LAYERDEPENDS_raspberrypi = "core"
 
 # Additional license directories.


### PR DESCRIPTION
* oe-core switched to mickedore in: https://git.openembedded.org/openembedded-core/commit/?id=57239d66b933c4313cf331d35d13ec2d0661c38f

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>