### PR TITLE
[mickledore] linux-raspberrypi_6.1.bb: Upgrade to 6.1.77

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_6.1.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_6.1.bb
@@ -1,9 +1,9 @@
-LINUX_VERSION ?= "6.1.61"
+LINUX_VERSION ?= "6.1.74"
 LINUX_RPI_BRANCH ?= "rpi-6.1.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-6.1"
 
-SRCREV_machine = "f364e0eb8f973e1aa24a3c451d18e84247a8efcd"
-SRCREV_meta = "29ec3dc6f4f59b731badcc864b212767023cc40c"
+SRCREV_machine = "1cdbd99f402b76c61632d09a49b20ce90af0cc72"
+SRCREV_meta = "7ca3655cbccce6330c6f947abf667b5e3ae5350b"
 
 KMETA = "kernel-meta"
 

--- a/recipes-kernel/linux/linux-raspberrypi_6.1.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_6.1.bb
@@ -1,9 +1,9 @@
-LINUX_VERSION ?= "6.1.74"
+LINUX_VERSION ?= "6.1.77"
 LINUX_RPI_BRANCH ?= "rpi-6.1.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-6.1"
 
-SRCREV_machine = "1cdbd99f402b76c61632d09a49b20ce90af0cc72"
-SRCREV_meta = "7ca3655cbccce6330c6f947abf667b5e3ae5350b"
+SRCREV_machine = "77fc1fbcb5c013329af9583307dd1ff3cd4752aa"
+SRCREV_meta = "43d1723dbe0ce7b341cf32feeb35ecbe6b0ce29a"
 
 KMETA = "kernel-meta"
 

--- a/recipes-kernel/linux/linux-raspberrypi_6.1.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_6.1.bb
@@ -1,9 +1,9 @@
-LINUX_VERSION ?= "6.1.54"
+LINUX_VERSION ?= "6.1.61"
 LINUX_RPI_BRANCH ?= "rpi-6.1.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-6.1"
 
-SRCREV_machine = "df4d584e66a660195422ca2b7ce1d68d1181f2a2"
-SRCREV_meta = "e7488dd3776c76fb7d94cc92ae7a2216423f8ece"
+SRCREV_machine = "f364e0eb8f973e1aa24a3c451d18e84247a8efcd"
+SRCREV_meta = "29ec3dc6f4f59b731badcc864b212767023cc40c"
 
 KMETA = "kernel-meta"
 


### PR DESCRIPTION
This is needed for "iw reg" to work correctly with updated wireless-reg which was backported to kirkstone in:
https://git.openembedded.org/openembedded-core/commit/?h=kirkstone&id=11c9c6eec5ff45cd1fd4858bc28f38693c5d0fde

The necessary changes are included in 6.1.74, but bump to 6.1.77 to keep 6.1 revision in sync for kirkstone, mickledore, nanbield, master branches.

```
work-shared/raspberrypi4-64/kernel-source $ git log --oneline f364e0eb8f973e1aa24a3c451d18e84247a8efcd..1cdbd99f402b76c61632d09a49b20ce90af0cc72 | grep cfg80211                                     
dd9465b10880 wifi: cfg80211: lock wiphy mutex for rfkill poll                                                                                                                                                                                 
15577a98ef29 wifi: cfg80211: fix CQM for non-range use                                                                                                                                                                                        
db57ef0dd4c2 wifi: cfg80211: fix certs build to not depend on file order                                                                                                                                                                      
ec350809cd98 wifi: cfg80211: Add my certificate                                                                                                                                                                                               
db46c77f3d51 Revert "wifi: cfg80211: fix CQM for non-range use"                                                                                                                                                                               
307a6525c82a wifi: cfg80211: fix CQM for non-range use                                                                                                                                                                                        
25bc87768cef wifi: cfg80211: fix kernel-doc for wiphy_delayed_work_flush()                                                                                                                                                                    
697fb94e3e8d wifi: cfg80211: add flush functions for wiphy work
```