### PR TITLE
libcamera: update PACKAGECONFIG for libcamera-0.1.0

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera/libcamera_%.bbappend
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera/libcamera_%.bbappend
@@ -1,2 +1,2 @@
-PACKAGECONFIG[raspberrypi] = "-Dpipelines=raspberrypi -Dipas=raspberrypi -Dcpp_args=-Wno-unaligned-access"
+PACKAGECONFIG[raspberrypi] = "-Dpipelines=rpi/vc4 -Dipas=rpi/vc4 -Dcpp_args=-Wno-unaligned-access"
 PACKAGECONFIG:append:rpi = " raspberrypi"


### PR DESCRIPTION
* libcamera was updated in meta-oe in: https://git.openembedded.org/meta-openembedded/commit/?id=4e0281797277cf44287de93618c51e4a219fac75

* now it was failing with:
  meson.build:3:0: ERROR: Options "raspberrypi" are not in allowed choices: "all, auto, imx8-isi, ipu3, rkisp1, rpi/vc4, simple, uvcvideo, vimc"

  because raspberrypi support was updated and renamed to rpi/vc4 in: https://github.com/raspberrypi/libcamera/commit/726e9274ea95fa46352556d340c5793a8da51fcd