### PR TITLE
rpi-base.inc: vc4-kms-dsi-ili9881-7inch.dtbo

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -77,6 +77,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/vc4-kms-v3d-pi4.dtbo \
     overlays/vc4-kms-v3d-pi5.dtbo \
     overlays/vc4-kms-dsi-7inch.dtbo \
+    overlays/vc4-kms-dsi-ili9881-7inch.dtbo \
     overlays/w1-gpio.dtbo \
     overlays/w1-gpio-pullup.dtbo \
     overlays/wm8960-soundcard.dtbo \


### PR DESCRIPTION
Add vc4-kms-dsi-ili9881-7inch.dtbo for the Raspberry Pi Touch Display 2 to RPI_KERNEL_DEVICETREE_OVERLAYS.

This work was sponsored by GOVCERT.LU.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Enabled support for Raspberry Pi Touch Display 2

**- How I did it**

Added `vc4-kms-dsi-ili9881-7inch.dtbo` to `RPI_KERNEL_DEVICETREE_OVERLAYS`.

To load the dtbo by default at the following line to your build setup, for example in `local.conf`:

```
RPI_EXTRA_CONFIG:append = " \
dtoverlay=vc4-kms-dsi-ili9881-7inch \
"
```

By default Raspberry Pi Touch Display 2 works in portrait mode. To rotate it in landscape mode for Weston (from `core-image-weston`), Add the following configuration to `weston.ini`:

```
[output]
name=DSI-2
mode=720x1280@60
transform=rotate-90 
```

Please note that in this example Raspberry Pi Touch Display 2 has been connected to physical connector `CAM/DISP 1` which was recognized and reported in the Weston log as `DSI-2`.
