### PR TITLE
Fix issues with ethernet in u-boot on rpi 3b+

### DIFF
--- a/recipes-bsp/u-boot/files/0001-Fix-problems-with-ethernet-on-raspberrypi-3b+.patch
+++ b/recipes-bsp/u-boot/files/0001-Fix-problems-with-ethernet-on-raspberrypi-3b+.patch
@@ -1,0 +1,30 @@
+From 407da149c24157fe0119f6ddde55a8a89b2482b3 Mon Sep 17 00:00:00 2001
+From: Jakub Szczudlo <jakubszczudlo40@gmail.com>
+Date: Tue, 4 Mar 2025 22:53:53 +0100
+Subject: [PATCH] Fix problems with ethernet on raspberrypi 3b+
+
+When initializing network devices on raspberry pi 3b+ the lan78xx_eth get seq 1. Because of that this network device doesn't get MAC address from BCM2835_MBOX and fail
+to bind device with driver and make using TFTP impossible without debugging. To address this issue and don't make much changes in uboot we can also add MAC address for
+device of sequence number=1
+---
+ board/raspberrypi/rpi/rpi.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/board/raspberrypi/rpi/rpi.c b/board/raspberrypi/rpi/rpi.c
+index 3fbec3674c1..921f55799c1 100644
+--- a/board/raspberrypi/rpi/rpi.c
++++ b/board/raspberrypi/rpi/rpi.c
+@@ -363,7 +363,10 @@ static void set_usbethaddr(void)
+ 	eth_env_set_enetaddr("usbethaddr", msg->get_mac_address.body.resp.mac);
+ 
+ 	if (!env_get("ethaddr"))
++	{
+ 		env_set("ethaddr", env_get("usbethaddr"));
++		env_set("eth1addr", env_get("usbethaddr"));
++	}
+ 
+ 	return;
+ }
+-- 
+2.43.0
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -4,7 +4,8 @@ SRC_URI:append:rpi = " \
     file://fw_env.config \
 "
 
-SRC_URI:append:rpi = " file://0001-rpi-always-set-fdt_addr-with-firmware-provided-FDT-address.patch"
+SRC_URI:append:rpi = " file://0001-rpi-always-set-fdt_addr-with-firmware-provided-FDT-address.patch \
+                       file://0001-Fix-problems-with-ethernet-on-raspberrypi-3b+.patch  "
 
 DEPENDS:append:rpi = " u-boot-default-script"
 


### PR DESCRIPTION
Problem accounter when I wanted to use TFTP to send files from server to raspberry. I found some dead links like the ones below:
https://lore.kernel.org/all/CANAwSgRQMQwTO0GjFpk0a9LHGhcwC2_C-YvWao8FnuQavZibRw@mail.gmail.com/T/
https://lists.denx.de/pipermail/u-boot/2024-February/546677.html
After some debugging I find the solution. It's easy to understand, don't break things and doesn't modify uboot in big manner  
**- What I did**
Fixes problems with init of ethernet device in uboot 
**- How I did it**
Add default MAC value not only for sequence 0 but also for sequence 1 device.

Also added screenshots
![before](https://github.com/user-attachments/assets/5808e92b-fcea-4039-b3f2-4143bda36406)
![after_patch](https://github.com/user-attachments/assets/e051174d-b2e3-4105-bcba-c8796e2c0f5c)

