### PR TITLE
rpi-base.inc: add the disable-wifi-pi5 overlay

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -20,6 +20,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/disable-bt.dtbo \
     overlays/disable-bt-pi5.dtbo \
     overlays/disable-wifi.dtbo \
+    overlays/disable-wifi-pi5.dtbo \
     overlays/dwc2.dtbo \
     overlays/gpio-ir.dtbo \
     overlays/gpio-ir-tx.dtbo \


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

For Raspberry PI 5 we need a different device tree overlay to disable WiFi, so we need to explicitly enable it & install to `/boot/overlays`.

**- How I did it**
Added an appropriate dtbo to `RPI_KERNEL_DEVICETREE_OVERLAYS`.