### PR TITLE
mesa: update to 24.3.1, wayland-protocol updated to 1.38

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,6 +1,28 @@
-# DRI3 note:
-# With oe-core commit 8509e2e1a87578882b71948ccef3b50ccf1228b3 dri3 is set
-# as default. To state out clearly that Raspi needs dri3 and to avoid surprises
-# in case oe-core changes this default, we set dri3 explicitly.
-PACKAGECONFIG:append:rpi = " gallium vc4 v3d kmsro ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11 dri3', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan broadcom', '', d)}"
+PACKAGECONFIG:append:rpi = " gallium gallium-llvm vc4 v3d ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan broadcom', '', d)}"
 DRIDRIVERS:class-target:rpi = ""
+
+# Remove unused patches
+SRC_URI = "https://mesa.freedesktop.org/archive/mesa-${PV}.tar.xz \
+           file://0001-meson-misdetects-64bit-atomics-on-mips-clang.patch \
+"
+
+SRC_URI[sha256sum] = "9c795900449ce5bc7c526ba0ab3532a22c3c951cab7e0dd9de5fcac41b0843af"
+PV = "24.3.1"
+
+# -Dglvnd is deprecated from true/false to enabled/disabled 
+PACKAGECONFIG[glvnd] = "-Dglvnd=enabled, -Dglvnd=disabled, libglvnd"
+
+# DRI3 note:
+# DRI3 Build option is removed from meson.
+PACKAGECONFIG:remove = "dri3"
+unset PACKAGECONFIG[dri3]
+
+DEPENDS += " wayland-protocols llvm python3-pyyaml python3-pyyaml-native"
+
+RDEPENDS:libgl-mesa += " llvm wayland-protocols"
+
+FILES:libgbm += " ${libdir}/gbm/dri_gbm*.so"
+
+FILES:libgl-mesa += " ${libdir}/libgallium*.so"
+
+FILES:libgbm-dev += " ${includedir}/gbm.h"

--- a/recipes-graphics/wayland/wayland-protocols_1.38.bb
+++ b/recipes-graphics/wayland/wayland-protocols_1.38.bb
@@ -1,0 +1,30 @@
+SUMMARY = "Collection of additional Wayland protocols"
+DESCRIPTION = "Wayland protocols that add functionality not \
+available in the Wayland core protocol. Such protocols either add \
+completely new functionality, or extend the functionality of some other \
+protocol either in Wayland core, or some other protocol in \
+wayland-protocols."
+HOMEPAGE = "http://wayland.freedesktop.org"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c7b12b6702da38ca028ace54aae3d484 \
+                    file://stable/presentation-time/presentation-time.xml;endline=26;md5=4646cd7d9edc9fa55db941f2d3a7dc53"
+
+SRC_URI = "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/${PV}/downloads/wayland-protocols-${PV}.tar.xz"
+SRC_URI[sha256sum] = "ff17292c05159d2b20ce6cacfe42d7e31a28198fa1429a769b03af7c38581dbe"
+
+UPSTREAM_CHECK_URI = "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/tags"
+UPSTREAM_CHECK_REGEX = "releases/(?P<pver>.+)"
+
+inherit meson pkgconfig allarch
+
+DEPENDS += " wayland-native"
+
+EXTRA_OEMESON += "-Dtests=false"
+
+PACKAGES = "${PN}"
+FILES:${PN} += "  \
+    ${datadir}/pkgconfig/wayland-protocols.pc  \
+    ${includedir}  \
+"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Based on PR #1390

Update to latest mesa 24.3.1 release
Fixes DRAM DSI linking to missing library drm-rp1-dsi_dri.so

fixes https://github.com/agherzan/meta-raspberrypi/issues/1389

Added new dependencies required by msea version update.
Removed DRI3 option as it's now removed from meson build options.
Updated Wayland Protocol to 1.38 as it's minimum required version for mesa 24.3.1
This PR will be completed when 24.3.1 is final official release. For now, I'm leaving it as work of progress to help whoever have issues with RPI5 DSI.
