### PR TITLE
layer.conf: update LAYERSERIES_COMPAT for styhead

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "raspberrypi"
 BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
-LAYERSERIES_COMPAT_raspberrypi = "nanbield scarthgap"
+LAYERSERIES_COMPAT_raspberrypi = "scarthgap styhead"
 LAYERDEPENDS_raspberrypi = "core"
 # Recommended for u-boot support for raspberrypi5
 # https://git.yoctoproject.org/meta-lts-mixins 'scarthgap/u-boot' branch


### PR DESCRIPTION
oe-core switched to styhead in: https://git.openembedded.org/openembedded-core/commit?id=cef91ebeb3f2b1d41336fff60555064430a80397

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

- What I did
Add styhead to LAYERSERIES_COMPAT and remove nanbiled.

- How I did it
Update LAYERSERIES_COMPAT_raspberrypi in conf/layer.conf