### PR TITLE
mesa: drop dri3 PACKAGECONFIG

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -1,6 +1,1 @@
-# DRI3 note:
-# With oe-core commit 8509e2e1a87578882b71948ccef3b50ccf1228b3 dri3 is set
-# as default. To state out clearly that Raspi needs dri3 and to avoid surprises
-# in case oe-core changes this default, we set dri3 explicitly.
-PACKAGECONFIG:append:rpi = " gallium vc4 v3d ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11 dri3', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan broadcom', '', d)}"
-DRIDRIVERS:class-target:rpi = ""
+PACKAGECONFIG:append:rpi = " gallium vc4 v3d ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'vulkan broadcom', '', d)}"


### PR DESCRIPTION
- remove DRIDRIVERS variable

Both are not available in current mesa recipe

This fixes:
ERROR: mesa-2_25.0.5-r0 do_recipe_qa: QA Issue: mesa: invalid PACKAGECONFIG(s): dri3 [invalid-packageconfig] ERROR: mesa-2_25.0.5-r0 do_recipe_qa: Fatal QA errors were found, failing task.