### PR TITLE
armstubs, rpi-config: add whitespace around assignments

### DIFF
--- a/recipes-bsp/armstubs/armstubs.bb
+++ b/recipes-bsp/armstubs/armstubs.bb
@@ -11,14 +11,14 @@ COMPATIBLE_MACHINE = "^rpi$"
 
 S = "${RPITOOLS_S}/armstubs"
 
-export CC7="${CC}"
-export LD7="${LD}"
-export OBJCOPY7="${OBJCOPY}"
-export OBJDUMP7="${OBJDUMP}"
-export CC8="${CC}"
-export LD8="${LD}"
-export OBJCOPY8="${OBJCOPY}"
-export OBJDUMP8="${OBJDUMP} -maarch64"
+export CC7 = "${CC}"
+export LD7 = "${LD}"
+export OBJCOPY7 = "${OBJCOPY}"
+export OBJDUMP7 = "${OBJDUMP}"
+export CC8 = "${CC}"
+export LD8 = "${LD}"
+export OBJCOPY8 = "${OBJCOPY}"
+export OBJDUMP8 = "${OBJDUMP} -maarch64"
 
 do_compile() {
     [ -z "${ARMSTUB}" ] && bbfatal "No ARMSTUB defined for your machine."

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -18,13 +18,13 @@ PR = "r5"
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
-PITFT22="${@bb.utils.contains("MACHINE_FEATURES", "pitft22", "1", "0", d)}"
-PITFT28r="${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "1", "0", d)}"
-PITFT28c="${@bb.utils.contains("MACHINE_FEATURES", "pitft28c", "1", "0", d)}"
-PITFT35r="${@bb.utils.contains("MACHINE_FEATURES", "pitft35r", "1", "0", d)}"
+PITFT = "${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
+PITFT22 = "${@bb.utils.contains("MACHINE_FEATURES", "pitft22", "1", "0", d)}"
+PITFT28r = "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "1", "0", d)}"
+PITFT28c = "${@bb.utils.contains("MACHINE_FEATURES", "pitft28c", "1", "0", d)}"
+PITFT35r = "${@bb.utils.contains("MACHINE_FEATURES", "pitft35r", "1", "0", d)}"
 
-VC4GRAPHICS="${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"
+VC4GRAPHICS = "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"
 VC4DTBO ?= "vc4-kms-v3d"
 GPIO_IR ?= "18"
 GPIO_IR_TX ?= "17"
@@ -35,7 +35,7 @@ CAN1_INTERRUPT_PIN ?= "24"
 
 ENABLE_UART ??= ""
 
-WM8960="${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "1", "0", d)}"
+WM8960 = "${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "1", "0", d)}"
 
 GPIO_SHUTDOWN_PIN ??= ""
 


### PR DESCRIPTION
With:
https://lists.openembedded.org/g/bitbake-devel/message/17508 there are WARNINGs like:

```
WARNING: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb:21 has a lack of whitespace around the assignment: 'PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"'
WARNING: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb:22 has a lack of whitespace around the assignment: 'PITFT22="${@bb.utils.contains("MACHINE_FEATURES", "pitft22", "1", "0", d)}"'
WARNING: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb:23 has a lack of whitespace around the assignment: 'PITFT28r="${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "1", "0", d)}"'
WARNING: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb:24 has a lack of whitespace around the assignment: 'PITFT28c="${@bb.utils.contains("MACHINE_FEATURES", "pitft28c", "1", "0", d)}"'
WARNING: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb:25 has a lack of whitespace around the assignment: 'PITFT35r="${@bb.utils.contains("MACHINE_FEATURES", "pitft35r", "1", "0", d)}"'
WARNING: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb:27 has a lack of whitespace around the assignment: 'VC4GRAPHICS="${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"'
WARNING: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb: meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bb:38 has a lack of whitespace around the assignment: 'WM8960="${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "1", "0", d)}"'
WARNING: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb:14 has a lack of whitespace around the assignment: 'export CC7="${CC}"'
WARNING: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb:15 has a lack of whitespace around the assignment: 'export LD7="${LD}"'
WARNING: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb:16 has a lack of whitespace around the assignment: 'export OBJCOPY7="${OBJCOPY}"'
WARNING: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb:17 has a lack of whitespace around the assignment: 'export OBJDUMP7="${OBJDUMP}"'
WARNING: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb:18 has a lack of whitespace around the assignment: 'export CC8="${CC}"'
WARNING: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb:19 has a lack of whitespace around the assignment: 'export LD8="${LD}"'
WARNING: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb:20 has a lack of whitespace around the assignment: 'export OBJCOPY8="${OBJCOPY}"'
WARNING: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb: meta-raspberrypi/recipes-bsp/armstubs/armstubs.bb:21 has a lack of whitespace around the assignment: 'export OBJDUMP8="${OBJDUMP} -maarch64"'
```