### PR TITLE
raspberrypi5.conf: Add CM5 dtb's

### DIFF
--- a/conf/machine/raspberrypi-armv8.conf
+++ b/conf/machine/raspberrypi-armv8.conf
@@ -33,6 +33,10 @@ RPI_KERNEL_DEVICETREE = " \
     broadcom/bcm2711-rpi-cm4.dtb \
     broadcom/bcm2711-rpi-cm4s.dtb \
     broadcom/bcm2712-rpi-5-b.dtb \
+    broadcom/bcm2712-rpi-cm5-cm5io.dtb \
+    broadcom/bcm2712-rpi-cm5-cm4io.dtb \
+    broadcom/bcm2712-rpi-cm5l-cm5io.dtb \
+    broadcom/bcm2712-rpi-cm5l-cm4io.dtb \
 "
 
 SDIMG_KERNELIMAGE ?= "kernel8.img"

--- a/conf/machine/raspberrypi5.conf
+++ b/conf/machine/raspberrypi5.conf
@@ -15,6 +15,10 @@ MACHINE_EXTRA_RRECOMMENDS += "\
 
 RPI_KERNEL_DEVICETREE = " \
     broadcom/bcm2712-rpi-5-b.dtb \
+    broadcom/bcm2712-rpi-cm5-cm5io.dtb \
+    broadcom/bcm2712-rpi-cm5-cm4io.dtb \
+    broadcom/bcm2712-rpi-cm5l-cm5io.dtb \
+    broadcom/bcm2712-rpi-cm5l-cm4io.dtb \
 "
 
 SDIMG_KERNELIMAGE ?= "kernel_2712.img"


### PR DESCRIPTION
Add new dtb's required for raspberry compute module 5

(cherry picked from commit 51f06365f36ccfbc51aa1d96ced828cdc0e10f7b)
