### PR TITLE
[styhead] rpi-u-boot-scr: use UNPACKDIR

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "raspberrypi"
 BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
-LAYERSERIES_COMPAT_raspberrypi = "nanbield scarthgap"
+LAYERSERIES_COMPAT_raspberrypi = "styhead"
 LAYERDEPENDS_raspberrypi = "core"
 # Recommended for u-boot support for raspberrypi5
 # https://git.yoctoproject.org/meta-lts-mixins 'scarthgap/u-boot' branch

--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -15,7 +15,7 @@ do_compile() {
     sed -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
         -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
         -e 's/@@BOOT_MEDIA@@/${BOOT_MEDIA}/' \
-        "${WORKDIR}/boot.cmd.in" > "${WORKDIR}/boot.cmd"
+        "${UNPACKDIR}/boot.cmd.in" > "${WORKDIR}/boot.cmd"
     mkimage -A ${UBOOT_ARCH} -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
 }
 


### PR DESCRIPTION
* see: https://lists.openembedded.org/g/openembedded-architecture/message/2007

* fixes:
  sed: can't read TOPDIR/BUILD/work/raspberrypi4_64-webos-linux/rpi-u-boot-scr/1.0/boot.cmd.in: No such file or directory
