### PR TITLE
support-for-seeed-can-fd-hat-v2

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -51,6 +51,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/iqaudio-dacplus.dtbo \
     overlays/mcp2515-can0.dtbo \
     overlays/mcp2515-can1.dtbo \
+    overlays/seeed-can-fd-hat-v2.dtbo \
     overlays/mcp3008.dtbo \
     overlays/miniuart-bt.dtbo \
     overlays/pitft22.dtbo \

--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -354,6 +354,12 @@ Tested modules:
 * WaveShare RS485 CAN HAT (8 MHz or 12 MHz crystal): <https://www.waveshare.com/rs485-can-hat.htm>
 * PiCAN2 Duo (16 MHz crystal): <http://skpang.co.uk/catalog/pican2-duo-canbus-board-for-raspberry-pi-23-p-1480.html>
 
+To enable the 2-Channel CAN-BUS(FD) Shield (MCP2518FD), set:
+
+    ENABLE_DUAL_CAN_SEED_FD_HAT_V2 = "1"
+
+* Seed Studio (2-Channel CAN-BUS(FD) Shield): <https://wiki.seeedstudio.com/2-Channel-CAN-BUS-FD-Shield-for-Raspberry-Pi/>
+
 ## Enable infrared
 
 Users who want to enable infrared support, for example for using LIRC (Linux

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -270,6 +270,10 @@ do_deploy() {
         echo "# Enable DUAL CAN" >>$CONFIG
         echo "dtoverlay=mcp2515-can0,oscillator=${CAN_OSCILLATOR},interrupt=${CAN0_INTERRUPT_PIN}" >>$CONFIG
         echo "dtoverlay=mcp2515-can1,oscillator=${CAN_OSCILLATOR},interrupt=${CAN1_INTERRUPT_PIN}" >>$CONFIG
+    # Enable DUAL CAN FOR SEED CAN FD HAT V2
+    elif [ "${ENABLE_DUAL_CAN_SEED_FD_HAT_V2}" = "1" ]; then
+        echo "# Enable DUAL CAN FOR SEED CAN FD HAT V2" >>$CONFIG
+        echo "dtoverlay=seeed-can-fd-hat-v2" >>$CONFIG
     # ENABLE CAN
     elif [ "${ENABLE_CAN}" = "1" ]; then
         echo "# Enable CAN" >>$CONFIG


### PR DESCRIPTION
Hey,

I needed support of the [seeed-can-fd-hat-v2 Can Shield](https://wiki.seeedstudio.com/2-Channel-CAN-BUS-FD-Shield-for-Raspberry-Pi/) so I added it to the layer. 

I tested the changes on my rpi4. 