### PR TITLE
Cherry-pick 98349bb367418866e008ba22ca75f4ab2984561a to kirkstone

### DIFF
--- a/recipes-core/psplash/files/framebuf.conf
+++ b/recipes-core/psplash/files/framebuf.conf
@@ -1,0 +1,4 @@
+[Unit]
+Requires=sys-devices-platform-gpu-graphics-fb0.device
+After=sys-devices-platform-gpu-graphics-fb0.device
+

--- a/recipes-core/psplash/psplash_%.bbappend
+++ b/recipes-core/psplash/psplash_%.bbappend
@@ -1,2 +1,12 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SPLASH_IMAGES:rpi = "file://psplash-raspberrypi-img.h;outsuffix=raspberrypi"
+
+SRC_URI:append:rpi = " file://framebuf.conf"
+
+do_install:append:rpi() {
+    if [ "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}" ]; then
+        install -Dm 0644 ${WORKDIR}/framebuf.conf ${D}${systemd_system_unitdir}/psplash-start.service.d/framebuf.conf
+    fi
+}
+
+FILES:${PN}:append:rpi = " ${systemd_system_unitdir}/psplash-start.service.d"


### PR DESCRIPTION
Especially with systemd its seen that psplash-start service starts before /dev/fb0 is created by kernel which results in

[FAILED] Failed to start Start psplash boot splash screen.

this is quite frequent race now with kernel 6.1

Add device dependency on sys-devices-platform-gpu-graphics-fb0.device via a unit file drop-in

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Fix `psplash-start.service` for branch kirkstone to avoid errors like:
```
Jan 01 00:00:09 raspberrypi4 systemd[1]: Starting Start psplash boot splash screen...
Jan 01 00:00:09 raspberrypi4 psplash[297]: Error opening /dev/fb0
Jan 01 00:00:09 raspberrypi4 systemd[1]: psplash-start.service: Main process exited, code=exited, status=255/EXCEPTION
Jan 01 00:00:09 raspberrypi4 systemd[1]: psplash-start.service: Failed with result 'exit-code'.
Jan 01 00:00:09 raspberrypi4 systemd[1]: Failed to start Start psplash boot splash screen.
```
Tested on Raspberry Pi 4.

**- How I did it**

Cherry-picked @kraj patch 98349bb367418866e008ba22ca75f4ab2984561a to branch kirkstone. Considering this is Yocto LTS release until Apr. 2026 it makes sense to backport this particular patch.

