### PR TITLE
rpi-config: Upgrade to tip of tree

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 COMPATIBLE_MACHINE = "^rpi$"
 
-SRCREV = "648ffc470824c43eb0d16c485f4c24816b32cd6f"
+SRCREV = "6ac2d832c6c3b208e2669f50ec1abf2c20cb7ff4"
 SRC_URI = "git://github.com/Evilpaul/RPi-config.git;protocol=https;branch=master \
           "
 


### PR DESCRIPTION
Upgrade to the latest version of the repository with includes the following improvements of the template for config.txt:

- update revision and date stamp
- additon of dtoverlay
- general updates

This work was sponsored by GOVCERT.LU.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Upgrade to the latest version of https://github.com/Evilpaul/RPi-config

**- How I did it**

While working on https://github.com/agherzan/meta-raspberrypi/pull/1237 I noticed that recipe `rpi-config` uses an older version and decided to upgrade the template for `config.txt` to the latest available version. The primary reason is that in the new version the date at the beginning of `config.txt` has been changed for `Revision 16, 2013/06/22` to `Revision 17, 2021/08/15`. Obviously there have been many additions in general to `config.txt` since 2013 so it is better to use a newer date.
