### PR TITLE
extra-build-config.md: added a white line

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -178,6 +178,7 @@ the following boards:
 * Raspberry Pi 3 64-bit
 * Raspberry Pi 4 32-bit
 * Raspberry Pi 4 64-bit
+
 It means that, for those boards, `RPI_USE_U_BOOT = "1"` is not compatible with
 `ENABLE_UART = "0"`.
 


### PR DESCRIPTION
There was in the rendered MarkDown no new line between the bullet list and the next line.

