### PR TITLE
Ab rootfs layout boot script

### DIFF
--- a/recipes-bsp/rpi-u-boot-scr/files/ab.boot.cmd.in
+++ b/recipes-bsp/rpi-u-boot-scr/files/ab.boot.cmd.in
@@ -1,0 +1,50 @@
+# Set the address of the Flattened Device Tree (FDT) and retreive the boot arguments
+fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
+
+echo "Using A/B rootfs layout setup"
+test -n "${BOOT_ORDER}"   || setenv BOOT_ORDER "A B"
+test -n "${BOOT_A_LEFT}"  || setenv BOOT_A_LEFT 3
+test -n "${BOOT_B_LEFT}"  || setenv BOOT_B_LEFT 3
+test -n "${BOOT_PART_NUM}" || setenv BOOT_PART_NUM "0:1"
+
+setenv bootpart
+
+for BOOT_SLOT in "${BOOT_ORDER}"; do
+  if test "x${bootpart}" != "x"; then
+    # skip remaining slots
+  elif test "x${BOOT_SLOT}" = "xA"; then
+    if itest ${BOOT_A_LEFT} -gt 0; then
+      setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
+      echo "Found valid slot A"
+      setenv bootpart "/dev/mmcblk0p2"
+      setenv BOOT_PART_NUM "0:2"
+    fi
+  elif test "x${BOOT_SLOT}" = "xB"; then
+    if itest ${BOOT_B_LEFT} -gt 0; then
+      setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
+      echo "Found valid slot B"
+      setenv bootpart "/dev/mmcblk0p3"
+      setenv BOOT_PART_NUM "0:3"
+    fi
+  fi
+done
+
+if test -n "${bootpart}"; then
+  setenv bootargs "${bootargs} root=${bootpart}"
+  saveenv
+else
+  echo "No valid slot found. Resetting tries to 3"
+  setenv BOOT_A_LEFT 3
+  setenv BOOT_B_LEFT 3
+  saveenv
+  reset
+fi        
+
+# Load the kernel image
+load @@BOOT_MEDIA@@ ${BOOT_PART_NUM} ${kernel_addr_r} boot/@@KERNEL_IMAGETYPE@@
+      
+# Check if the uboot.env file exists on the specified boot media and partition    
+if test ! -e @@BOOT_MEDIA@@ 0:1 uboot.env; then saveenv; fi;
+
+# Execute the kernel boot command
+@@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr}

--- a/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
+++ b/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
@@ -1,3 +1,4 @@
+echo "Using single rootfs layout setup"
 fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
 fatload @@BOOT_MEDIA@@ 0:1 ${kernel_addr_r} @@KERNEL_IMAGETYPE@@
 if test ! -e @@BOOT_MEDIA@@ 0:1 uboot.env; then saveenv; fi;

--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -7,16 +7,26 @@ DEPENDS = "u-boot-mkimage-native"
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-SRC_URI = "file://boot.cmd.in"
+SRC_URI = "file://boot.cmd.in \
+           file://ab.boot.cmd.in"
 
 BOOT_MEDIA ?= "mmc"
 
 do_compile() {
-    sed -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
-        -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
-        -e 's/@@BOOT_MEDIA@@/${BOOT_MEDIA}/' \
-        "${WORKDIR}/boot.cmd.in" > "${WORKDIR}/boot.cmd"
-    mkimage -A ${UBOOT_ARCH} -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
+    if [ "${RPI_AB_PARTITION_LAYOUT}" = "0" ]; then
+        sed -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
+            -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
+            -e 's/@@BOOT_MEDIA@@/${BOOT_MEDIA}/' \
+            "${WORKDIR}/boot.cmd.in" > "${WORKDIR}/boot.cmd"
+        mkimage -A ${UBOOT_ARCH} -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
+    else
+        sed -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
+            -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
+            -e 's/@@BOOT_MEDIA@@/${BOOT_MEDIA}/' \
+            -e 's/@@RPI_AB_PARTITION_LAYOUT@@/${RPI_AB_PARTITION_LAYOUT}/' \
+            "${WORKDIR}/ab.boot.cmd.in" > "${WORKDIR}/boot.cmd"
+        mkimage -A ${UBOOT_ARCH} -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
+    fi
 }
 
 inherit kernel-arch deploy nopackages


### PR DESCRIPTION
Description:
This patch adds a new boot script "ab.boot.cmd.in", to support A/B partition layout.
The recipe "rpi-u-boot-scr" has been updated by consequence.
