### PR TITLE
psplash: udev rule to notify systemd of available framebuffers

### DIFF
--- a/recipes-core/udev/udev-rules-rpi.bb
+++ b/recipes-core/udev/udev-rules-rpi.bb
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SRC_URI = " \
 	git://github.com/RPi-Distro/raspberrypi-sys-mods;protocol=https;branch=master \
 	file://can.rules \
+	file://fb.rules \
 	"
 SRCREV = "5ce3ef2b7f377c23fea440ca9df0e30f3f8447cf"
 
@@ -16,4 +17,5 @@ do_install () {
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${S}/etc.armhf/udev/rules.d/99-com.rules ${D}${sysconfdir}/udev/rules.d/
     install -m 0644 ${UNPACKDIR}/can.rules ${D}${sysconfdir}/udev/rules.d/
+    install -m 0644 ${UNPACKDIR}/fb.rules ${D}${sysconfdir}/udev/rules.d/
 }

--- a/recipes-core/udev/udev-rules-rpi/fb.rules
+++ b/recipes-core/udev/udev-rules-rpi/fb.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="graphics", KERNEL=="fb[0-9]*", TAG+="systemd"


### PR DESCRIPTION
When using psplash in combination with systemd the splash screen is not shown. The dependency to sys-devices-platform-gpu-graphics-fb0.device will terminate psplash-start.service because systemd is not aware of the framebuffer device node.
See https://lists.yoctoproject.org/g/yocto/topic/91286438#57156

Adding a udev rule to notify systemd