### PR TITLE
picamera-libs: removed unused libraries from python3-picamera

### DIFF
--- a/recipes-multimedia/picamera-libs/picamera-libs.bb
+++ b/recipes-multimedia/picamera-libs/picamera-libs.bb
@@ -11,6 +11,7 @@ S = "${RPIFW_S}"
 do_install(){
     install -m 0755 -d ${D}${libdir}
     install -m 0755 ${S}/opt/vc/lib/*.so ${D}${libdir}
+    rm -f ${D}${libdir}/libGLES* ${D}${libdir}/libEGL* ${D}${libdir}/libWFC.so ${D}${libdir}/libOpenVG.so
 }
 
 FILES:${PN} = "${libdir}"


### PR DESCRIPTION
Apparently the recipe for python3 picamera is installing some libraries from /opt/vc/lib that are not necessary to the picamera module. The gles2 library, in particular, overwrites a symlink to another version of the gles2 library. The result is that two different gles2 libs are placed in /usr/lib.

This commit removes a few unneeded libraries, leaving libmmal and its dependencies, that are instead required.