### PR TITLE
mesa: Resolve invalid PACKAGECONFIG entries for mesa >=25

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -1,6 +1,2 @@
-# DRI3 note:
-# With oe-core commit 8509e2e1a87578882b71948ccef3b50ccf1228b3 dri3 is set
-# as default. To state out clearly that Raspi needs dri3 and to avoid surprises
-# in case oe-core changes this default, we set dri3 explicitly.
-PACKAGECONFIG:append:rpi = " gallium vc4 v3d kmsro ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11 dri3', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan broadcom', '', d)}"
+PACKAGECONFIG:append:rpi = " gallium vc4 v3d ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan broadcom', '', d)}"
 DRIDRIVERS:class-target:rpi = ""


### PR DESCRIPTION
Remove invalid PACKAGECONFIG options 'kmsro' and 'dri3' for rpi when using walnascar

This address QA issue in mesa recipe to ensure valid configuration:

```
  ERROR: mesa-2_25.0.5-r0 do_recipe_qa: QA Issue: mesa: invalid
         PACKAGECONFIG(s): dri3 kmsro [invalid-packageconfig]
```


**- What I did**

* Removed unsupported PACKAGECONFIG options 'kmsro' and 'dri3' for the Raspberry Pi (rpi) machine when using the 'walnascar' layer series in the mesa recipe.

**- How I did it**

* Updated the `mesa.bbappend` file to conditionally remove 'kmsro' and 'dri3' from the PACKAGECONFIG for the rpi machine when the 'walnascar' layer series is detected, using the `bb.utils.contains` function.
