### PR TITLE
udev-rules-rpi: Delete fb.rules

### DIFF
--- a/recipes-core/udev/udev-rules-rpi.bb
+++ b/recipes-core/udev/udev-rules-rpi.bb
@@ -5,7 +5,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SRC_URI = " \
 	git://github.com/RPi-Distro/raspberrypi-sys-mods;protocol=https;branch=master \
 	file://can.rules \
-	file://fb.rules \
 	"
 SRCREV = "5ce3ef2b7f377c23fea440ca9df0e30f3f8447cf"
 
@@ -17,5 +16,4 @@ do_install () {
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${S}/etc.armhf/udev/rules.d/99-com.rules ${D}${sysconfdir}/udev/rules.d/
     install -m 0644 ${UNPACKDIR}/can.rules ${D}${sysconfdir}/udev/rules.d/
-    install -m 0644 ${UNPACKDIR}/fb.rules ${D}${sysconfdir}/udev/rules.d/
 }

--- a/recipes-core/udev/udev-rules-rpi/fb.rules
+++ b/recipes-core/udev/udev-rules-rpi/fb.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="graphics", KERNEL=="fb[0-9]*", TAG+="systemd"


### PR DESCRIPTION
OE-core has added fb.rules to psplash via [1] so avoid adding it here

This effectively reverts commit e9e5efa750490cd0dac853eb65640d0cb337b03e

[1] https://git.yoctoproject.org/poky/commit/?id=af38235305fc2ac59a82f0413a1fe4cc5161ff86


Cc: Bastian Wanner <bastian.wanner@inovex.de>

