### PR TITLE
linux-firmware-rpidistro: Fix WiFi on Raspberry Pi 5

### DIFF
--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -27,6 +27,11 @@ inherit allarch
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
+# The minimal firmware doesn't work with Raspberry Pi 5, so default to the
+# standard firmware
+CYFMAC43455_SDIO_FIRMWARE ??= "minimal"
+CYFMAC43455_SDIO_FIRMWARE:raspberrypi5 ??= "standard"
+
 do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/brcm ${D}${nonarch_base_libdir}/firmware/cypress
 
@@ -43,7 +48,7 @@ do_install() {
     done
 
     cp -R --no-dereference --preserve=mode,links -v debian/config/brcm80211/cypress/* ${D}${nonarch_base_libdir}/firmware/cypress/
-    ln -s cyfmac43455-sdio-minimal.bin ${D}${nonarch_base_libdir}/firmware/cypress/cyfmac43455-sdio.bin
+    ln -s cyfmac43455-sdio-${CYFMAC43455_SDIO_FIRMWARE}.bin ${D}${nonarch_base_libdir}/firmware/cypress/cyfmac43455-sdio.bin
 
     rm ${D}${nonarch_base_libdir}/firmware/cypress/README.txt
 }


### PR DESCRIPTION
Switches the Raspberry Pi 5 to use the standard cyfman43455-sdio firmware by default. The minimal firmware on this device is unable to connect to a WiFi access point.

This also matches the behavior of Raspberry Pi OS, which defaults to the standard firmware

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
