### PR TITLE
X11 at Raspberry Pi5

### DIFF
--- a/conf/machine/raspberrypi5.conf
+++ b/conf/machine/raspberrypi5.conf
@@ -24,7 +24,7 @@ RPI_KERNEL_DEVICETREE = " \
 SDIMG_KERNELIMAGE ?= "kernel_2712.img"
 SERIAL_CONSOLES ?= "115200;ttyAMA10"
 
-VC4DTBO ?= "vc4-kms-v3d"
+VC4DTBO ?= "vc4-kms-v3d-pi5"
 
 # When u-boot is enabled we need to use the "Image" format and the "booti"
 # command to load the kernel

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -336,6 +336,11 @@ do_deploy:append:raspberrypi3-64() {
     echo "dtparam=audio=on" >> $CONFIG
 }
 
+do_deploy:append:raspberrypi5() {
+    echo "max_framebuffers=2" >> $CONFIG
+    echo "disable_fw_kms_setup=1" >> $CONFIG
+}
+
 do_deploy:append() {
     if grep -q -E '^.{80}.$' ${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt; then
         bbwarn "config.txt contains lines longer than 80 characters, this is not supported"

--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -1,6 +1,2 @@
-# DRI3 note:
-# With oe-core commit 8509e2e1a87578882b71948ccef3b50ccf1228b3 dri3 is set
-# as default. To state out clearly that Raspi needs dri3 and to avoid surprises
-# in case oe-core changes this default, we set dri3 explicitly.
-PACKAGECONFIG:append:rpi = " gallium vc4 v3d ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11 dri3', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan broadcom', '', d)}"
+PACKAGECONFIG:append:rpi = " gallium vc4 v3d ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan broadcom', '', d)}"
 DRIDRIVERS:class-target:rpi = ""

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/99-vc4.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/99-vc4.conf
@@ -1,0 +1,6 @@
+Section "OutputClass"
+    Identifier "vc4"
+    MatchDriver "vc4"
+    Driver "modesetting"
+    Option "PrimaryGPU" "true"
+EndSection

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
@@ -4,6 +4,11 @@ SRC_URI:append:rpi = " \
     file://xorg.conf.d/98-pitft.conf \
     file://xorg.conf.d/99-calibration.conf \
 "
+
+SRC_URI:append:raspberrypi5 = " \
+    file://99-vc4.conf \
+"
+
 do_install:append:rpi () {
     PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
     if [ "${PITFT}" = "1" ]; then
@@ -11,6 +16,11 @@ do_install:append:rpi () {
         install -m 0644 ${UNPACKDIR}/xorg.conf.d/98-pitft.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
         install -m 0644 ${UNPACKDIR}/xorg.conf.d/99-calibration.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
     fi
+}
+
+do_install:append:raspberrypi5 () {
+    install -d ${D}/${sysconfdir}/X11/xorg.conf.d/
+    install -m 0644 ${S}/99-vc4.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
 }
 
 FILES:${PN}:append:rpi = " ${sysconfdir}/X11/xorg.conf.d/*"


### PR DESCRIPTION
The X11 was not working for my Raspberry Pi5 at master of meta-raspberrypi and meta-openembedded.

All credits for the the contributors of https://github.com/agherzan/meta-raspberrypi/issues/1426

@kraj @agherzan  Please review this PR careful please.
