### PR TITLE
machines: simplify MACHINEOVERRIDES definitions

### DIFF
--- a/conf/machine/raspberrypi-cm.conf
+++ b/conf/machine/raspberrypi-cm.conf
@@ -2,7 +2,7 @@
 #@NAME: RaspberryPi Compute Module (CM1)
 #@DESCRIPTION: Machine configuration for the RaspberryPi Compute Module (CM1)
 
-MACHINEOVERRIDES = "raspberrypi:${MACHINE}"
+MACHINEOVERRIDES =. "raspberrypi:"
 include conf/machine/raspberrypi.conf
 
 ARMSTUB ?= "armstub.bin"

--- a/conf/machine/raspberrypi0-2w-64.conf
+++ b/conf/machine/raspberrypi0-2w-64.conf
@@ -2,9 +2,9 @@
 #@NAME: RaspberryPi0 2 Wifi Development Board
 #@DESCRIPTION: Machine configuration for the RaspberryPi0 2 Wifi in 64 bits mode
 
-include conf/machine/raspberrypi3-64.conf
+MACHINEOVERRIDES =. "raspberrypi3-64:"
 
-MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberrypi3-64:${MACHINE}')}"
+include conf/machine/raspberrypi3-64.conf
 
 MACHINE_EXTRA_RRECOMMENDS += "\
     linux-firmware-rpidistro-bcm43436 \

--- a/conf/machine/raspberrypi0-2w.conf
+++ b/conf/machine/raspberrypi0-2w.conf
@@ -2,9 +2,9 @@
 #@NAME: RaspberryPi0 2 Wifi Development Board
 #@DESCRIPTION: Machine configuration for the RaspberryPi0 2 Wifi in 32 bits mode
 
-include conf/machine/raspberrypi3.conf
+MACHINEOVERRIDES =. "raspberrypi3:"
 
-MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberrypi3:${MACHINE}')}"
+include conf/machine/raspberrypi3.conf
 
 MACHINE_EXTRA_RRECOMMENDS += "\
     linux-firmware-rpidistro-bcm43436 \

--- a/conf/machine/raspberrypi0.conf
+++ b/conf/machine/raspberrypi0.conf
@@ -2,7 +2,7 @@
 #@NAME: RaspberryPi Zero Development Board
 #@DESCRIPTION: Machine configuration for the RaspberryPi Zero board (https://www.raspberrypi.org/blog/raspberry-pi-zero)
 
-MACHINEOVERRIDES = "raspberrypi:${MACHINE}"
+MACHINEOVERRIDES =. "raspberrypi:"
 include conf/machine/raspberrypi.conf
 
 SERIAL_CONSOLES ?= "115200;ttyAMA0"

--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -2,7 +2,7 @@
 #@NAME: RaspberryPi 3 Development Board
 #@DESCRIPTION: Machine configuration for the RaspberryPi 3 in 64 bits mode
 
-MACHINEOVERRIDES = "raspberrypi3:${MACHINE}"
+MACHINEOVERRIDES =. "raspberrypi3:"
 
 MACHINE_EXTRA_RRECOMMENDS += "\
     linux-firmware-rpidistro-bcm43430 \

--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -2,7 +2,7 @@
 #@NAME: RaspberryPi 4 Development Board (64bit)
 #@DESCRIPTION: Machine configuration for the RaspberryPi 4 in 64 bits mode
 
-MACHINEOVERRIDES = "raspberrypi4:${MACHINE}"
+MACHINEOVERRIDES =. "raspberrypi4:"
 
 MACHINE_FEATURES += "pci"
 MACHINE_EXTRA_RRECOMMENDS += "\


### PR DESCRIPTION
Prepending new definitions should be preferred to assignment, as it is simpler and more conducive to defining new machine configurations that reuse these configurations.

This PR is a follow-up on #1166, which saw this same patch merged to the `kirkstone` branch.