### PR TITLE
rpi-base: Add missing hifiberry overlay

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -28,6 +28,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/hifiberry-amp.dtbo \
     overlays/hifiberry-dac.dtbo \
     overlays/hifiberry-dacplus.dtbo \
+    overlays/hifiberry-dacplusadcpro.dtbo \
     overlays/hifiberry-digi.dtbo \
     overlays/justboom-both.dtbo \
     overlays/justboom-dac.dtbo \


### PR DESCRIPTION
There is anoter hifiberry hat, for which there is currently no overlay added to the build, so let's add it:

hifiberry-dacplusadcpro.dtbo

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
