### PR TITLE
Add officially supported camera modules

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -31,6 +31,10 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/i2c-gpio.dtbo \
     overlays/i2c-rtc.dtbo \
     overlays/imx219.dtbo \
+    overlays/imx290.dtbo \
+    overlays/imx296.dtbo \
+    overlays/imx327.dtbo \
+    overlays/imx378.dtbo \
     overlays/imx477.dtbo \
     overlays/imx708.dtbo \
     overlays/iqaudio-dac.dtbo \
@@ -42,6 +46,8 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/mcp2515-can1.dtbo \
     overlays/mcp3008.dtbo \
     overlays/miniuart-bt.dtbo \
+    overlays/ov5647.dtbo \
+    overlays/ov9281.dtbo \
     overlays/overlay_map.dtb \
     overlays/pitft22.dtbo \
     overlays/pitft28-capacitive.dtbo \

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -15,7 +15,6 @@ XSERVER = " \
     "
 
 RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
-    overlays/overlay_map.dtb \
     overlays/at86rf233.dtbo \
     overlays/disable-bt.dtbo \
     overlays/disable-wifi.dtbo \
@@ -29,9 +28,6 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/hifiberry-dac.dtbo \
     overlays/hifiberry-dacplus.dtbo \
     overlays/hifiberry-digi.dtbo \
-    overlays/justboom-both.dtbo \
-    overlays/justboom-dac.dtbo \
-    overlays/justboom-digi.dtbo \
     overlays/i2c-gpio.dtbo \
     overlays/i2c-rtc.dtbo \
     overlays/imx219.dtbo \
@@ -39,10 +35,14 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/imx708.dtbo \
     overlays/iqaudio-dac.dtbo \
     overlays/iqaudio-dacplus.dtbo \
+    overlays/justboom-both.dtbo \
+    overlays/justboom-dac.dtbo \
+    overlays/justboom-digi.dtbo \
     overlays/mcp2515-can0.dtbo \
     overlays/mcp2515-can1.dtbo \
     overlays/mcp3008.dtbo \
     overlays/miniuart-bt.dtbo \
+    overlays/overlay_map.dtb \
     overlays/pitft22.dtbo \
     overlays/pitft28-capacitive.dtbo \
     overlays/pitft28-resistive.dtbo \
@@ -52,9 +52,9 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/rpi-poe.dtbo \
     overlays/vc4-fkms-v3d.dtbo \
     overlays/vc4-fkms-v3d-pi4.dtbo \
+    overlays/vc4-kms-dsi-7inch.dtbo \
     overlays/vc4-kms-v3d.dtbo \
     overlays/vc4-kms-v3d-pi4.dtbo \
-    overlays/vc4-kms-dsi-7inch.dtbo \
     overlays/w1-gpio.dtbo \
     overlays/w1-gpio-pullup.dtbo \
     overlays/wm8960-soundcard.dtbo \

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -108,13 +108,6 @@ Example to force HDMI output to 720p in CEA mode:
 
 See: <https://www.raspberrypi.com/documentation/computers/configuration.html#hdmi-configuration>
 
-## Video camera support with V4L2 drivers
-
-Set this variable to enable support for the video camera (Linux 3.12.4+
-required):
-
-    VIDEO_CAMERA = "1"
-
 ## Enable offline compositing support
 
 Set this variable to enable support for dispmanx offline compositing:
@@ -389,28 +382,25 @@ option:
         # Raspberry Pi 7\" display/touch screen \n \
         lcd_rotate=2 \n \
         '
-## Enable Raspberry Pi Camera Module
+## Camera Modules
 
-Raspberry Pi does not have the unicam device ( Raspberry Pi Camera ) enabled by default.
-Because this unicam device ( bcm2835-unicam ) as of now is used by libcamera opensource.
-So we have to explicitly enable it in local.conf.
+Automatic camera detection is enabled by default, which is equivalent to:
 
-    RASPBERRYPI_CAMERA_V2 = "1"
+    RASPBERRYPI_CAMERA = "auto"
 
-This will add the device tree overlay imx219 ( Raspberry Pi Camera Module V2 sensor driver 
-) to config.txt. Also, this will enable adding Contiguous Memory Allocation value in the 
-cmdline.txt.
+To override the automatic camera detection, clear `RASPBERRYPI_CAMERA`
+or specify an explicit camera module name. Common values are predefined to
+avoid case sensitivity issues or typos, like `${RASPBERRYPI_CAMERA_V2}`.
+For example, request the support for the Camera Module 3 with either:
 
-Similarly, the Raspberry Pi Camera Module v3 also has to be explicitly enabled in local.conf.
+    RASPBERRYPI_CAMERA = "${RASPBERRYPI_CAMERA_V3}"
 
-    RASPBERRYPI_CAMERA_V3 = "1"
+or directly:
 
-This will add the device tree overlay imx708 ( Raspberry Pi Camera Module V3 sensor driver ) 
-to config.txt.
+    RASPBERRYPI_CAMERA = "imx708"
 
 See:
-* <https://www.raspberrypi.com/documentation/computers/camera_software.html>
-* <https://www.raspberrypi.org/blog/an-open-source-camera-stack-for-raspberry-pi-using-libcamera/>
+* <https://www.raspberrypi.com/documentation/computers/camera_software.html#if-you-do-need-to-alter-the-configuration>
 
 ## WM8960 soundcard support
 

--- a/recipes-bsp/bootfiles/files/config.txt
+++ b/recipes-bsp/bootfiles/files/config.txt
@@ -1,0 +1,1 @@
+# https://www.raspberrypi.com/documentation/computers/config_txt.html

--- a/recipes-bsp/bootfiles/rpi-config.bb
+++ b/recipes-bsp/bootfiles/rpi-config.bb
@@ -2,18 +2,16 @@ DESCRIPTION = "Commented config.txt file for the Raspberry Pi. \
                The Raspberry Pi config.txt file is read by the GPU before \
                the ARM core is initialised. It can be used to set various \
                system configuration parameters."
+HOMEPAGE = "https://www.raspberrypi.com/documentation/computers/config_txt.html"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 COMPATIBLE_MACHINE = "^rpi$"
 
-SRCREV = "648ffc470824c43eb0d16c485f4c24816b32cd6f"
-SRC_URI = "git://github.com/Evilpaul/RPi-config.git;protocol=https;branch=master \
-          "
+SRC_URI = "file://config.txt"
 
-S = "${WORKDIR}/git"
-
-PR = "r5"
+S = "${WORKDIR}"
+B = "${WORKDIR}/build"
 
 INHIBIT_DEFAULT_DEPS = "1"
 
@@ -38,9 +36,8 @@ GPIO_SHUTDOWN_PIN ??= ""
 
 inherit deploy nopackages
 
-do_deploy() {
-    install -d ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}
-    CONFIG=${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+do_compile() {
+    CONFIG=${B}/config.txt
 
     cp ${S}/config.txt $CONFIG
 
@@ -318,7 +315,7 @@ do_deploy() {
     fi
 }
 
-do_deploy:append:raspberrypi3-64() {
+do_compile:append:raspberrypi3-64() {
     echo "# have a properly sized image" >> $CONFIG
     echo "disable_overscan=1" >> $CONFIG
 
@@ -326,7 +323,9 @@ do_deploy:append:raspberrypi3-64() {
     echo "dtparam=audio=on" >> $CONFIG
 }
 
-do_deploy:append() {
+do_deploy() {
+    install -D -m 600 ${B}/config.txt ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+
     if grep -q -E '^.{80}.$' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt; then
         bbwarn "config.txt contains lines longer than 80 characters, this is not supported"
     fi

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -45,84 +45,84 @@ do_deploy() {
     cp ${S}/config.txt $CONFIG
 
     if [ -n "${KEY_DECODE_MPG2}" ]; then
-        sed -i '/#decode_MPG2=/ c\decode_MPG2=${KEY_DECODE_MPG2}' $CONFIG
+        echo "decode_MPG2=${KEY_DECODE_MPG2}" >> $CONFIG
     fi
     if [ -n "${KEY_DECODE_WVC1}" ]; then
-        sed -i '/#decode_WVC1=/ c\decode_WVC1=${KEY_DECODE_WVC1}' $CONFIG
+        echo "decode_WVC1=${KEY_DECODE_WVC1}" >> $CONFIG
     fi
     if [ -n "${DISABLE_OVERSCAN}" ]; then
-        sed -i '/#disable_overscan=/ c\disable_overscan=${DISABLE_OVERSCAN}' $CONFIG
+        echo "disable_overscan=${DISABLE_OVERSCAN}" >> $CONFIG
     fi
     if [ "${DISABLE_SPLASH}" = "1" ]; then
-        sed -i '/#disable_splash=/ c\disable_splash=${DISABLE_SPLASH}' $CONFIG
+        echo "disable_splash=${DISABLE_SPLASH}" >> $CONFIG
     fi
 
     # Set overclocking options
     if [ -n "${ARM_FREQ}" ]; then
-        sed -i '/#arm_freq=/ c\arm_freq=${ARM_FREQ}' $CONFIG
+        echo "arm_freq=${ARM_FREQ}" >> $CONFIG
     fi
     if [ -n "${GPU_FREQ}" ]; then
-        sed -i '/#gpu_freq=/ c\gpu_freq=${GPU_FREQ}' $CONFIG
+        echo "gpu_freq=${GPU_FREQ}" >> $CONFIG
     fi
     if [ -n "${CORE_FREQ}" ]; then
-        sed -i '/#core_freq=/ c\core_freq=${CORE_FREQ}' $CONFIG
+        echo "core_freq=${CORE_FREQ}" >> $CONFIG
     fi
     if [ -n "${SDRAM_FREQ}" ]; then
-        sed -i '/#sdram_freq=/ c\sdram_freq=${SDRAM_FREQ}' $CONFIG
+        echo "sdram_freq=${SDRAM_FREQ}" >> $CONFIG
     fi
     if [ -n "${OVER_VOLTAGE}" ]; then
-        sed -i '/#over_voltage=/ c\over_voltage=${OVER_VOLTAGE}' $CONFIG
+        echo "over_voltage=${OVER_VOLTAGE}" >> $CONFIG
     fi
 
     # GPU memory
     if [ -n "${GPU_MEM}" ]; then
-        sed -i '/#gpu_mem=/ c\gpu_mem=${GPU_MEM}' $CONFIG
+        echo "gpu_mem=${GPU_MEM}" >> $CONFIG
     fi
     if [ -n "${GPU_MEM_256}" ]; then
-        sed -i '/#gpu_mem_256=/ c\gpu_mem_256=${GPU_MEM_256}' $CONFIG
+        echo "gpu_mem_256=${GPU_MEM_256}" >> $CONFIG
     fi
     if [ -n "${GPU_MEM_512}" ]; then
-        sed -i '/#gpu_mem_512=/ c\gpu_mem_512=${GPU_MEM_512}' $CONFIG
+        echo "gpu_mem_512=${GPU_MEM_512}" >> $CONFIG
     fi
     if [ -n "${GPU_MEM_1024}" ]; then
-        sed -i '/#gpu_mem_1024=/ c\gpu_mem_1024=${GPU_MEM_1024}' $CONFIG
+        echo "gpu_mem_1024=${GPU_MEM_1024}" >> $CONFIG
     fi
 
     # Set boot delay
     if [ -n "${BOOT_DELAY}" ]; then
-        sed -i '/#boot_delay=/ c\boot_delay=${BOOT_DELAY}' $CONFIG
+        echo "boot_delay=${BOOT_DELAY}" >> $CONFIG
     fi
     if [ -n "${BOOT_DELAY_MS}" ]; then
-        sed -i '/#boot_delay_ms=/ c\boot_delay_ms=${BOOT_DELAY_MS}' $CONFIG
+        echo "boot_delay_ms=${BOOT_DELAY_MS}" >> $CONFIG
     fi
 
     # Set HDMI and composite video options
     if [ -n "${HDMI_FORCE_HOTPLUG}" ]; then
-        sed -i '/#hdmi_force_hotplug=/ c\hdmi_force_hotplug=${HDMI_FORCE_HOTPLUG}' $CONFIG
+        echo "hdmi_force_hotplug=${HDMI_FORCE_HOTPLUG}" >> $CONFIG
     fi
     if [ -n "${HDMI_DRIVE}" ]; then
-        sed -i '/#hdmi_drive=/ c\hdmi_drive=${HDMI_DRIVE}' $CONFIG
+        echo "hdmi_drive=${HDMI_DRIVE}" >> $CONFIG
     fi
     if [ -n "${HDMI_GROUP}" ]; then
-        sed -i '/#hdmi_group=/ c\hdmi_group=${HDMI_GROUP}' $CONFIG
+        echo "hdmi_group=${HDMI_GROUP}" >> $CONFIG
     fi
     if [ -n "${HDMI_MODE}" ]; then
-        sed -i '/#hdmi_mode=/ c\hdmi_mode=${HDMI_MODE}' $CONFIG
+        echo "hdmi_mode=${HDMI_MODE}" >> $CONFIG
     fi
     if [ -n "${HDMI_CVT}" ]; then
         echo 'hdmi_cvt=${HDMI_CVT}' >> $CONFIG
     fi
     if [ -n "${CONFIG_HDMI_BOOST}" ]; then
-        sed -i '/#config_hdmi_boost=/ c\config_hdmi_boost=${CONFIG_HDMI_BOOST}' $CONFIG
+        echo "config_hdmi_boost=${CONFIG_HDMI_BOOST}" >> $CONFIG
     fi
     if [ -n "${SDTV_MODE}" ]; then
-        sed -i '/#sdtv_mode=/ c\sdtv_mode=${SDTV_MODE}' $CONFIG
+        echo "sdtv_mode=${SDTV_MODE}" >> $CONFIG
     fi
     if [ -n "${SDTV_ASPECT}" ]; then
-        sed -i '/#sdtv_aspect=/ c\sdtv_aspect=${SDTV_ASPECT}' $CONFIG
+        echo "sdtv_aspect=${SDTV_ASPECT}" >> $CONFIG
     fi
     if [ -n "${DISPLAY_ROTATE}" ]; then
-        sed -i '/#display_rotate=/ c\display_rotate=${DISPLAY_ROTATE}' $CONFIG
+        echo "display_rotate=${DISPLAY_ROTATE}" >> $CONFIG
     fi
 
     # Video camera support
@@ -136,7 +136,7 @@ do_deploy() {
         # was that there could be a file size limitation affecting certain
         # variables. It was commented that this limitation could be 4k but
         # not proved.
-        sed -i '/#start_x=/ c\start_x=1' $CONFIG
+        echo "start_x=1" >> $CONFIG
     fi
 
     # Offline compositing support


### PR DESCRIPTION
This patchset adds support for the camera modules listed in the official [documentation](https://www.raspberrypi.com/documentation/computers/camera_software.html#if-you-do-need-to-alter-the-configuration) and simplify the configuration with a single RASPBERRYPI_CAMERA variable (and predefined aliases) to describe if and which camera model is used.

At the same time, add an empty config.txt template file to the rpi-config package, because relying on a commented out config file from a user github repository is error prone and only a few keys are added to the configuration anyway. Prefer to point the user to the official [documentation](https://www.raspberrypi.com/documentation/computers/config_txt.html) instead.