### PR TITLE
docs: Fix ReadTheDocs sphinx.configuration requirement

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,7 @@
 version: 2
 
+sphinx:
+  configuration: docs/conf.py
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION
Deprecation of projects using Sphinx or MkDocs without an explicit configuration file:

https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
