### PR TITLE
linux-firmware-rpidistro: Add cyfmac43455-sdio.bin symlink to minimal

### DIFF
--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -43,6 +43,7 @@ do_install() {
     done
 
     cp -R --no-dereference --preserve=mode,links -v debian/config/brcm80211/cypress/* ${D}${nonarch_base_libdir}/firmware/cypress/
+    ln -s cyfmac43455-sdio-minimal.bin ${D}${nonarch_base_libdir}/firmware/cypress/cyfmac43455-sdio.bin
 
     rm ${D}${nonarch_base_libdir}/firmware/cypress/README.txt
 }


### PR DESCRIPTION
According to the README on rpi-distro firmware-nonfree [1] this symlink needs to exists.

Fixes,

```
[    6.794584] brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.bin failed with error -2
```

There are previous reported stability issues with 802.11r [2] and choosing minimal removes this support and indirectly fixes the issues.

[1] https://github.com/RPi-Distro/firmware-nonfree/blob/bookworm/debian/config/brcm80211/cypress/README.txt
[2] https://github.com/raspberrypi/linux/issues/3849

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
