### PR TITLE
[whinlatter] mesa: drop kmsro PACKAGECONFIG

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -2,5 +2,5 @@
 # With oe-core commit 8509e2e1a87578882b71948ccef3b50ccf1228b3 dri3 is set
 # as default. To state out clearly that Raspi needs dri3 and to avoid surprises
 # in case oe-core changes this default, we set dri3 explicitly.
-PACKAGECONFIG:append:rpi = " gallium vc4 v3d kmsro ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11 dri3', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan broadcom', '', d)}"
+PACKAGECONFIG:append:rpi = " gallium vc4 v3d ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11 dri3', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan broadcom', '', d)}"
 DRIDRIVERS:class-target:rpi = ""


### PR DESCRIPTION
kmsro is no longer valid gallium-drivers, the PACKAGECONFIG will be removed by: https://lists.openembedded.org/g/openembedded-core/message/214763

we need to remove it here as well.

kmsro was removed in:
https://gitlab.freedesktop.org/mesa/mesa/-/commit/89863a050bea429d9574a307bc28953bb60accaf

This PR should be applied after branching for walnascar as mesa-25 is only in master for whinlatter.