### PR TITLE
sdimage-raspberrypi.wks: increase /boot minimal size from 20 to 100

### DIFF
--- a/wic/sdimage-raspberrypi.wks
+++ b/wic/sdimage-raspberrypi.wks
@@ -2,5 +2,5 @@
 # long-description: Creates a partitioned SD card image for use with
 # Raspberry Pi. Boot files are located in the first vfat partition.
 
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 20
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 100
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4096


### PR DESCRIPTION
* current aarch64 kernel image alone is 24MB: 24M tmp-glibc/deploy/images/raspberrypi4-64/Image-raspberrypi4-64-1-6.1.77+git0+43d1723dbe_77fc1fbcb5-r0.1-20110405230000.bin and with rpi-bootfiles it takes around 46MB (e.g. this is from kirkstone raspberrypi4-64 build):
```
2.0K    boot.scr
2.0K    cmdline.txt
4.0K    fixup4cd.dat
4.0K    fixup_cd.dat
4.0K    uEnv.txt
6.0K    fixup4.dat
8.0K    fixup.dat
10K     fixup4db.dat
10K     fixup4x.dat
10K     fixup_db.dat
10K     fixup_x.dat
16K     uboot.env
36K     config.txt
52K     bcm2711-rpi-4-b.dtb
52K     bcm2711-rpi-400.dtb
52K     bcm2711-rpi-cm4.dtb
52K     bootcode.bin
126K    overlays
558K    kernel8.img
786K    start4cd.elf
786K    start_cd.elf
2.2M    start4.elf
2.9M    start.elf
2.9M    start4x.elf
3.6M    start4db.elf
3.6M    start_x.elf
4.6M    start_db.elf
23M     Image
```

* it is increased automatically to fit the content:
```
  tmp-glibc/deploy/images/raspberrypi4-64 $ sfdisk -l core-image-minimal-raspberrypi4-64.rootfs--1.0-r0-20110405230000.wic Disk core-image-minimal-raspberrypi4-64.rootfs--1.0-r0-20110405230000.wic: 241.2 MiB, 252915712 bytes, 493976 sectors Units: sectors of 1 * 512 = 512 bytes Sector size (logical/physical): 512 bytes / 512 bytes I/O size (minimum/optimal): 512 bytes / 512 bytes Disklabel type: dos Disk identifier: 0x076c4a2a

  Device                                                                Boot  Start    End Sectors   Size Id Type
  core-image-minimal-raspberrypi4-64.rootfs--1.0-r0-20110405230000.wic1 *      8192 157815  149624  73.1M  c W95 FAT32 (LBA)
  core-image-minimal-raspberrypi4-64.rootfs--1.0-r0-20110405230000.wic2      163840 493975  330136 161.2M 83 Linux
```
  but if you want to update the kernel in place or add some additional files later, it might not be big enough, increase the minimal size from 20M to 100M

* reminder (as I forgot about it before): "--size" is just minimum

  https://docs.yoctoproject.org/ref-manual/kickstart.html says:

>  --size: The minimum partition size. Specify as an integer value optionally followed by one of the units “k” / “K” for kibibyte, “M” for mebibyte and “G” for gibibyte. The default unit if none is given is “M”. You do not need this option if you use --source.
>  --fixed-size: The exact partition size. Specify as an integer value optionally followed by one of the units “k” / “K” for kibibyte, “M” for mebibyte and “G” for gibibyte. The default unit if none is given is “M”. Cannot be specify together with --size. An error occurs when assembling the disk image if the partition data is larger than --fixed-size.