### PR TITLE
Enable dtoverlay=imx477 when RASPBERRYPI_HD_CAMERA is set

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -205,10 +205,10 @@ do_deploy() {
     fi
 
     # Choose Camera Sensor to be used, default imx477 sensor
-    #if [ "${RASPBERRYPI_HD_CAMERA}" = "1" ]; then
-    #    echo "# Enable Sony RaspberryPi Camera(imx477)" >> $CONFIG
-    #    echo "dtoverlay=imx477" >> $CONFIG
-    #fi
+    if [ "${RASPBERRYPI_HD_CAMERA}" = "1" ]; then
+       echo "# Enable Sony RaspberryPi Camera(imx477)" >> $CONFIG
+       echo "dtoverlay=imx477" >> $CONFIG
+    fi
 
     # Choose Camera Sensor to be used, default imx708 sensor
     if [ "${RASPBERRYPI_CAMERA_V3}" = "1" ]; then


### PR DESCRIPTION
**- What I did**

Correctly handle `RASPBERRYPI_HD_CAMERA` when writing out `/boot/config.txt`

Looks like this code block was commented out, but should be enabled. =)

Closes: https://github.com/agherzan/meta-raspberrypi/issues/1167
Ref: https://github.com/bitsy-ai/printnanny-os/issues/311