### PR TITLE
Enable to support USB boot

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -74,6 +74,22 @@ To remove (or adjust) this delay set these variables in local.conf:
     BOOT_DELAY = "0"
     BOOT_DELAY_MS = "0"
 
+## Boot media
+
+The Raspberry Pi 4 board can load the boot image files from SD card and USB memory.
+By default SD card media is used as boot media.
+
+To switch the boot media from SD card to USB memory, the following variables are supported
+in local.conf: `CMDLINE_ROOT_PARTITION` and `BOOT_MEDIA`.
+The default value of `CMDLINE_ROOT_PARTITION` is "/dev/mmcblk0p2" to mount SD card. If you want to mount USB memory partition, set CMDLINE_ROOT_PARTITION to "/dev/sda2".
+`BOOT_MEDIA` allows  `mmc` and `usb`. The "mmc" is required to load an image from the SD card, following the u-boot specification. Similarly, if you want to load a boot image file from USB memory, set BOOT_MEDIA to "usb".
+
+For example, if you want to use USB boot, please define
+the following parameters in your local.conf file.
+
+    CMDLINE_ROOT_PARTITION = "/dev/sda2"
+    BOOT_MEDIA = "usb"
+
 ## Set overclocking options
 
 The Raspberry Pi can be overclocked. As of now overclocking up to the "Turbo

--- a/recipes-bsp/bootfiles/rpi-cmdline.bb
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bb
@@ -9,7 +9,9 @@ inherit deploy nopackages
 CMDLINE_DWC_OTG ?= "dwc_otg.lpm_enable=0"
 
 CMDLINE_ROOT_FSTYPE ?= "rootfstype=ext4"
-CMDLINE_ROOTFS ?= "root=/dev/mmcblk0p2 ${CMDLINE_ROOT_FSTYPE} rootwait"
+CMDLINE_ROOT_PARTITION ?= "/dev/mmcblk0p2"
+
+CMDLINE_ROOTFS ?= "root=${CMDLINE_ROOT_PARTITION} ${CMDLINE_ROOT_FSTYPE} rootwait"
 
 CMDLINE_SERIAL ?= "${@oe.utils.conditional("ENABLE_UART", "1", "console=serial0,115200", "", d)}"
 

--- a/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
+++ b/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
@@ -1,4 +1,4 @@
 fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
-fatload mmc 0:1 ${kernel_addr_r} @@KERNEL_IMAGETYPE@@
-if test ! -e mmc 0:1 uboot.env; then saveenv; fi;
+fatload @@BOOT_MEDIA@@ 0:1 ${kernel_addr_r} @@KERNEL_IMAGETYPE@@
+if test ! -e @@BOOT_MEDIA@@ 0:1 uboot.env; then saveenv; fi;
 @@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr}

--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -9,9 +9,12 @@ INHIBIT_DEFAULT_DEPS = "1"
 
 SRC_URI = "file://boot.cmd.in"
 
+BOOT_MEDIA ?= "mmc"
+
 do_compile() {
     sed -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
         -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
+        -e 's/@@BOOT_MEDIA@@/${BOOT_MEDIA}/' \
         "${WORKDIR}/boot.cmd.in" > "${WORKDIR}/boot.cmd"
     mkimage -A ${UBOOT_ARCH} -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
 }


### PR DESCRIPTION
Raspberry Pi 4 board can boot the image from USB memory. But, current meta-raspberrypi supports only SD boot.

 This commit allows switching SD boot to other device. For example, if you want to use USB boot, please define the following parameters in your conf/local.conf file.
CMDLINE_ROOT_PARTITION = "/dev/sda2"
BOOT_MEDIA = "usb"

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
 I checked 
**- How I did it**
This commit is a proposal then I wrote some description in commit message 