### PR TITLE
rpidistro-vlc: fix error uint64_t does not name

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/files/0009-demux-dash-include-cstdint-needed-for-uint64_t.patch
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/files/0009-demux-dash-include-cstdint-needed-for-uint64_t.patch
@@ -1,0 +1,30 @@
+From 6fca76ebd76bf8fce9b111e31bda64015cdc770f Mon Sep 17 00:00:00 2001
+From: Johannes Kauffmann <johanneskauffmann@hotmail.com>
+Date: Mon, 11 Jul 2022 19:35:57 +0000
+Subject: [PATCH] demux: dash: include cstdint, needed for uint64_t
+
+Fixes #27077.
+
+Upstream-Status: Backport
+
+https://github.com/videolan/vlc/commit/6fca76ebd76bf8fce9b111e31bda64015cdc770f
+
+---
+ modules/demux/dash/mpd/TemplatedUri.hpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules/demux/dash/mpd/TemplatedUri.hpp b/modules/demux/dash/mpd/TemplatedUri.hpp
+index 1eeb70cbb6..7f7264a9c8 100644
+--- a/modules/demux/dash/mpd/TemplatedUri.hpp
++++ b/modules/demux/dash/mpd/TemplatedUri.hpp
+@@ -21,6 +21,7 @@
+ #ifndef TEMPLATEDURI_HPP
+ #define TEMPLATEDURI_HPP
+ 
++#include <cstdint>
+ #include <string>
+ 
+ namespace dash
+-- 
+2.34.1
+

--- a/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.17.bb
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.17.bb
@@ -15,6 +15,7 @@ SRC_URI = "\
     file://0006-mmal_chain.patch \
     file://0007-armv6.patch \
     file://0008-configure-Disable-incompatible-function-pointer-type.patch \
+    file://0009-demux-dash-include-cstdint-needed-for-uint64_t.patch \
     file://2001-fix-luaL-checkint.patch \
     file://2002-use-vorbisidec.patch \
     file://3001-configure.ac-setup-for-OE-usage.patch \


### PR DESCRIPTION
Build failure occurring with gcc version 13.1.1.

**- What I did**

Add patch to fix builds with latest gcc in OE-core.

**- How I did it**
