### PR TITLE
rpi-base.inc: added the disable-bt-pi5 device tree overlay

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -18,6 +18,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/overlay_map.dtb \
     overlays/at86rf233.dtbo \
     overlays/disable-bt.dtbo \
+    overlays/disable-bt-pi5.dtbo \
     overlays/disable-wifi.dtbo \
     overlays/dwc2.dtbo \
     overlays/gpio-ir.dtbo \


### PR DESCRIPTION
The overlay to disable Bluetooth is different for Raspberry Pi 5.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

To disable the Bluetooth on a Raspberry Pi 5 a new device tree overlay is added to the /boot/overlays directory.

fixes #1346 