### PR TITLE
Update raspberrypi-firmware to 20231027 to support CM4 1.1 and Pi3B+ 1.4

### DIFF
--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,9 +1,9 @@
-RPIFW_DATE ?= "20210527"
-SRCREV ?= "1eb8921ae7158249894f89e8bb6c4bfb04ec7377"
+RPIFW_DATE ?= "20231027"
+SRCREV ?= "9814645c19bd8621fdd382e13369b1efea816c1c"
 RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz;downloadfilename=raspberrypi-firmware-${SRCREV}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[sha256sum] = "32fb5cc72703247622839c3cb4df2f369f91d2185770df867ac9758283bf5380"
+SRC_URI[sha256sum] = "3d6c65c891cf4264e959847d7d24447301f7ed936e9b5726cdd6c19d2a596cf9"
 
 PV = "${RPIFW_DATE}"


### PR DESCRIPTION
Fixes #1173