### PR TITLE
rpi-base: build uart dts overlays by default

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -59,6 +59,17 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/pps-gpio.dtbo \
     overlays/rpi-ft5406.dtbo \
     overlays/rpi-poe.dtbo \
+    overlays/uart0.dtbo \
+    overlays/uart0-pi5.dtbo \
+    overlays/uart1.dtbo \
+    overlays/uart1-pi5.dtbo \
+    overlays/uart2.dtbo \
+    overlays/uart2-pi5.dtbo \
+    overlays/uart3.dtbo \
+    overlays/uart3-pi5.dtbo \
+    overlays/uart4.dtbo \
+    overlays/uart4-pi5.dtbo \
+    overlays/uart5.dtbo \
     overlays/vc4-fkms-v3d.dtbo \
     overlays/vc4-fkms-v3d-pi4.dtbo \
     overlays/vc4-kms-v3d.dtbo \


### PR DESCRIPTION
**- What I did**

I think as we add by default the overlays `disable-bt `and `miniuart-bt ` to `RPI_KERNEL_DEVICETREE_OVERLAYS` we also need to add the overlays to enable the uart peripherals.
Indeed if we want to use the uart0 peripheral on a Raspberry PI4 with the PL011 with need to enable the following overlays:
```
dtoverlay=disable-bt
dtoverlay=uart0
```

**- How I did it**

Add all the uart dts overlays to `RPI_KERNEL_DEVICETREE_OVERLAYS`
