### PR TITLE
Fix boottime kernel panic on RPi CM5

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -80,6 +80,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/w1-gpio.dtbo \
     overlays/w1-gpio-pullup.dtbo \
     overlays/wm8960-soundcard.dtbo \
+    overlays/bcm2712d0.dtbo \
     "
 
 RPI_KERNEL_DEVICETREE ?= " \

--- a/conf/machine/raspberrypi-armv8.conf
+++ b/conf/machine/raspberrypi-armv8.conf
@@ -33,6 +33,10 @@ RPI_KERNEL_DEVICETREE = " \
     broadcom/bcm2711-rpi-cm4.dtb \
     broadcom/bcm2711-rpi-cm4s.dtb \
     broadcom/bcm2712-rpi-5-b.dtb \
+    broadcom/bcm2712-rpi-cm5-cm5io.dtb \
+    broadcom/bcm2712-rpi-cm5-cm4io.dtb \
+    broadcom/bcm2712-rpi-cm5l-cm5io.dtb \
+    broadcom/bcm2712-rpi-cm5l-cm4io.dtb \
 "
 
 SDIMG_KERNELIMAGE ?= "kernel8.img"

--- a/conf/machine/raspberrypi5.conf
+++ b/conf/machine/raspberrypi5.conf
@@ -15,6 +15,10 @@ MACHINE_EXTRA_RRECOMMENDS += "\
 
 RPI_KERNEL_DEVICETREE = " \
     broadcom/bcm2712-rpi-5-b.dtb \
+    broadcom/bcm2712-rpi-cm5-cm5io.dtb \
+    broadcom/bcm2712-rpi-cm5-cm4io.dtb \
+    broadcom/bcm2712-rpi-cm5l-cm5io.dtb \
+    broadcom/bcm2712-rpi-cm5l-cm4io.dtb \
 "
 
 SDIMG_KERNELIMAGE ?= "kernel_2712.img"


### PR DESCRIPTION
Fixes #1394 

This adds the required devicetree and overlays to the raspberrypi5.conf file to allow booting the RPi CM5 without a kernel panic.

Thanks @gokamura for finding the fix.

U-Boot still doesn't work in my testing, waiting to get the uart headers to see if there is some output there.
