### PR TITLE
recipes: Switch to using UNPACKDIR instead of WORKDIR

### DIFF
--- a/recipes-bsp/gpio-shutdown/gpio-shutdown.bb
+++ b/recipes-bsp/gpio-shutdown/gpio-shutdown.bb
@@ -19,8 +19,8 @@ do_install() {
             ${D}${sysconfdir}/inittab.d \
             ${D}${sysconfdir}/init.d
 
-        install -m 0755 ${WORKDIR}/gpio-shutdown-keymap.sh ${D}${sysconfdir}/init.d/
-        install -m 0755 ${WORKDIR}/bind_gpio_shutdown.tab ${D}${sysconfdir}/inittab.d/
+        install -m 0755 ${UNPACKDIR}/gpio-shutdown-keymap.sh ${D}${sysconfdir}/init.d/
+        install -m 0755 ${UNPACKDIR}/bind_gpio_shutdown.tab ${D}${sysconfdir}/inittab.d/
     elif ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
         # Systemd init does not require any configuration.
         # Note: cannot have an empty branch, hence the redundant dir install.

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -10,7 +10,7 @@ DEPENDS:append:rpi = " u-boot-default-script"
 
 do_install:append:rpi () {
     install -d ${D}${sysconfdir}
-    install -m 0644 ${WORKDIR}/fw_env.config ${D}${sysconfdir}/fw_env.config
+    install -m 0644 ${UNPACKDIR}/fw_env.config ${D}${sysconfdir}/fw_env.config
 }
 
 # Temporary avoid Raspberry Pi 5 because U-Boot has not been ported yet

--- a/recipes-core/psplash/psplash_%.bbappend
+++ b/recipes-core/psplash/psplash_%.bbappend
@@ -5,7 +5,7 @@ SRC_URI:append:rpi = " file://framebuf.conf"
 
 do_install:append:rpi() {
     if [ "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}" ]; then
-        install -Dm 0644 ${WORKDIR}/framebuf.conf ${D}${systemd_system_unitdir}/psplash-start.service.d/framebuf.conf
+        install -Dm 0644 ${UNPACKDIR}/framebuf.conf ${D}${systemd_system_unitdir}/psplash-start.service.d/framebuf.conf
     fi
 }
 

--- a/recipes-core/udev/udev-rules-rpi.bb
+++ b/recipes-core/udev/udev-rules-rpi.bb
@@ -15,5 +15,5 @@ INHIBIT_DEFAULT_DEPS = "1"
 do_install () {
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${S}/etc.armhf/udev/rules.d/99-com.rules ${D}${sysconfdir}/udev/rules.d/
-    install -m 0644 ${WORKDIR}/can.rules ${D}${sysconfdir}/udev/rules.d/
+    install -m 0644 ${UNPACKDIR}/can.rules ${D}${sysconfdir}/udev/rules.d/
 }

--- a/recipes-core/udev/udev-rules-udisks-rpi_1.0.bb
+++ b/recipes-core/udev/udev-rules-udisks-rpi_1.0.bb
@@ -7,7 +7,7 @@ INHIBIT_DEFAULT_DEPS = "1"
 
 do_install () {
 	install -d ${D}${base_libdir}/udev/rules.d
-	install -m 644 ${WORKDIR}/80-udisks-rpi.rules ${D}${base_libdir}/udev/rules.d
+	install -m 644 ${UNPACKDIR}/80-udisks-rpi.rules ${D}${base_libdir}/udev/rules.d
 }
 
 FILES:${PN} = "${base_libdir}/udev/rules.d"

--- a/recipes-graphics/vc-graphics/vc-graphics.inc
+++ b/recipes-graphics/vc-graphics/vc-graphics.inc
@@ -33,10 +33,10 @@ do_install () {
   cp -R include/* ${D}${includedir}
 
   install -d ${D}${libdir}/pkgconfig
-  install -m 0644 ${WORKDIR}/egl.pc ${D}${libdir}/pkgconfig/
+  install -m 0644 ${UNPACKDIR}/egl.pc ${D}${libdir}/pkgconfig/
 
   install -d ${D}/${sysconfdir}/init.d
-  install -m 0755 ${WORKDIR}/vchiq.sh ${D}${sysconfdir}/init.d/
+  install -m 0755 ${UNPACKDIR}/vchiq.sh ${D}${sysconfdir}/init.d/
 }
 
 # These are proprietary binaries generated elsewhere so don't check ldflags

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
@@ -8,8 +8,8 @@ do_install:append:rpi () {
     PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
     if [ "${PITFT}" = "1" ]; then
         install -d ${D}/${sysconfdir}/X11/xorg.conf.d/
-        install -m 0644 ${WORKDIR}/xorg.conf.d/98-pitft.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
-        install -m 0644 ${WORKDIR}/xorg.conf.d/99-calibration.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
+        install -m 0644 ${UNPACKDIR}/xorg.conf.d/98-pitft.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
+        install -m 0644 ${UNPACKDIR}/xorg.conf.d/99-calibration.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
     fi
 }
 


### PR DESCRIPTION
UNPACKDIR is new contruct for do_unpack things in latest master we should be using that instead of WORKDIR for referencing those files


