### PR TITLE
libcamera: fix c++ flags and failed buildpaths QA check

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera/libcamera_%.bbappend
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera/libcamera_%.bbappend
@@ -1,2 +1,3 @@
-PACKAGECONFIG[raspberrypi] = "-Dpipelines=rpi/vc4 -Dipas=rpi/vc4 -Dcpp_args=-Wno-unaligned-access"
+PACKAGECONFIG[raspberrypi] = "-Dpipelines=rpi/vc4 -Dipas=rpi/vc4"
 PACKAGECONFIG:append:rpi = " raspberrypi"
+CXXFLAGS:append:rpi = " -Wno-unaligned-access "


### PR DESCRIPTION
Building libcamera from the latest meta-oe fails with QA check error:

```
ERROR: libcamera-1_0.4.0-r0 do_package_qa: QA Issue: File /usr/lib/libcamera.so.0.4.0 in package libcamera contains reference to TMPDIR [buildpaths]
ERROR: libcamera-1_0.4.0-r0 do_package_qa: QA Issue: File /usr/lib/libcamera-base.so.0.4.0 in package libcamera contains reference to TMPDIR [buildpaths]
ERROR: libcamera-1_0.4.0-r0 do_package_qa: QA Issue: File /usr/lib/libcamera/ipa_rpi_vc4.so in package libcamera contains reference to TMPDIR [buildpaths]
ERROR: libcamera-1_0.4.0-r0 do_package_qa: QA Issue: File /usr/libexec/libcamera/raspberrypi_ipa_proxy in package libcamera contains reference to TMPDIR [buildpaths]
ERROR: libcamera-1_0.4.0-r0 do_package_qa: QA Issue: File /usr/libexec/libcamera/v4l2-compat.so in package libcamera contains reference to TMPDIR [buildpaths]
ERROR: libcamera-1_0.4.0-r0 do_package_qa: QA Issue: File /usr/bin/cam in package libcamera contains reference to TMPDIR [buildpaths]
ERROR: libcamera-1_0.4.0-r0 do_package_qa: Fatal QA errors were found, failing task.
```

Looking into the logs, it seems the `cpp_args` option (used in the PACKAGECONFIG) were overriding most of the CXXFLAGS from Yocto, including the removal of the `-f*-prefix-map` options, which left the buildpath in the binaries. To fix this, add the `-Wno-unaligned-access` flag to `CXXFLAGS` instead of using meson's cpp_args option.

Same g++ invocation before (upper) and after (lower) the change:
```
aarch64-poky-linux-g++ -mcpu=cortex-a53+crc -mbranch-protection=standard -fstack-protector-strong -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/recipe-sysroot -Isrc/libcamera/base/libcamera-base.so.0.4.0.p -Isrc/libcamera/base -I../git/src/libcamera/base -Iinclude -I../git/include -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c++17 -Wno-redundant-move -Wmissing-declarations -Wshadow -include /yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/build/config.h -Wno-unaligned-access -fPIC -pthread -DLIBCAMERA_BASE_PRIVATE -MD -MQ src/libcamera/base/libcamera-base.so.0.4.0.p/object.cpp.o -MF src/libcamera/base/libcamera-base.so.0.4.0.p/object.cpp.o.d -o src/libcamera/base/libcamera-base.so.0.4.0.p/object.cpp.o -c ../git/src/libcamera/base/object.cpp
aarch64-poky-linux-g++ -mcpu=cortex-a53+crc -mbranch-protection=standard -fstack-protector-strong -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/recipe-sysroot -Isrc/libcamera/base/libcamera-base.so.0.4.0.p -Isrc/libcamera/base -I../git/src/libcamera/base -Iinclude -I../git/include -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c++17 -Wno-redundant-move -Wmissing-declarations -Wshadow -include /yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/build/config.h -O2 -g -fcanon-prefix-map -fmacro-prefix-map=/yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/git=/usr/src/debug/libcamera/0.4.0 -fdebug-prefix-map=/yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/git=/usr/src/debug/libcamera/0.4.0 -fmacro-prefix-map=/yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/build=/usr/src/debug/libcamera/0.4.0 -fdebug-prefix-map=/yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/build=/usr/src/debug/libcamera/0.4.0 -fdebug-prefix-map=/yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/recipe-sysroot= -fmacro-prefix-map=/yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/recipe-sysroot= -fdebug-prefix-map=/yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/recipe-sysroot-native= -fmacro-prefix-map=/yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libcamera/0.4.0/recipe-sysroot-native= -pipe -fvisibility-inlines-hidden -Wno-unaligned-access -fPIC -pthread -DLIBCAMERA_BASE_PRIVATE -MD -MQ src/libcamera/base/libcamera-base.so.0.4.0.p/object.cpp.o -MF src/libcamera/base/libcamera-base.so.0.4.0.p/object.cpp.o.d -o src/libcamera/base/libcamera-base.so.0.4.0.p/object.cpp.o -c ../git/src/libcamera/base/object.cpp
```