### PR TITLE
docs: Fix ReadTheDocs builds.os requirement

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,9 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
 python:
-  version: "3.7"
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
This fixes:

The configuration key "build.os" is required to build your
documentation. Read more at
https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os