### PR TITLE
Enable build of mesa-demos for userland graphics drivers

### DIFF
--- a/recipes-graphics/mesa/mesa-demos_%.bbappend
+++ b/recipes-graphics/mesa/mesa-demos_%.bbappend
@@ -1,2 +1,3 @@
-# mesa-demos need libgles1 and userland driver does not have it
-COMPATIBLE_HOST:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '(.*)', 'null', d)}"
+# mesa-demos userland driver doesn't provide libgles1 and the EGL headers it provides break the mesa-demos build.
+# And enabling the `wayland` option without enabling `egl` is useless.
+PACKAGECONFIG:remove:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'egl gles1 wayland', d)}"


### PR DESCRIPTION

Enable build of mesa-demos for userland graphics drivers
* mesa-demos can be built fine if both `gles1` and `egl` options are disabled. This allows to have utilities like `glxinfo` or `glxgears`
