### PR TITLE
update vlc,ffmpeg PREFERRED_PROVIDER

### DIFF
--- a/conf/machine/include/rpi-default-providers.inc
+++ b/conf/machine/include/rpi-default-providers.inc
@@ -7,10 +7,6 @@ PREFERRED_PROVIDER_virtual/libgles2 ?= "${@bb.utils.contains("MACHINE_FEATURES",
 PREFERRED_PROVIDER_virtual/libgl ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "mesa", "mesa-gl", d)}"
 PREFERRED_PROVIDER_virtual/mesa ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "mesa", "mesa-gl", d)}"
 PREFERRED_PROVIDER_virtual/libgbm ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "mesa", "mesa-gl", d)}"
-PREFERRED_PROVIDER_vlc ?= "rpidistro-vlc"
-PREFERRED_PROVIDER_ffmpeg ?= "rpidistro-ffmpeg"
-PREFERRED_PROVIDER_libav ?= "rpidistro-ffmpeg"
-PREFERRED_PROVIDER_libpostproc ?= "rpidistro-ffmpeg"
 PREFERRED_PROVIDER_jpeg ?= "jpeg"
 
 PREFERRED_PROVIDER_virtual/libomxil ?= "userland"

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -487,14 +487,15 @@ MMAL is not enabled by default. To enable it add
 
     DISABLE_VC4GRAPHICS = "1"
 
-to `local.conf`. Adding `vlc` to `IMAGE_INSTALL` will then default to building the Raspberry
-Pi's Distro implementation of VLC with HW accelerated video decode through MMAL into the system
-image. It also defaults to building VLC with Raspberry PI's Distro implementation of ffmpeg. The
-oe-core implementation of ffmpeg and the meta-openembedded/meta-multimedia implementation of VLC
-can however be selected via:
+to `local.conf`. Adding `vlc` to `IMAGE_INSTALL` will then default to building the oe-core
+implementation of ffmpeg and the meta-openembedded/meta-multimedia implementation of VLC.
+The Raspberry Pi's Distro implementation of VLC with HW accelerated video decode through
+MMAL and the Raspberry PI's Distro implementation of ffmpeg. Can however be selected via:
 
-    PREFERRED_PROVIDER_ffmpeg = "ffmpeg"
-    PREFERRED_PROVIDER_vlc = "vlc"
+    PREFERRED_PROVIDER_vlc = "rpidistro-vlc"
+    PREFERRED_PROVIDER_ffmpeg = "rpidistro-ffmpeg"
+    PREFERRED_PROVIDER_libav = "rpidistro-ffmpeg"
+    PREFERRED_PROVIDER_libpostproc = "rpidistro-ffmpeg"
 
 Usage example: Start VLC with mmal_vout plugin and without an active display server.
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Switch to defaulting to OE core ffmpeg &
meta-openembedded vlc.

**- Reason**

Upgrades to newer rpi-distro VLC version
in an OE environment have proven to be
tedious due to all the PI foundation patches.

Some patches aren't fully pushed into github
and require updates to build.

Maintaining patches have also proven to be unstable.

Default to stable builds of both so that peoples
builds aren't broken.

If rpi-distro version of ffmpeg & vlc wanted
users may switch by setting PREFFERED_PROVIDER.

**- How I did it**

@kraj @agherzan .

What do you guys think?