### PR TITLE
rpi-base: Adds EXTRA_IMAGEDEPENDS to fix the image task do_populate_lic_deploy

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -148,6 +148,9 @@ IMAGE_BOOT_FILES ?= "${BOOTFILES_DIR_NAME}/* \
                  ${@make_dtb_boot_files(d)} \
                  ${RPI_EXTRA_IMAGE_BOOT_FILES} \
                  "
+
+EXTRA_IMAGEDEPENDS += "rpi-bootfiles"
+
 do_image_wic[depends] += " \
     virtual/kernel:do_deploy \
     rpi-bootfiles:do_deploy \


### PR DESCRIPTION
This fix is needed to bring the complete dependency chain in order to guarantee the recursive runtime dependencies [1] of do_populate_lic_deploy in do_populate_lic will run as expected.

[1] _openembedded-core/meta/classes-recipe/license_image.bbclass:do_populate_lic_deploy[recrdeptask] += "do_populate_lic do_deploy"_

Fix the following image build issues:
```
ERROR: lmp-base-console-image-1.0-r0 do_populate_lic_deploy: Couldn't find license information for dependency rpi-config
```