### PR TITLE
raspi-utils: Add missing utilities like vcgencmd

### DIFF
--- a/recipes-devtools/raspi-utils/raspi-utils_git.bb
+++ b/recipes-devtools/raspi-utils/raspi-utils_git.bb
@@ -2,7 +2,12 @@ SUMMARY = "A collection of scripts and simple applications"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENCE;md5=4c01239e5c3a3d133858dedacdbca63c"
 
+RCONFLICTS:${PN} = "userland"
 DEPENDS:append = " dtc"
+PACKAGES =+ " ${PN}-raspinfo"
+PACKAGES =+ " ${PN}-ovmerge"
+RDEPENDS:${PN}-raspinfo += " bash"
+RDEPENDS:${PN}-ovmerge += " perl"
 
 PV = "1.0+git"
 
@@ -14,9 +19,35 @@ S = "${WORKDIR}/git"
 
 FILES:${PN}:append = " \
     ${datadir}/bash-completion/completions/pinctrl \
+    ${datadir}/bash-completion/completions/vcgencmd \
+"
+FILES:${PN}-raspinfo += "${bindir}/raspinfo"
+FILES:${PN}-ovmerge += "${bindir}/ovmerge"
+
+OECMAKE_TARGET_COMPILE = "\
+    dtmerge/all \
+    eeptools/all \
+    otpset/all \
+    overlaycheck/all \
+    ovmerge/all \
+    pinctrl/all \
+    raspinfo/all \
+    vcgencmd/all \
+    vclog/all \
+    vcmailbox/all \
 "
 
-OECMAKE_TARGET_COMPILE = "pinctrl/all dtmerge/all"
-OECMAKE_TARGET_INSTALL = "pinctrl/install dtmerge/install"
+OECMAKE_TARGET_INSTALL = "\
+    dtmerge/install \
+    eeptools/install \
+    otpset/install \
+    overlaycheck/install \
+    ovmerge/install \
+    pinctrl/install \
+    raspinfo/install \
+    vcgencmd/install \
+    vclog/install \
+    vcmailbox/install \
+"
 
 inherit cmake


### PR DESCRIPTION
**- What I did**

The `raspi-utils` package that builds tools from the https://github.com/raspberrypi/utils repository neglected to include all of the utilities provided therein. I would like to include those missing utilities, so I added them to the recipe.

The `raspi-utils` recipe originally only built the `dtmerge` and `pinctrl` utilities. I've extended the recipe to include the other build targets which are:

  * eeptools
  * otpset
  * overlaycheck
  * ovmerge
  * raspinfo
  * vcgencmd
  * vclog
  * vcmailbox
  
 

**- How I did it**

I extended the `OECMAKE_TARGET_COMPILE` and `OECMAKE_TARGET_INSTALL` variables to include all the targets available in the upstream repository. The original variables become:

```shell
OECMAKE_TARGET_COMPILE = "\
    dtmerge/all \
    eeptools/all \
    otpset/all \
    overlaycheck/all \
    ovmerge/all \
    pinctrl/all \
    raspinfo/all \
    vcgencmd/all \
    vclog/all \
    vcmailbox/all \
"

OECMAKE_TARGET_INSTALL = "\
    dtmerge/install \
    eeptools/install \
    otpset/install \
    overlaycheck/install \
    ovmerge/install \
    pinctrl/install \
    raspinfo/install \
    vcgencmd/install \
    vclog/install \
    vcmailbox/install \
"
```
