### PR TITLE
[Micledore] backport patch: linux-raspberrypi: stop setting powersave as the default CPU governor

### DIFF
--- a/recipes-kernel/linux/files/default-cpu-governor.cfg
+++ b/recipes-kernel/linux/files/default-cpu-governor.cfg
@@ -1,0 +1,9 @@
+# The defconfigs from the RPi Kernel set "powersave" as the default CPU governor.
+# That is a bad idea as it reduces performance, so we unset that default option here.
+# The option to build the powersave governor (but not as the default) is also enabled.
+# A fix for this was sent to upstream: https://github.com/raspberrypi/linux/pull/5666
+# However, we need to carry this option override until those defconfigs are fixed on
+# *all* the kernel branches that we support. So that can be a long time depending
+# on wheter the above PR gets accepted and/or backported to the stable branches.
+CONFIG_CPU_FREQ_DEFAULT_GOV_POWERSAVE=n
+CONFIG_CPU_FREQ_GOV_POWERSAVE=y

--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -15,6 +15,7 @@ SRC_URI += " \
     ${@bb.utils.contains("INITRAMFS_IMAGE_BUNDLE", "1", "file://initramfs-image-bundle.cfg", "", d)} \
     ${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "file://vc4graphics.cfg", "", d)} \
     ${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "file://wm8960.cfg", "", d)} \
+    file://default-cpu-governor.cfg \
     "
 
 SRC_URI:append:raspberrypi4 = " \


### PR DESCRIPTION
This cherry-picks 0a4a68dba67442fbe3832a9d0764fa4ba7d08fba from master into Mickledore branch
