### PR TITLE
Update to whinlatter release series and adapt to UNPACKDIR changes

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "raspberrypi"
 BBFILE_PATTERN_raspberrypi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi = "9"
 
-LAYERSERIES_COMPAT_raspberrypi = "styhead walnascar"
+LAYERSERIES_COMPAT_raspberrypi = "whinlatter"
 LAYERDEPENDS_raspberrypi = "core"
 
 # Additional license directories.

--- a/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera-apps/libcamera-apps_git.bb
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera-apps/libcamera-apps_git.bb
@@ -15,7 +15,6 @@ SRC_URI = "\
 PV = "1.4.2+git${SRCPV}"
 SRCREV = "9ae39f85ae6bee9761c36b9b5b80d675bc1fa369"
 
-S = "${WORKDIR}/git"
 
 DEPENDS = "libcamera libexif jpeg tiff libpng boost"
 

--- a/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.17.bb
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/rpidistro-vlc/rpidistro-vlc_3.0.17.bb
@@ -32,7 +32,6 @@ SRC_URI = "\
 
 SRCREV = "b276eb0d7bc3213363e97dbb681ef7c927be6c73"
 
-S = "${WORKDIR}/git"
 
 PROVIDES = "vlc"
 RPROVIDES:${PN} = "${PROVIDES}"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-blinka_6.2.2.bb
@@ -6,7 +6,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=660e614bc7efb0697cc793d8a22a55c2"
 SRC_URI = "git://github.com/adafruit/Adafruit_Blinka.git;branch=main;protocol=https"
 SRCREV = "dc688f354fe779c9267c208b99f310af87e79272"
 
-S = "${WORKDIR}/git"
 
 inherit setuptools3
 

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-circuitpython-busdevice_5.0.5.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-circuitpython-busdevice_5.0.5.bb
@@ -6,7 +6,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=6ec69d6e9e6c85adfb7799d7f8cf044e"
 SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_BusDevice.git;branch=main;protocol=https"
 SRCREV = "1bfe8005293205e2f7b2cc498ab5a946f1133b40"
 
-S = "${WORKDIR}/git"
 
 inherit setuptools3
 

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-circuitpython-motor_3.2.6.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-circuitpython-motor_3.2.6.bb
@@ -6,7 +6,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b72678307cc7c10910b5ef460216af07"
 SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Motor.git;branch=main;protocol=https"
 SRCREV = "2251bfc0501d0acfb96c0a43f4f2b4c6a10ca14e"
 
-S = "${WORKDIR}/git"
 
 inherit setuptools3
 

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-circuitpython-motorkit_1.6.1.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-circuitpython-motorkit_1.6.1.bb
@@ -6,7 +6,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=6ad4a8854b39ad474755ef1aea813bac"
 SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_MotorKit.git;branch=main;protocol=https"
 SRCREV = "8c1462b4129b21f6db156d1517abb017bb74b982"
 
-S = "${WORKDIR}/git"
 
 inherit setuptools3
 

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-circuitpython-pca9685_3.3.4.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-circuitpython-pca9685_3.3.4.bb
@@ -6,7 +6,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e7eb6b599fb0cfb06485c64cd4242f62"
 SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_PCA9685.git;branch=main;protocol=https"
 SRCREV = "2780c4102f4c23fbab252aa1198b61ba7e2d1b2c"
 
-S = "${WORKDIR}/git"
 
 inherit setuptools3
 

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -12,7 +12,6 @@ SRC_URI = "git://github.com/Evilpaul/RPi-config.git;protocol=https;branch=master
            file://0001-config.txt-reintroduce-start_x.patch \
           "
 
-S = "${WORKDIR}/git"
 
 PR = "r5"
 

--- a/recipes-bsp/common/raspberrypi-tools.inc
+++ b/recipes-bsp/common/raspberrypi-tools.inc
@@ -1,7 +1,7 @@
 RPITOOLS_DATE ?= "20220711"
 SRCREV ?= "439b6198a9b340de5998dd14a26a0d9d38a6bcac"
 RPITOOLS_SRC_URI ?= "git://github.com/raspberrypi/tools;protocol=https;branch=master"
-RPITOOLS_S ?= "${WORKDIR}/git"
+RPITOOLS_S ?= "${UNPACKDIR}/${BP}"
 
 SRC_URI = "${RPITOOLS_SRC_URI}"
 

--- a/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
+++ b/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
@@ -11,7 +11,6 @@ SRC_URI = " \
 SRCREV = "1bd0a1052b2e74d7af04de18d30b5edb12d8a423"
 PV = "v2025.03.10-2712"
 
-S = "${WORKDIR}/git"
 
 RDEPENDS:${PN} += " \
     coreutils \

--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -21,8 +21,7 @@ do_compile() {
 
 inherit kernel-arch deploy nopackages
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 do_deploy() {
     install -d ${DEPLOYDIR}

--- a/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.17.bb
+++ b/recipes-connectivity/pi-bluetooth/pi-bluetooth_0.1.17.bb
@@ -12,7 +12,6 @@ SRC_URI = "\
 "
 SRCREV = "fd4775bf90e037551532fc214a958074830bb80d"
 
-S = "${WORKDIR}/git"
 
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', 'update-rc.d', d)}
 # hciuart.service replaces what was brcm43438.service 

--- a/recipes-core/udev/udev-rules-rpi.bb
+++ b/recipes-core/udev/udev-rules-rpi.bb
@@ -8,7 +8,6 @@ SRC_URI = " \
 	"
 SRCREV = "5ce3ef2b7f377c23fea440ca9df0e30f3f8447cf"
 
-S = "${WORKDIR}/git"
 
 INHIBIT_DEFAULT_DEPS = "1"
 

--- a/recipes-devtools/pi-blaster/pi-blaster_git.bb
+++ b/recipes-devtools/pi-blaster/pi-blaster_git.bb
@@ -8,7 +8,6 @@ SRC_URI = "git://github.com/sarfata/pi-blaster;branch=master;protocol=https \
            file://remove-initscript-lsb-dependency.patch \
            "
 
-S = "${WORKDIR}/git"
 
 SRCREV = "fbba9a7dcef0f352a11f8a2a5f6cbc15b62c0829"
 

--- a/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.10.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-register_1.9.10.bb
@@ -5,7 +5,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=6ec69d6e9e6c85adfb7799d7f8cf044e"
 
 SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Register.git;branch=main;protocol=https"
 SRCREV = "d1e8ac7ad9dcd65ab83749db3e5c96ffee80ebb7"
-S = "${WORKDIR}/git"
 
 DEPENDS += "python3-setuptools-scm-native"
 

--- a/recipes-devtools/python/python3-adafruit-platformdetect_3.27.0.bb
+++ b/recipes-devtools/python/python3-adafruit-platformdetect_3.27.0.bb
@@ -5,7 +5,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=fccd531dce4b989c05173925f0bbb76c"
 
 SRC_URI = "git://github.com/adafruit/Adafruit_Python_PlatformDetect.git;branch=main;protocol=https"
 SRCREV = "e1460098eeca5ea573f92814691bb378e15530d9"
-S = "${WORKDIR}/git"
 
 inherit setuptools3
 

--- a/recipes-devtools/python/python3-adafruit-pureio_1.1.9.bb
+++ b/recipes-devtools/python/python3-adafruit-pureio_1.1.9.bb
@@ -6,7 +6,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2a21fcca821a506d4c36f7bbecc0d009"
 SRC_URI = "git://github.com/adafruit/Adafruit_Python_PureIO.git;branch=main;protocol=https"
 SRCREV = "383b615ce9ff5bbefdf77652799f380016fda353"
 
-S = "${WORKDIR}/git"
 
 inherit setuptools3
 

--- a/recipes-devtools/python/python3-rtimu_7.2.1.bb
+++ b/recipes-devtools/python/python3-rtimu_7.2.1.bb
@@ -11,5 +11,5 @@ SRC_URI = "git://github.com/RPi-Distro/RTIMULib.git;protocol=http;branch=master;
           "
 SRCREV = "b949681af69b45f0f7f4bb53b6770037b5b02178"
 
-S = "${WORKDIR}/git/Linux/python"
+S = "${UNPACKDIR}/${BP}/Linux/python"
 inherit setuptools3

--- a/recipes-devtools/python/rpio_0.10.1.bb
+++ b/recipes-devtools/python/rpio_0.10.1.bb
@@ -9,7 +9,6 @@ SRC_URI = "\
     git://github.com/metachris/RPIO.git;protocol=https;branch=master \
     "
 SRCREV = "be1942a69b2592ddacd9dc833d2668a19aafd8d2"
-S = "${WORKDIR}/git"
 
 inherit setuptools3
 

--- a/recipes-devtools/raspi-gpio/raspi-gpio_git.bb
+++ b/recipes-devtools/raspi-gpio/raspi-gpio_git.bb
@@ -12,5 +12,4 @@ SRCREV = "22b44e4765b4b78dc5b22394fff484e353d5914d"
 SRC_URI = "git://github.com/RPi-Distro/raspi-gpio.git;protocol=https;branch=master \
           "
 
-S = "${WORKDIR}/git"
 

--- a/recipes-devtools/raspi-utils/raspi-utils_git.bb
+++ b/recipes-devtools/raspi-utils/raspi-utils_git.bb
@@ -15,7 +15,6 @@ SRC_URI = "git://github.com/raspberrypi/utils;protocol=https;branch=master"
 
 SRCREV = "b9c63214c535d7df2b0fa6743b7b3e508363c25a"
 
-S = "${WORKDIR}/git"
 
 FILES:${PN}:append = " \
     ${datadir}/bash-completion/completions/pinctrl \

--- a/recipes-graphics/raspidmx/raspidmx_git.bb
+++ b/recipes-graphics/raspidmx/raspidmx_git.bb
@@ -20,7 +20,6 @@ SRC_URI = "git://github.com/AndrewFromMelbourne/raspidmx;protocol=https;branch=m
 PV = "0.0+git${SRCPV}"
 SRCREV = "e2ee6faa0d01a5ece06bcc74a47f37d7e6837310"
 
-S = "${WORKDIR}/git"
 
 inherit pkgconfig
 

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -51,7 +51,6 @@ SRC_URI = "\
 
 SRC_URI:remove:toolchain-clang = "file://0021-cmake-Disable-format-overflow-warning-as-error.patch"
 
-S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig
 

--- a/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
+++ b/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
@@ -29,7 +29,6 @@ SRC_URI = " \
 SRCREV = "78d6a07730e2d20c035899521ab67726dc028e1c"
 PV = "1.2-9+rpt3"
 
-S = "${WORKDIR}/git"
 
 inherit allarch
 

--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -20,7 +20,6 @@ SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree;branch=bookworm;protocol
 "
 SRCREV = "4b356e134e8333d073bd3802d767a825adec3807"
 PV = "20230625-2+rpt3"
-S = "${WORKDIR}/git"
 
 inherit allarch
 

--- a/recipes-multimedia/omxplayer/omxplayer_git.bb
+++ b/recipes-multimedia/omxplayer/omxplayer_git.bb
@@ -40,7 +40,6 @@ SRC_URI = "git://github.com/popcornmix/omxplayer.git;protocol=https;branch=maste
 
 SRC_URI:append = "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", " file://0001-Fix-build-with-vc4-driver.patch ", "", d)}"
 
-S = "${WORKDIR}/git"
 
 COMPATIBLE_MACHINE = "^rpi$"
 COMPATIBLE_HOST:aarch64 = "null"

--- a/recipes-multimedia/python3-picamera/python3-picamera_git.bb
+++ b/recipes-multimedia/python3-picamera/python3-picamera_git.bb
@@ -14,7 +14,6 @@ RDEPENDS:${PN} = "python3-numbers   \
 SRC_URI = "git://git@github.com/waveform80/picamera.git;protocol=ssh;branch=master"
 SRCREV = "7e4f1d379d698c44501fb84b886fadf3fc164b70"
 
-S = "${WORKDIR}/git"
 
 inherit setuptools3
 

--- a/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_5.1.4.bb
+++ b/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_5.1.4.bb
@@ -50,7 +50,6 @@ SRC_URI = "\
 
 SRCREV = "1c363463c432c5ed492c7b759abb6e015b93b6b5"
 
-S = "${WORKDIR}/git"
 
 # libraries to build in addition to avutil
 PACKAGECONFIG[avdevice] = "--enable-avdevice,--disable-avdevice"


### PR DESCRIPTION
I verified that `bitbake -c patch world` runs successfully with these changes. I haven’t done a full world build, recipes shouldn’t need further fixes.

Related commits:

https://git.openembedded.org/openembedded-core/commit/?id=75eb26e71dba4096d5632b7f6b13db4f13aa6d7f
https://git.openembedded.org/openembedded-core/commit/?id=f80c07019ddadaf9c5fb890faabfda7920ecd15e
https://git.openembedded.org/openembedded-core/commit/?id=7321cc17ae5483f17fe9cdffea7b62acd9d9c3a2
https://git.openembedded.org/openembedded-core/commit/?id=f64b7e5fb3181734c8dde87b27e872a026261a74
https://git.openembedded.org/openembedded-core/commit/?id=46480a5e66747a673041fe4452a0ab14a1736d5e