### PR TITLE
README.md: pi3-disable-bt is renamed to disable-bt in kas example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ a section as follows:
 local_conf_header:
   rpi-specific: |
     ENABLE_I2C = "1"
-    RPI_EXTRA_CONFIG = "dtoverlay=pi3-disable-bt"
+    RPI_EXTRA_CONFIG = "dtoverlay=disable-bt"
 ```
 
 To configure the machine, you have to update the `machine` variable.


### PR DESCRIPTION
in commit 01b162388e38eb7f7bdd77e80e20454672f993f9 with commit message:

  rpi-base: Drop old dtbo names

  pi3-disable-bt is renamed to disable-bt and pi3-miniuart-bt is renamed
  to miniuart-bt in 2014, now with 5.4 these are not recognised anymore
  and miniuart-bt and disable-bt are already part of RPI_KERNEL_DEVICETREE_OVERLAYS