### PR TITLE
linux-raspberrypi.inc: Weakly assign COMPATIBLE_MACHINE

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -3,7 +3,7 @@ SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-COMPATIBLE_MACHINE = "^rpi$"
+COMPATIBLE_MACHINE ?= "^rpi$"
 
 PE = "1"
 PV = "${LINUX_VERSION}+git${SRCPV}"


### PR DESCRIPTION
COMPATIBLE_MACHINE is expected to be overridden by linux-raspberrypi-v7.inc for linux-raspberrypi-v7 machine this however does not work because linux-raspberrypi-v7_5.15.bb includes linux-raspberrypi-v7.inc and linux-raspberrypi.inc ( via linux-raspberrypi_5.15.bb) and setting from linux-raspberrypi.inc takes precedence over one coming from linux-raspberrypi-v7.inc as a result linux-raspberrypi-v7 kernel recipe becomes available for raspberrypi4 machine as well, this recipe however needs certain defines e.g.RASPBERRYPI_v7_KERNEL which are only available in raspberrypi-armv7.conf

Signed-off-by: Khem Raj <raj.khem@gmail.com>

