### PR TITLE
conf/layer.conf: Remove meta-lts-mixins

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,9 +11,6 @@ BBFILE_PRIORITY_raspberrypi = "9"
 
 LAYERSERIES_COMPAT_raspberrypi = "styhead"
 LAYERDEPENDS_raspberrypi = "core"
-# Recommended for u-boot support for raspberrypi5
-# https://git.yoctoproject.org/meta-lts-mixins 'scarthgap/u-boot' branch
-LAYERRECOMMENDS_raspberrypi = "lts-u-boot-mixin"
 
 # Additional license directories.
 LICENSE_PATH += "${LAYERDIR}/files/custom-licenses"


### PR DESCRIPTION
Remove layer dependency from meta-lts-mixins 'scarthgap/u-boot' because now the BSP supports styhead which brings U-Boot 2024.07.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Removed layer dependency from meta-lts-mixins 'scarthgap/u-boot'. Historically, this dependency was added temporary to provide U-Boot 2024.04 instead of 2024.01 because of Raspberry Pi 5.

**- How I did it**

Modified `conf/layer.conf`
