### PR TITLE
rpi-cmdline: Fix being renamed of network interfaces

### DIFF
--- a/recipes-bsp/bootfiles/rpi-cmdline.bb
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bb
@@ -46,6 +46,9 @@ CMDLINE_ISOL_CPUS ?= "${@setup_isolcpus(d)}"
 # if the MAC addresses are omitted, random values will be used
 CMDLINE_RNDIS ?= ""
 
+# That allows to keep the traditional network interface names
+CMDLINE_IFNAMES ?= "net.ifnames=0"
+
 CMDLINE = " \
     ${CMDLINE_ISOL_CPUS} \
     ${CMDLINE_DWC_OTG} \
@@ -57,6 +60,7 @@ CMDLINE = " \
     ${CMDLINE_PITFT} \
     ${CMDLINE_DEBUG} \
     ${CMDLINE_RNDIS} \
+    ${CMDLINE_IFNAMES} \
     "
 
 do_compile() {


### PR DESCRIPTION
Added `net.ifnames=0` kernel parameter into `CMDLINE`.

If we boot the kernel this way, the network interfaces will not be renamed. Otherwise it will be renamed.

Without parameter:

root@raspberrypi3-64:~# ip addr
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute
       valid_lft forever preferred_lft forever
2: enu1u1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel qlen 1000
    link/ether b8:27:eb:d9:fd:59 brd ff:ff:ff:ff:ff:ff
3: wlxb827eb8ca80c: <BROADCAST,MULTICAST> mtu 1500 qdisc noop qlen 1000
    link/ether b8:27:eb:8c:a8:0c brd ff:ff:ff:ff:ff:ff

root@raspberrypi3-64:~# journalctl | grep wlan
Feb 27 17:26:08 raspberrypi3-64 kernel: brcmfmac mmc1:0001:1 wlxb827eb8ca80c: renamed from wlan0
Feb 27 17:26:10 raspberrypi3-64 kernel[296]: [    8.711897] brcmfmac mmc1:0001:1 wlxb827eb8ca80c: renamed from wlan0

With parameter:

root@raspberrypi3-64:~# ip addr
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute
       valid_lft forever preferred_lft forever
2: eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel qlen 1000
    link/ether b8:27:eb:d9:fd:59 brd ff:ff:ff:ff:ff:ff
3: wlan0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel qlen 1000
    link/ether b8:27:eb:8c:a8:0c brd ff:ff:ff:ff:ff:ff