### PR TITLE
rpi-base: Fix wic image kernel dependency

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -149,6 +149,7 @@ IMAGE_BOOT_FILES ?= "${BOOTFILES_DIR_NAME}/* \
                  ${RPI_EXTRA_IMAGE_BOOT_FILES} \
                  "
 do_image_wic[depends] += " \
+    virtual/kernel:do_deploy \
     rpi-bootfiles:do_deploy \
     ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
     "


### PR DESCRIPTION
wic images depend on the kernel device trees, and therefore should depend on virtual/kernel:do_deploy to make sure these are present in the deploy directory.

Most of the time, this dependency is satisfied indirectly since a rootfs image will depend on the kernel, but add it explicitly for the cases where it is not.
