### PR TITLE
rpi-base: Fix wic image kernel dependency

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -141,6 +141,7 @@ IMAGE_BOOT_FILES ?= "${BOOTFILES_DIR_NAME}/* \
                     '${KERNEL_IMAGETYPE};${SDIMG_KERNELIMAGE}', d)} \
                  "
 do_image_wic[depends] += " \
+    virtual/kernel:do_deploy \
     rpi-bootfiles:do_deploy \
     ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
     "


### PR DESCRIPTION
wic images depend on the kernel device trees, and therefore should depend on virtual/kernel:do_deploy to make sure these are present in the deploy directory.

Most of the time, this dependency is satisfied indirectly since a rootfs image will depend on the kernel, but add it explicitly for the cases where it is not.

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>
(cherry picked from commit 482d864b8f1af84915ed6a9641e80af4e49a1f63)