### PR TITLE
python3-sense-hat: Drop PYTHON_PN

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/python/python3-sense-hat_2.2.0.bb
+++ b/dynamic-layers/meta-python/recipes-devtools/python/python3-sense-hat_2.2.0.bb
@@ -18,7 +18,7 @@ DEPENDS += " \
     "
 
 RDEPENDS:${PN} += " \
-    ${PYTHON_PN}-numpy \
-    ${PYTHON_PN}-rtimu \
-    ${PYTHON_PN}-pillow \
+    python3-numpy \
+    python3-rtimu \
+    python3-pillow \
     "


### PR DESCRIPTION
Starting OE core commit b566b1e32c7993d1ab7795562f648e52ce186a70, we no longer need PYTHON_PN for any abstraction of python2 vs python3.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
