### PR TITLE
Add support for Raspberry Pi Camera Module v3

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -35,6 +35,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/i2c-rtc.dtbo \
     overlays/imx219.dtbo \
     overlays/imx477.dtbo \
+    overlays/imx708.dtbo \
     overlays/iqaudio-dac.dtbo \
     overlays/iqaudio-dacplus.dtbo \
     overlays/mcp2515-can0.dtbo \

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -379,19 +379,27 @@ option:
         # Raspberry Pi 7\" display/touch screen \n \
         lcd_rotate=2 \n \
         '
-## Enable Raspberrypi Camera V2
+## Enable Raspberry Pi Camera Module
 
-RaspberryPi does not have the unicam device ( RaspberryPi Camera ) enabled by default.
+Raspberry Pi does not have the unicam device ( Raspberry Pi Camera ) enabled by default.
 Because this unicam device ( bcm2835-unicam ) as of now is used by libcamera opensource.
-So we have to explicitly set in local.conf.
+So we have to explicitly enable it in local.conf.
 
     RASPBERRYPI_CAMERA_V2 = "1"
 
-This will add the device tree overlays imx219 ( RaspberryPi Camera sensor V2 driver ) to config.txt.
-Also, this will enable adding Contiguous Memory Allocation value in the cmdline.txt.
+This will add the device tree overlay imx219 ( Raspberry Pi Camera Module V2 sensor driver 
+) to config.txt. Also, this will enable adding Contiguous Memory Allocation value in the 
+cmdline.txt.
 
-Ref.:
-* <https://github.com/raspberrypi/documentation/blob/master/linux/software/libcamera/README.md>
+Similarly, the Raspberry Pi Camera Module v3 also has to be explicitly enabled in local.conf.
+
+    RASPBERRYPI_CAMERA_V3 = "1"
+
+This will add the device tree overlay imx708 ( Raspberry Pi Camera Module V3 sensor driver ) 
+to config.txt.
+
+See:
+* <https://www.raspberrypi.com/documentation/computers/camera_software.html>
 * <https://www.raspberrypi.org/blog/an-open-source-camera-stack-for-raspberry-pi-using-libcamera/>
 
 ## WM8960 soundcard support

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -210,6 +210,12 @@ do_deploy() {
     #    echo "dtoverlay=imx477" >> $CONFIG
     #fi
 
+    # Choose Camera Sensor to be used, default imx708 sensor
+    if [ "${RASPBERRYPI_CAMERA_V3}" = "1" ]; then
+        echo "# Enable Sony RaspberryPi Camera(imx708)" >> $CONFIG
+        echo "dtoverlay=imx708" >> $CONFIG
+    fi
+
     # Waveshare "C" 1024x600 7" Rev2.1 IPS capacitive touch (http://www.waveshare.com/7inch-HDMI-LCD-C.htm)
     if [ "${WAVESHARE_1024X600_C_2_1}" = "1" ]; then
         echo "# Waveshare \"C\" 1024x600 7\" Rev2.1 IPS capacitive touch screen" >> $CONFIG


### PR DESCRIPTION
I would like to see support for the Raspberry Pi Camera Module v3 which uses the imx708 sensor. Therefore, I added the required device tree overlay and config. I am not able to test this right now but it would be great if an admin could verify this patch.