### PR TITLE
bcm2835: update 1.71 -> 1.73

### DIFF
--- a/recipes-devtools/bcm2835/bcm2835_1.73.bb
+++ b/recipes-devtools/bcm2835/bcm2835_1.73.bb
@@ -12,8 +12,7 @@ COMPATIBLE_MACHINE = "^rpi$"
 
 SRC_URI = "http://www.airspayce.com/mikem/bcm2835/bcm2835-${PV}.tar.gz"
 
-SRC_URI[md5sum] = "9bd2d39bf4b3a9e81dce799ca51c826a"
-SRC_URI[sha256sum] = "564920d205977d7e2846e434947708455d468d3a952feca9faef643abd03a227"
+SRC_URI[sha256sum] = "e67a986462618988a5a86752e36e3ebdd7c5cae66940ff7330aea243b2762525"
 
 inherit autotools
 


### PR DESCRIPTION
Update to version 1.73:

- Fixed some inconsistent indenting in bcm2835.c that triggers warnings for some people.
- Added Timeout checks to bcm2835_i2c_write() in case of IO problems. New reason code BCM2835_I2C_REASON_ERROR_TIMEOUT added.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

I updated bcm2835

**- How I did it**

Updated the recipe from 1.71 to 1.73 and performed very basic quick tests on Raspberry Pi Zero 2 64-bit.
