### PR TITLE
rpi-base: Remove customizing SPLASH var

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -113,9 +113,6 @@ SERIAL_CONSOLES_CHECK ??= "${SERIAL_CONSOLES}"
 # This variable is referred to by recipes fetching / generating the files.
 BOOTFILES_DIR_NAME ?= "bootfiles"
 
-# Set Raspberrypi splash image
-SPLASH ?= "psplash-raspberrypi"
-
 def make_dtb_boot_files(d):
     # Generate IMAGE_BOOT_FILES entries for device tree files listed in
     # KERNEL_DEVICETREE.


### PR DESCRIPTION
psplash-raspberrypi does not exist anymore, we use psplash from core
