### PR TITLE
sdcard_image-rpi.bbclass: include ${IMAGE_NAME_SUFFIX} directly in bo…

### DIFF
--- a/classes/sdcard_image-rpi.bbclass
+++ b/classes/sdcard_image-rpi.bbclass
@@ -60,7 +60,7 @@ do_image_rpi_sdimg[depends] = " \
 do_image_rpi_sdimg[recrdeps] = "do_build"
 
 # SD card image name
-SDIMG = "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.rpi-sdimg"
+SDIMG = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rpi-sdimg"
 
 # Additional files and/or directories to be copied into the vfat partition from the IMAGE_ROOTFS.
 FATPAYLOAD ?= ""


### PR DESCRIPTION
…th ${IMAGE_NAME} and ${IMAGE_LINK_NAME}

* Adjust to https://git.openembedded.org/openembedded-core/commit/?id=26d97acc71379ab6702fa54a23b6542a3f51779c

* ${IMAGE_NAME}${IMAGE_NAME_SUFFIX} is almost always used together already and when they aren't it's usually because of hardcoded '.rootfs' suffix

* it's a bit strange, because ${IMAGE_NAME_SUFFIX} is applied after the version from ${IMAGE_VERSION_SUFFIX}, if we move it to ${IMAGE_LINK_NAME} then it will be applied before the version and ${IMAGE_LINK_NAME} will be just the version-less symlink to latest built version.

* it's not added to INITRAMFS_IMAGE_NAME as it assumes that all images used as initramfs will set IMAGE_NAME_SUFFIX to empty. Many already do as shown bellow, but you might need to extend this list in your layer.