### PR TITLE
rpi-eeprom_git: v.2024.01.05-2712 Update recipe to latest rpi-eeprom

### DIFF
--- a/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
+++ b/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
@@ -8,8 +8,8 @@ SRC_URI = " \
     git://github.com/raspberrypi/rpi-eeprom.git;protocol=https;branch=master \
 "
 
-SRCREV = "f13b5789f56f65112e2b8aa58be43ebfcbedfe1d"
-PV = "v2023.10.18-2712"
+SRCREV = "759460850c2cb69e19567947a42fbed996e7bf61"
+PV = "v.2024.01.05-2712"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This follows the current latest release of rpi-eeprom: https://github.com/raspberrypi/rpi-eeprom

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
Updated pr version and tested updating eeprom
**- How I did it**
changed the version and the checksum