### PR TITLE
libcamera-apps: Fix library packaging issues for rpicam_app.so.1.4.2

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera-apps/libcamera-apps_git.bb
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera-apps/libcamera-apps_git.bb
@@ -40,3 +40,5 @@ do_install:append() {
 
 # not picked automatically, because it's missing common 'lib' prefix
 FILES:${PN}-dev += "${libdir}/rpicam_app.so"
+
+FILES:${PN} += "${libdir}/rpicam_app.so.${@d.getVar("PV", False).__str__().split('+')[0]}"


### PR DESCRIPTION
Package rpicam_app.so.1.4.2 library for the default package to fix the following error.

ERROR: libcamera-apps-1.4.2+git-r0 do_package: QA Issue: libcamera-apps: Files/directories were installed but not shipped in any package:
  /usr/lib/rpicam_app.so.1.4.2
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install. libcamera-apps: 1 installed and not shipped files. [installed-vs-shipped] ERROR: libcamera-apps-1.4.2+git-r0 do_package: Fatal QA errors were found, failing task. ERROR: Logfile of failure stored in: /home/build-2/tmp/work/cortexa53-poky-linux/libcamera-apps/1.4.2+git/temp/log.do_package.1110484 ERROR: Task (/home/meta-raspberrypi/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera-apps/libcamera-apps_git.bb:do_package) failed with exit code '1'

The following version expansion is used to make it compatible with future package version changes.

${@d.getVar("PV", False).__str__().split('+')[0]}"

Fixes: https://github.com/agherzan/meta-raspberrypi/issues/1440

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->