### PR TITLE
scarthgap/raspberrypi5 u-boot

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,6 +11,9 @@ BBFILE_PRIORITY_raspberrypi = "9"
 
 LAYERSERIES_COMPAT_raspberrypi = "nanbield scarthgap"
 LAYERDEPENDS_raspberrypi = "core"
+# Recommended for u-boot support for raspberrypi5
+# https://git.yoctoproject.org/meta-lts-mixins 'scarthgap/u-boot' branch
+LAYERRECOMMENDS_raspberrypi = "lts-u-boot-mixin"
 
 # Additional license directories.
 LICENSE_PATH += "${LAYERDIR}/files/custom-licenses"

--- a/conf/machine/raspberrypi5.conf
+++ b/conf/machine/raspberrypi5.conf
@@ -24,3 +24,5 @@ VC4DTBO ?= "vc4-kms-v3d"
 
 # "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet
 KERNEL_IMAGETYPE_DIRECT ?= "Image"
+
+UBOOT_MACHINE = "rpi_arm64_config"

--- a/conf/machine/raspberrypi5.conf
+++ b/conf/machine/raspberrypi5.conf
@@ -22,7 +22,11 @@ SERIAL_CONSOLES ?= "115200;ttyAMA10"
 
 VC4DTBO ?= "vc4-kms-v3d"
 
+# When u-boot is enabled we need to use the "Image" format and the "booti"
+# command to load the kernel
+KERNEL_IMAGETYPE_UBOOT ?= "Image"
 # "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet
 KERNEL_IMAGETYPE_DIRECT ?= "Image"
+KERNEL_BOOTCMD ?= "booti"
 
 UBOOT_MACHINE = "rpi_arm64_config"

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -12,6 +12,3 @@ do_install:append:rpi () {
     install -d ${D}${sysconfdir}
     install -m 0644 ${WORKDIR}/fw_env.config ${D}${sysconfdir}/fw_env.config
 }
-
-# Temporary avoid Raspberry Pi 5 because U-Boot has not been ported yet
-COMPATIBLE_MACHINE:raspberrypi5 = "(-)"


### PR DESCRIPTION
**- What I did**

1. Re-enable `u-boot` for `raspberrypi5`.
2. Add the `meta-lts-mixins` `scarthgap/u-boot` layer to LAYERRECOMMENDS (so that, for instance, [layerindex](https://layers.openembedded.org) can know about the recommendation).
3. Update the `KERNEL_IMAGETYPE_UBOOT` to be in line with `raspberypi4-64` so that it is functional.

**- How I did it**
Create a `meta-lts-mixins` `scarthgap/u-boot` branch so we can have newer u-boot than what is released in openembedded-core.

Known issues: For the author at least, a debug UART cable must be attached to the `UART` port between `HDMI0` and `HDMI`. We know the `u-boot` support in `v2024.04` was flagged as **initial** so we should not expect everything to be completely functional yet (usb, ethernet).

This is the same content as the mailing list pull request: https://lore.kernel.org/yocto/cover.1712518899.git.tim.orling@konsulko.com/T/#m9b15ef9ee8601531fdbf3afce60444d25848b06f