### PR TITLE
conf/layer.conf: Remove duplicated BBFILES

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,11 +23,6 @@ LICENSE_PATH += "${LAYERDIR}/files/custom-licenses"
 #
 # The .bbappend and .bb files are included if the respective layer
 # collection is available.
-BBFILES += "${@' '.join('${LAYERDIR}/dynamic-layers/%s/recipes*/*/*.bbappend' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-BBFILES += "${@' '.join('${LAYERDIR}/dynamic-layers/%s/recipes*/*/*.bb' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-
 BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
@@ -37,6 +32,8 @@ BBFILES_DYNAMIC += " \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bbappend \
     multimedia-layer:${LAYERDIR}/dynamic-layers/multimedia-layer/*/*/*.bb \
     multimedia-layer:${LAYERDIR}/dynamic-layers/multimedia-layer/*/*/*.bbappend \
+    meta-python:${LAYERDIR}/dynamic-layers/meta-python/*/*/*.bb \
+    meta-python:${LAYERDIR}/dynamic-layers/meta-python/*/*/*.bbappend \
 "
 
 DEFAULT_TEST_SUITES:remove:rpi = "parselogs"


### PR DESCRIPTION
The following line doubles BBFILES for all layers in BBFILE_COLLECTIONS: BBFILES += "${@' '.join('${LAYERDIR}/dynamic-layers/%s/recipes*/*/*.bb' % layer \
               for layer in BBFILE_COLLECTIONS.split())}"

And most of them are invalid, use BBFILES_DYNAMIC is the correct solution.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
