### PR TITLE
linux-firmware-rpidistro: Upgrade to bookworm/20230625-2+rpt3

### DIFF
--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -18,8 +18,8 @@ LICENSE_FLAGS = "synaptics-killswitch"
 SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree;branch=bookworm;protocol=https \
     file://0001-Default-43455-firmware-to-standard-variant.patch \
 "
-SRCREV = "223ccf3a3ddb11b3ea829749fbbba4d65b380897"
-PV = "20230625-2+rpt2"
+SRCREV = "4b356e134e8333d073bd3802d767a825adec3807"
+PV = "20230625-2+rpt3"
 S = "${WORKDIR}/git"
 
 inherit allarch


### PR DESCRIPTION
The upgrade was necessary to get WLAN running on a CM4 (under scarthgap). Otherwise I continuously got the following kernel messages when trying to connect:
[   31.907395] brcmfmac: brcmf_set_channel: set chanspec 0xd022 fail, reason -52
[   32.023434] brcmfmac: brcmf_set_channel: set chanspec 0xd026 fail, reason -52
[   32.135403] brcmfmac: brcmf_set_channel: set chanspec 0xd02a fail, reason -52
[   32.247392] brcmfmac: brcmf_set_channel: set chanspec 0xd02e fail, reason -52
[   33.919395] brcmfmac: brcmf_set_channel: set chanspec 0xd090 fail, reason -52
[   33.926940] brcmfmac: brcmf_set_channel: set chanspec 0xd095 fail, reason -52
[   33.935151] brcmfmac: brcmf_set_channel: set chanspec 0xd099 fail, reason -52
[   33.942691] brcmfmac: brcmf_set_channel: set chanspec 0xd09d fail, reason -52
[   33.950338] brcmfmac: brcmf_set_channel: set chanspec 0xd0a1 fail, reason -52
[   33.957903] brcmfmac: brcmf_set_channel: set chanspec 0xd0a5 fail, reason -52

Firmware version before:  BCM4345/6 wl0: Apr 15 2021 03:03:20 version 7.45.234 (4ca95bb CY) FWID 01-996384e2
Firmware version current: BCM4345/6 wl0: Aug 29 2023 01:47:08 version 7.45.265 (28bca26 CY) FWID 01-b677b91b
