### PR TITLE
raspidmx, userland, omxplayer: Fix Upstream-Status formatting

### DIFF
--- a/recipes-graphics/raspidmx/raspidmx/0001-gitignore-add-archives-from-lib-directory.patch
+++ b/recipes-graphics/raspidmx/raspidmx/0001-gitignore-add-archives-from-lib-directory.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] gitignore: add archives from lib directory
 
 The build creates two *.a files in the lib directory, add these to .gitignore.
 
-Upstream-status: submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
+Upstream-Status: Submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
 Signed-off-by: Trevor Woerner <twoerner@gmail.com>
 ---
  .gitignore | 1 +

--- a/recipes-graphics/raspidmx/raspidmx/0002-add-install-targets-to-Makefiles.patch
+++ b/recipes-graphics/raspidmx/raspidmx/0002-add-install-targets-to-Makefiles.patch
@@ -3,7 +3,7 @@ From: Trevor Woerner <twoerner@gmail.com>
 Date: Fri, 4 Dec 2020 01:54:37 -0500
 Subject: [PATCH] add "install" targets to Makefiles
 
-Upstream-status: submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
+Upstream-Status: Submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
 Signed-off-by: Trevor Woerner <twoerner@gmail.com>
 ---
  Makefile                   | 3 +++

--- a/recipes-graphics/raspidmx/raspidmx/0003-switch-to-pkg-config.patch
+++ b/recipes-graphics/raspidmx/raspidmx/0003-switch-to-pkg-config.patch
@@ -10,7 +10,7 @@ I get a build error saying:
 Therefore switch to the more common and more generic "pkg-config" instead of
 using a libpng-specific tool for flags and libraries.
 
-Upstream-status: submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
+Upstream-Status: Submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
 Signed-off-by: Trevor Woerner <twoerner@gmail.com>
 ---
  game/Makefile       | 4 ++--

--- a/recipes-graphics/raspidmx/raspidmx/0004-add-libvchostif-to-link.patch
+++ b/recipes-graphics/raspidmx/raspidmx/0004-add-libvchostif-to-link.patch
@@ -9,7 +9,7 @@ I end up with link errors of the type:
 
 Which is caused by not having -lvchostif in the link.
 
-Upstream-status: submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
+Upstream-Status: Submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
 Signed-off-by: Trevor Woerner <twoerner@gmail.com>
 ---
  game/Makefile              | 2 +-

--- a/recipes-graphics/raspidmx/raspidmx/0005-change-library-linking-order.patch
+++ b/recipes-graphics/raspidmx/raspidmx/0005-change-library-linking-order.patch
@@ -10,7 +10,7 @@ linking so that it succeeds. Otherwise I get errors like the following:
 
 ...as well as undefined references to various other libpng objects.
 
-Upstream-status: submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
+Upstream-Status: Submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
 Signed-off-by: Trevor Woerner <twoerner@gmail.com>
 ---
  game/Makefile       | 2 +-

--- a/recipes-graphics/raspidmx/raspidmx/0006-game-Makefile-install-sample-png-files.patch
+++ b/recipes-graphics/raspidmx/raspidmx/0006-game-Makefile-install-sample-png-files.patch
@@ -3,7 +3,7 @@ From: Trevor Woerner <twoerner@gmail.com>
 Date: Fri, 4 Dec 2020 03:47:17 -0500
 Subject: [PATCH] game/Makefile: install sample png files
 
-Upstream-status: submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
+Upstream-Status: Submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
 Signed-off-by: Trevor Woerner <twoerner@gmail.com>
 ---
  game/Makefile | 2 ++

--- a/recipes-graphics/raspidmx/raspidmx/0007-Makefile-reorganize.patch
+++ b/recipes-graphics/raspidmx/raspidmx/0007-Makefile-reorganize.patch
@@ -16,7 +16,7 @@ To build simply invoke 'make' with or without a -j option.
 To install simply invoke: make TARGET=install
 To clean simply invoke: make TARGET=clean
 
-Upstream-status: submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
+Upstream-Status: Submitted [https://github.com/AndrewFromMelbourne/raspidmx/pull/29]
 Signed-off-by: Trevor Woerner <twoerner@gmail.com>
 ---
  Makefile | 19 +++++++------------

--- a/recipes-graphics/userland/files/0022-all-host_applications-remove-non-existent-projects.patch
+++ b/recipes-graphics/userland/files/0022-all-host_applications-remove-non-existent-projects.patch
@@ -7,7 +7,7 @@ The ALL_APPS symbol will optionally build an additional set of projects,
 however, several of them don't exist anymore. Remove them from the list of
 ALL_APPS.
 
-Upstream-status: submitted [https://github.com/raspberrypi/userland/pull/661]
+Upstream-Status: Submitted [https://github.com/raspberrypi/userland/pull/661]
 Signed-off-by: Trevor Woerner <twoerner@gmail.com>
 ---
  host_applications/linux/CMakeLists.txt | 4 ----

--- a/recipes-graphics/userland/files/0023-hello_pi-optionally-build-wayland-specific-app.patch
+++ b/recipes-graphics/userland/files/0023-hello_pi-optionally-build-wayland-specific-app.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] hello_pi: optionally build wayland-specific app
 
 Only build the wayland-specific hello_pi app when building for wayland.
 
-Upstream-status: inappropriate [the wayland example is not part of upstream]
+Upstream-Status: Inappropriate [the wayland example is not part of upstream]
 Signed-off-by: Trevor Woerner <twoerner@gmail.com>
 ---
  host_applications/linux/apps/hello_pi/CMakeLists.txt | 4 +++-

--- a/recipes-multimedia/omxplayer/omxplayer/0005-Don-t-require-internet-connection-during-build.patch
+++ b/recipes-multimedia/omxplayer/omxplayer/0005-Don-t-require-internet-connection-during-build.patch
@@ -10,7 +10,7 @@ The following issues break offline builds:
 * Makefile.ffmpeg explicitly does a "git clone" from the internet.
 
 Signed-off-by: Paul Barker <pbarker@toganlabs.com>
-Upstream-status: Inappropriate
+Upstream-Status: Inappropriate
 
 ---
  Makefile        | 6 ++----

--- a/recipes-multimedia/omxplayer/omxplayer/0006-Prevent-ffmpeg-configure-compile-race-condition.patch
+++ b/recipes-multimedia/omxplayer/omxplayer/0006-Prevent-ffmpeg-configure-compile-race-condition.patch
@@ -7,7 +7,7 @@ Additional dependency information is needed in Makefile.ffmpeg to ensure that
 the configure stage is finished before the compile stage starts.
 
 Signed-off-by: Paul Barker <pbarker@toganlabs.com>
-Upstream-status: Pending
+Upstream-Status: Pending
 
 ---
  Makefile.ffmpeg | 4 ++--


### PR DESCRIPTION
* now I've used the right tool to hopefully find them all in one go:

```
../openembedded-core/scripts/contrib/patchreview.py .

Total patches found: 70
Patches missing Signed-off-by: 17 (24%)
Patches with malformed Signed-off-by: 0 (0%)
Patches missing CVE: 1 (1%)
Patches missing Upstream-Status: 32 (46%)
Patches with malformed Upstream-Status: 0 (0%)
Patches in Pending state: 8 (11%)
```
