### PR TITLE
layer.conf: update LAYERSERIES_COMPAT for nanbield

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "raspberrypi"
 BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
-LAYERSERIES_COMPAT_raspberrypi = "mickledore"
+LAYERSERIES_COMPAT_raspberrypi = "nanbield"
 LAYERDEPENDS_raspberrypi = "core"
 
 # Additional license directories.


### PR DESCRIPTION
* oe-core switched to nanbield in: https://git.openembedded.org/openembedded-core/commit/?id=f212cb12a0db9c9de5afd3cc89b1331d386e55f6