### PR TITLE
rpi-u-boot-scr: WORKDIR -> UNPACKDIR transition

### DIFF
--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -21,6 +21,9 @@ do_compile() {
 
 inherit kernel-arch deploy nopackages
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_deploy() {
     install -d ${DEPLOYDIR}
     install -m 0644 boot.scr ${DEPLOYDIR}


### PR DESCRIPTION
This adapts to the oe-core rework to enforce a separate directory for unpacking local sources (UNPACKDIR) instead of directly using WORKDIR.

Follows the preliminary guideline from:
https://lists.openembedded.org/g/openembedded-architecture/message/2007

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Fixed issues with the S variable in newer Yocto and OpenEmbedded versions.

**- How I did it**

By following the guideline:
https://lists.openembedded.org/g/openembedded-architecture/message/2007
