### PR TITLE
linux-raspberrypi: stop setting powersave as the default CPU governor

### DIFF
--- a/recipes-kernel/linux/files/default-cpu-governor.cfg
+++ b/recipes-kernel/linux/files/default-cpu-governor.cfg
@@ -1,0 +1,9 @@
+# The defconfigs from the RPi Kernel set "powersave" as the default CPU governor.
+# That is a bad idea as it reduces performance, so we unset that default option here.
+# The option to build the powersave governor (but not as the default) is also enabled.
+# A fix for this was sent to upstream: https://github.com/raspberrypi/linux/pull/5666
+# However, we need to carry this option override until those defconfigs are fixed on
+# *all* the kernel branches that we support. So that can be a long time depending
+# on wheter the above PR gets accepted and/or backported to the stable branches.
+CONFIG_CPU_FREQ_DEFAULT_GOV_POWERSAVE=n
+CONFIG_CPU_FREQ_GOV_POWERSAVE=y

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -15,6 +15,7 @@ SRC_URI += " \
     ${@bb.utils.contains("INITRAMFS_IMAGE_BUNDLE", "1", "file://initramfs-image-bundle.cfg", "", d)} \
     ${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "file://vc4graphics.cfg", "", d)} \
     ${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "file://wm8960.cfg", "", d)} \
+    file://default-cpu-governor.cfg \
     "
 
 SRC_URI:append:raspberrypi4 = " \


### PR DESCRIPTION
* The defconfigs from the RPi Kernel set `powersave` as the default CPU governor, which is a bad idea as that reduces performance by setting the CPU frequency to the minimum one.

* In case of a Yocto build user-space is not configured by default to change the CPU governor, so `powersave` will remain the CPU governor and it will slow down everything.

* I submitted a fix for those defconfigs to upstream here: https://github.com/raspberrypi/linux/pull/5666 However, we shouldn't wait until that is accepted and backported to all the stable branches (if ever is).

* This patch unsets the selection of `powersave` as the default CPU governor.

* Then the CPU governor that will be selected as default after this patch will be the Linux's default one that is either `ondemand` or `schedutil` depending on the Kernel version.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
