### PR TITLE
linux-firmware-rpidistro: Fix wireless error message on RPi

### DIFF
--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro/0002-Default-all-RPi-43455-boards-to-standard-variant.patch
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro/0002-Default-all-RPi-43455-boards-to-standard-variant.patch
@@ -1,0 +1,79 @@
+From 20741d848c32e0fb2e4841cf8bbc9ec3d198bb6b Mon Sep 17 00:00:00 2001
+From: Omri Sarig <omri.sarig@prevas.dk>
+Date: Thu, 9 Jan 2025 19:00:10 +0100
+Subject: [PATCH 2/2] Default all RPi 43455 boards to standard variant
+
+As the patch above explains, the symlink that is being used by the
+brcmfmac43455-sdio.* files is one that is created by the Debian system,
+which we do not have in our implementation. Therefore, when the system
+tries to load these files, an error message is generated.
+
+By changing the symlinks to be to the standard variant, the problem is
+solved for the build.
+
+The code is also working without this patch - when the driver is unable
+to load the board-specific file (such as
+brcmfmac43455-sdio.raspberrypi,3-model-a-plus.bin), it reverts to using
+the base file (brcmfmac43455-sdio.bin), which is a correct link (as it
+is fixed in the patch above). However, the driver is still generating an
+error message in this case, which is being solved by linking the
+board-specific files to the standard variant as well.
+
+Upstream-Status: Inappropriate [issue reported at https://github.com/RPi-Distro/firmware-nonfree/issues/26]
+Signed-off-by: Omri Sarig <omri.sarig@prevas.dk>
+---
+ .../brcm/brcmfmac43455-sdio.raspberrypi,3-model-a-plus.bin      | 2 +-
+ .../brcm/brcmfmac43455-sdio.raspberrypi,3-model-b-plus.bin      | 2 +-
+ .../brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.bin    | 2 +-
+ .../brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.bin | 2 +-
+ .../brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.bin | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,3-model-a-plus.bin b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,3-model-a-plus.bin
+index 9c39208..b914838 120000
+--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,3-model-a-plus.bin
++++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,3-model-a-plus.bin
+@@ -1 +1 @@
+-../cypress/cyfmac43455-sdio.bin
+\ No newline at end of file
++../cypress/cyfmac43455-sdio-standard.bin
+\ No newline at end of file
+diff --git a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,3-model-b-plus.bin b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,3-model-b-plus.bin
+index 9c39208..b914838 120000
+--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,3-model-b-plus.bin
++++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,3-model-b-plus.bin
+@@ -1 +1 @@
+-../cypress/cyfmac43455-sdio.bin
+\ No newline at end of file
++../cypress/cyfmac43455-sdio-standard.bin
+\ No newline at end of file
+diff --git a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.bin b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.bin
+index 9c39208..b914838 120000
+--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.bin
++++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.bin
+@@ -1 +1 @@
+-../cypress/cyfmac43455-sdio.bin
+\ No newline at end of file
++../cypress/cyfmac43455-sdio-standard.bin
+\ No newline at end of file
+diff --git a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.bin b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.bin
+index 9c39208..b914838 120000
+--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.bin
++++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.bin
+@@ -1 +1 @@
+-../cypress/cyfmac43455-sdio.bin
+\ No newline at end of file
++../cypress/cyfmac43455-sdio-standard.bin
+\ No newline at end of file
+diff --git a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.bin b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.bin
+index 9c39208..b914838 120000
+--- a/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.bin
++++ b/debian/config/brcm80211/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.bin
+@@ -1 +1 @@
+-../cypress/cyfmac43455-sdio.bin
+\ No newline at end of file
++../cypress/cyfmac43455-sdio-standard.bin
+\ No newline at end of file
+-- 
+2.34.1
+

--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -17,6 +17,7 @@ LICENSE_FLAGS = "synaptics-killswitch"
 
 SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree;branch=bookworm;protocol=https \
     file://0001-Default-43455-firmware-to-standard-variant.patch \
+    file://0002-Default-all-RPi-43455-boards-to-standard-variant.patch \
 "
 SRCREV = "4b356e134e8333d073bd3802d767a825adec3807"
 PV = "20230625-2+rpt3"


### PR DESCRIPTION
**- What I did**

Fix an error message generated when creating an image with brcmfmac enabled.

As #1396 describes, the brcmfmac driver generates an error message during boot, which can be seen by inspecting the log of the device.
This error happens because several files in linux-firmware-rpidistro links to non-existing files.
By updating the link of these files to the valid files in the target, this error message is fixed.

**- How I did it**

Create a patch file for the linux-firmware-rpidistro recipe, that changes the links of different rpi board firmware files from linking to non-existing files, to link to the file which exists in the system.

A similar change was already implemented for the base file - this PR do the same fix for all the rest of the RPi files, so no error message will be generated.

---

Fixes: #1396
