### PR TITLE
docs: fix syntax for overriding fs type for initramfs image

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -180,7 +180,7 @@ To build an initramfs image:
   - `INITRAMFS_IMAGE_BUNDLE = "1"`
   - `BOOT_SPACE = "1073741"`
   - `INITRAMFS_MAXSIZE = "315400"`
-  - `IMAGE_FSTYPES_pn-${INITRAMFS_IMAGE} = "${INITRAMFS_FSTYPES}"`
+  - `IMAGE_FSTYPES:pn-${INITRAMFS_IMAGE} = "${INITRAMFS_FSTYPES}"`
 
 ## Including additional files in the SD card image boot partition
 


### PR DESCRIPTION
**- What I did**

I fixed the documentation for initramfs: I tried creating an initramfs image following the official (latest) documentation of the meta-raspberrypi layer but there was a dependency loop error caused by the `IMAGE_FSTYPES_pn-${INITRAMFS_IMAGE}` variable not following the latest syntax for overrides.

**- How I did it**

I fixed the doc by using the `IMAGE_FSTYPES:pn-${INITRAMFS_IMAGE}` syntax for the override.
