### PR TITLE
armstubs, rpi-config: Add whitespace around variable assignments

### DIFF
--- a/recipes-bsp/armstubs/armstubs.bb
+++ b/recipes-bsp/armstubs/armstubs.bb
@@ -11,14 +11,14 @@ COMPATIBLE_MACHINE = "^rpi$"
 
 S = "${RPITOOLS_S}/armstubs"
 
-export CC7="${CC}"
-export LD7="${LD}"
-export OBJCOPY7="${OBJCOPY}"
-export OBJDUMP7="${OBJDUMP}"
-export CC8="${CC}"
-export LD8="${LD}"
-export OBJCOPY8="${OBJCOPY}"
-export OBJDUMP8="${OBJDUMP} -maarch64"
+export CC7 = "${CC}"
+export LD7 = "${LD}"
+export OBJCOPY7 = "${OBJCOPY}"
+export OBJDUMP7 = "${OBJDUMP}"
+export CC8 = "${CC}"
+export LD8 = "${LD}"
+export OBJCOPY8 = "${OBJCOPY}"
+export OBJDUMP8 = "${OBJDUMP} -maarch64"
 
 do_compile() {
     [ -z "${ARMSTUB}" ] && bbfatal "No ARMSTUB defined for your machine."

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -18,13 +18,13 @@ PR = "r5"
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
-PITFT22="${@bb.utils.contains("MACHINE_FEATURES", "pitft22", "1", "0", d)}"
-PITFT28r="${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "1", "0", d)}"
-PITFT28c="${@bb.utils.contains("MACHINE_FEATURES", "pitft28c", "1", "0", d)}"
-PITFT35r="${@bb.utils.contains("MACHINE_FEATURES", "pitft35r", "1", "0", d)}"
+PITFT = "${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
+PITFT22 = "${@bb.utils.contains("MACHINE_FEATURES", "pitft22", "1", "0", d)}"
+PITFT28r = "${@bb.utils.contains("MACHINE_FEATURES", "pitft28r", "1", "0", d)}"
+PITFT28c = "${@bb.utils.contains("MACHINE_FEATURES", "pitft28c", "1", "0", d)}"
+PITFT35r = "${@bb.utils.contains("MACHINE_FEATURES", "pitft35r", "1", "0", d)}"
 
-VC4GRAPHICS="${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"
+VC4GRAPHICS = "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"
 VC4DTBO ?= "vc4-kms-v3d"
 GPIO_IR ?= "18"
 GPIO_IR_TX ?= "17"
@@ -35,7 +35,7 @@ CAN1_INTERRUPT_PIN ?= "24"
 
 ENABLE_UART ??= ""
 
-WM8960="${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "1", "0", d)}"
+WM8960 = "${@bb.utils.contains("MACHINE_FEATURES", "wm8960", "1", "0", d)}"
 
 GPIO_SHUTDOWN_PIN ??= ""
 


### PR DESCRIPTION
Fix recently introduced warnings.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- Add whitespace around variable assignments.**
