### PR TITLE
Define CAN interrupt pins

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -340,6 +340,13 @@ Some modules may require setting the frequency of the crystal oscillator used on
 
     CAN_OSCILLATOR="8000000"
 
+Configure the interrupt pin to the one connected to the CAN module. By default,
+the pins are set to 25 for can0 and 24 for can1. To change them to 12 and 16,
+the following variables also have to be set:
+
+    CAN0_INTERRUPT_PIN = "12"
+    CAN1_INTERRUPT_PIN = "16"
+
 Tested modules:
 
 * PiCAN2 (16 MHz crystal): <http://skpang.co.uk/catalog/pican2-canbus-board-for-raspberry-pi-23-p-1475.html>

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -30,6 +30,8 @@ GPIO_IR ?= "18"
 GPIO_IR_TX ?= "17"
 
 CAN_OSCILLATOR ?= "16000000"
+CAN0_INTERRUPT_PIN ?= "25"
+CAN1_INTERRUPT_PIN ?= "24"
 
 ENABLE_UART ??= ""
 
@@ -268,12 +270,12 @@ do_deploy() {
     # ENABLE DUAL CAN
     if [ "${ENABLE_DUAL_CAN}" = "1" ]; then
         echo "# Enable DUAL CAN" >>$CONFIG
-        echo "dtoverlay=mcp2515-can0,oscillator=${CAN_OSCILLATOR},interrupt=25" >>$CONFIG
-        echo "dtoverlay=mcp2515-can1,oscillator=${CAN_OSCILLATOR},interrupt=24" >>$CONFIG
+        echo "dtoverlay=mcp2515-can0,oscillator=${CAN_OSCILLATOR},interrupt=${CAN0_INTERRUPT_PIN}" >>$CONFIG
+        echo "dtoverlay=mcp2515-can1,oscillator=${CAN_OSCILLATOR},interrupt=${CAN1_INTERRUPT_PIN}" >>$CONFIG
     # ENABLE CAN
     elif [ "${ENABLE_CAN}" = "1" ]; then
         echo "# Enable CAN" >>$CONFIG
-        echo "dtoverlay=mcp2515-can0,oscillator=${CAN_OSCILLATOR},interrupt=25" >>$CONFIG
+        echo "dtoverlay=mcp2515-can0,oscillator=${CAN_OSCILLATOR},interrupt=${CAN0_INTERRUPT_PIN}" >>$CONFIG
     fi
 
 


### PR DESCRIPTION
Fixes #1264

**- What I did**
The users can now define CAN interrupt pins that are different from the hard-coded one.

**- How I did it**
I defined two more CAN variables that let users configure the CAN interrupt pins depending by the module that they used (or by their custom boards). It is similar to CAN_OSCILLATOR. I also added these variables to the documentation

Once this is merged I will cherry-pick this commit to Kirkstone (because I need this change)