### PR TITLE
kas-poky-rpi.yml: renamed ABORT to HALT

### DIFF
--- a/kas-poky-rpi.yml
+++ b/kas-poky-rpi.yml
@@ -55,7 +55,7 @@ local_conf_header:
         STOPTASKS,${DL_DIR},1G,100K \
         STOPTASKS,${SSTATE_DIR},1G,100K \
         STOPTASKS,/tmp,100M,100K \
-        ABORT,${TMPDIR},100M,1K \
-        ABORT,${DL_DIR},100M,1K \
-        ABORT,${SSTATE_DIR},100M,1K \
-        ABORT,/tmp,10M,1K"
+        HALT,${TMPDIR},100M,1K \
+        HALT,${DL_DIR},100M,1K \
+        HALT,${SSTATE_DIR},100M,1K \
+        HALT,/tmp,10M,1K"


### PR DESCRIPTION
Naming changed in Yocto.  And it avoids a warning during the run.
