### PR TITLE
raspberrypi5: add bcm2712d0 overlay required for booting up correctly

### DIFF
--- a/conf/machine/raspberrypi5.conf
+++ b/conf/machine/raspberrypi5.conf
@@ -17,6 +17,8 @@ RPI_KERNEL_DEVICETREE = " \
     broadcom/bcm2712-rpi-5-b.dtb \
 "
 
+RPI_KERNEL_DEVICETREE_OVERLAYS:append = " overlays/bcm2712d0.dtbo"
+
 SDIMG_KERNELIMAGE ?= "kernel_2712.img"
 SERIAL_CONSOLES ?= "115200;ttyAMA10"
 


### PR DESCRIPTION
fix raspberrypi5 boot up

solve https://github.com/agherzan/meta-raspberrypi/issues/1410