### PR TITLE
Some Kas stuff

### DIFF
--- a/kas-poky-rpi.yml
+++ b/kas-poky-rpi.yml
@@ -48,7 +48,7 @@ local_conf_header:
     USER_CLASSES = "buildstats"
     PATCHRESOLVE = "noop"
   debug-tweaks: |
-    EXTRA_IMAGE_FEATURES = "debug-tweaks"
+    IMAGE_FEATURES += "empty-root-password allow-empty-password allow-root-login post-install-logging"
   diskmon: |
     BB_DISKMON_DIRS = "\
         STOPTASKS,${TMPDIR},1G,100K \

--- a/kas-poky-rpi.yml
+++ b/kas-poky-rpi.yml
@@ -59,3 +59,7 @@ local_conf_header:
         HALT,${DL_DIR},100M,1K \
         HALT,${SSTATE_DIR},100M,1K \
         HALT,/tmp,10M,1K"
+  license: |
+    # Uncomment next line to allow the license
+    # See: linux-firmware-rpidistro in docs/ipcompliance.md
+    #LICENSE_FLAGS_ACCEPTED = "synaptics-killswitch"


### PR DESCRIPTION
* Added, but in comment, the synaptics-killswitch license.  Because it's easier to have in in the KAS file.

* The 'debug-tweaks' image_feature is removed in Yocto.
  I replaced it with was under it.  But this is (and was) insecure.
  **But I would be in favor of having this replaced by a more secure settings**.
  It could be in comment as a warning to the user.

br