### PR TITLE
pi-bluetooth: fix typo in Upstream-Status

### DIFF
--- a/recipes-connectivity/pi-bluetooth/pi-bluetooth/0001-bthelper-correct-path-for-hciconfig-under-Yocto.patch
+++ b/recipes-connectivity/pi-bluetooth/pi-bluetooth/0001-bthelper-correct-path-for-hciconfig-under-Yocto.patch
@@ -3,7 +3,7 @@ From: "Peter A. Bigot" <pab@pabigot.com>
 Date: Wed, 14 Nov 2018 09:19:51 -0600
 Subject: [PATCH] bthelper: correct path for hciconfig under Yocto
 
-Upstream-Status: Inapproprate [OE-specific]
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Peter A. Bigot <pab@pabigot.com>
 Signed-off-by: Andrei Gherzan <andrei@gherzan.ro>
 


### PR DESCRIPTION
* fixes: WARNING: pi-bluetooth-0.1.17-r0 do_patch: QA Issue: Malformed Upstream-Status in patch meta-raspberrypi/recipes-connectivity/pi-bluetooth/pi-bluetooth/0001-bthelper-correct-path-for-hciconfig-under-Yocto.patch Please correct according to https://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines#Patch_Header_Recommendations:_Upstream-Status : Upstream-Status: Inapproprate [OE-specific] [patch-status-noncore]