### PR TITLE
rpi-base: Add missing broadcom/ prefix to find DTB files

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -69,21 +69,22 @@ RPI_KERNEL_DEVICETREE_OVERLAYS:append:raspberrypi5 = " \
 "
 
 RPI_KERNEL_DEVICETREE ?= " \
-    bcm2708-rpi-zero.dtb \
-    bcm2708-rpi-zero-w.dtb \
-    bcm2708-rpi-b.dtb \
-    bcm2708-rpi-b-rev1.dtb \
-    bcm2708-rpi-b-plus.dtb \
-    bcm2709-rpi-2-b.dtb \
-    bcm2710-rpi-2-b.dtb \
-    bcm2710-rpi-3-b.dtb \
-    bcm2710-rpi-3-b-plus.dtb \
-    bcm2711-rpi-4-b.dtb \
-    bcm2711-rpi-400.dtb \
-    bcm2708-rpi-cm.dtb \
-    bcm2710-rpi-cm3.dtb \
-    bcm2711-rpi-cm4.dtb \
-    bcm2711-rpi-cm4s.dtb \
+    broadcom/bcm2708-rpi-zero.dtb \
+    broadcom/bcm2708-rpi-zero-w.dtb \
+    broadcom/bcm2708-rpi-b.dtb \
+    broadcom/bcm2708-rpi-b-rev1.dtb \
+    broadcom/bcm2708-rpi-b-plus.dtb \
+    broadcom/bcm2709-rpi-2-b.dtb \
+    broadcom/bcm2710-rpi-2-b.dtb \
+    broadcom/bcm2710-rpi-3-b.dtb \
+    broadcom/bcm2710-rpi-3-b-plus.dtb \
+    broadcom/bcm2710-rpi-zero-2.dtb \
+    broadcom/bcm2711-rpi-4-b.dtb \
+    broadcom/bcm2711-rpi-400.dtb \
+    broadcom/bcm2708-rpi-cm.dtb \
+    broadcom/bcm2710-rpi-cm3.dtb \
+    broadcom/bcm2711-rpi-cm4.dtb \
+    broadcom/bcm2711-rpi-cm4s.dtb \
     "
 
 KERNEL_DEVICETREE ??= " \


### PR DESCRIPTION
This is a backport of 6a7aac79ce1dc5331ec820796592797e3a66c41d from the master branch. 
It allows for building device-trees in kernel 6.6, using kirkstone.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information
Backported
If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->
