### PR TITLE
[scarthgap] Raspberry Pi Linux kernel 6.12

### DIFF
--- a/conf/machine/include/rpi-default-versions.inc
+++ b/conf/machine/include/rpi-default-versions.inc
@@ -1,4 +1,4 @@
 # RaspberryPi BSP default versions
 
-PREFERRED_VERSION_linux-raspberrypi ??= "6.6.%"
+PREFERRED_VERSION_linux-raspberrypi ??= "6.12.%"
 PREFERRED_VERSION_linux-raspberrypi-v7 ??= "${PREFERRED_VERSION_linux-raspberrypi}"

--- a/recipes-bsp/bootfiles/rpi-bootfiles.bb
+++ b/recipes-bsp/bootfiles/rpi-bootfiles.bb
@@ -5,14 +5,14 @@ LIC_FILES_CHKSUM = "file://LICENCE.broadcom;md5=c403841ff2837657b2ed8e5bb474ac8d
 
 inherit deploy nopackages
 
-RPIFW_DATE ?= "20250326"
-SRCREV = "f49a3960223f20ea0b2e30646f65be67bafe30dc"
+RPIFW_DATE ?= "20250430"
+SRCREV = "bc7f439c234e19371115e07b57c366df59cc1bc7"
 SHORTREV = "${@d.getVar("SRCREV", False).__str__()[:7]}"
-RPIFW_SRC_URI ?= "https://api.github.com/repos/raspberrypi/firmware/tarball/f49a3960223f20ea0b2e30646f65be67bafe30dc;downloadfilename=raspberrypi-firmware-${SHORTREV}.tar.gz"
+RPIFW_SRC_URI ?= "https://api.github.com/repos/raspberrypi/firmware/tarball/${SRCREV};downloadfilename=raspberrypi-firmware-${SHORTREV}.tar.gz"
 RPIFW_S ?= "${WORKDIR}/raspberrypi-firmware-${SHORTREV}"
 
 SRC_URI = "${RPIFW_SRC_URI}"
-SRC_URI[sha256sum] = "26926a9c56be907a87fafb5bc8add431ec6b763598de340e7401ce5684d2c55b"
+SRC_URI[sha256sum] = "2c027debbef53c86c9ff9197d056d501b95f6ad214ad4db00a8a59b947574eb1"
 
 PV = "${RPIFW_DATE}"
 

--- a/recipes-kernel/linux/linux-raspberrypi-v7_6.12.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-v7_6.12.bb
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Andrei Gherzan <andrei.gherzan@huawei.com>
+#
+# SPDX-License-Identifier: MIT
+
+require linux-raspberrypi-v7.inc
+require linux-raspberrypi_6.12.bb

--- a/recipes-kernel/linux/linux-raspberrypi_6.12.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_6.12.bb
@@ -1,14 +1,14 @@
-LINUX_VERSION ?= "6.12.1"
-LINUX_RPI_BRANCH ?= ""
+LINUX_VERSION ?= "6.12.25"
+LINUX_RPI_BRANCH ?= "rpi-6.12.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-6.12"
 
-SRCREV_machine = "614fa9b0b1a21c0cc320b9915393bdaa31357de9"
-SRCREV_meta = "96ce9b7ee67702aec75816c4d44a527061c418c5"
+SRCREV_machine = "3dd2c2c507c271d411fab2e82a2b3b7e0b6d3f16"
+SRCREV_meta = "1f6ab68a1d86836bf1b82b791df03da3cfeacb3f"
 
 KMETA = "kernel-meta"
 
 SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;name=machine;nobranch=1;protocol=https \
+    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH};protocol=https \
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
     file://powersave.cfg \
     file://android-drivers.cfg \

--- a/recipes-kernel/linux/linux-raspberrypi_6.12.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_6.12.bb
@@ -1,0 +1,31 @@
+LINUX_VERSION ?= "6.12.1"
+LINUX_RPI_BRANCH ?= ""
+LINUX_RPI_KMETA_BRANCH ?= "yocto-6.12"
+
+SRCREV_machine = "614fa9b0b1a21c0cc320b9915393bdaa31357de9"
+SRCREV_meta = "96ce9b7ee67702aec75816c4d44a527061c418c5"
+
+KMETA = "kernel-meta"
+
+SRC_URI = " \
+    git://github.com/raspberrypi/linux.git;name=machine;nobranch=1;protocol=https \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
+    file://powersave.cfg \
+    file://android-drivers.cfg \
+    "
+
+require linux-raspberrypi.inc
+
+KERNEL_DTC_FLAGS += "-@ -H epapr"
+
+RDEPENDS:${KERNEL_PACKAGE_NAME}:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-base:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-base"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-image:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-image"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-dev:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-dev"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-vmlinux:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-vmlinux"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-modules:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-modules"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-dbg:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-dbg"
+
+DEPLOYDEP = ""
+DEPLOYDEP:raspberrypi-armv7 = "${RASPBERRYPI_v7_KERNEL}:do_deploy"
+do_deploy[depends] += "${DEPLOYDEP}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Adds support for the Raspberry Pi fork of the Linux kernel version 6.12 as well as the required firmware.

**- How I did it**

Cherry-picked patches from branch master to scarthgap and tested on Raspberry Pi 5. This is related to https://github.com/agherzan/meta-raspberrypi/pull/1462

This pull request replaces #1479.

On a side note, during the test I noticed:

```
root@raspberrypi5:~# dmesg | grep error
[    5.170687] brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.bin failed with error -2
[    5.678945] rp1-pio 1f00178000.pio: probe with driver rp1-pio failed with error -2
```

Based on my experience this is related to https://github.com/agherzan/meta-raspberrypi/pull/1408 so after merging PR #1408 in master we should also port it to Scarthgap.

This backporting work was sponsored by GOVCERT.LU.

