### PR TITLE
rpi-base: Added missing HiFiBerry

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -27,6 +27,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/hifiberry-amp.dtbo \
     overlays/hifiberry-dac.dtbo \
     overlays/hifiberry-dacplus.dtbo \
+    overlays/hifiberry-dacplusadcpro.dtbo \
     overlays/hifiberry-digi.dtbo \
     overlays/justboom-both.dtbo \
     overlays/justboom-dac.dtbo \

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -25,9 +25,15 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/gpio-poweroff.dtbo \
     overlays/gpio-shutdown.dtbo \
     overlays/hifiberry-amp.dtbo \
+    overlays/hifiberry-amp100.dtbo \
+    overlays/hifiberry-amp3.dtbo \
+    overlays/hifiberry-amp4pro.dtbo \
     overlays/hifiberry-dac.dtbo \
     overlays/hifiberry-dacplus.dtbo \
     overlays/hifiberry-dacplusadcpro.dtbo \
+    overlays/hifiberry-dacplusdsp.dtbo \
+    overlays/hifiberry-dacplushd.dtbo \
+    overlays/hifiberry-digi-pro.dtbo \
     overlays/hifiberry-digi.dtbo \
     overlays/justboom-both.dtbo \
     overlays/justboom-dac.dtbo \

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -27,7 +27,6 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/hifiberry-amp.dtbo \
     overlays/hifiberry-amp100.dtbo \
     overlays/hifiberry-amp3.dtbo \
-    overlays/hifiberry-amp4pro.dtbo \
     overlays/hifiberry-dac.dtbo \
     overlays/hifiberry-dacplus.dtbo \
     overlays/hifiberry-dacplusadcpro.dtbo \


### PR DESCRIPTION
…Pro, DAC+ DSP, DAC+ HD, Digi Pro.

**- What I did**

Added missing support for HiFiBerry AMP100, AMP3, AMP4 Pro, DAC+ ADC Pro, DAC+ DSP, DAC+ HD, Digi Pro.

**- How I did it**

Add right lines to rpi-base.inc. Changes were tested and works fine with the branch.

Connected also with issue #1168