### PR TITLE
[kirkstone] docker-build: use --no-cache

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -32,7 +32,7 @@ runs:
         n=1
         until [ "$n" -gt "$tries" ]; do
           echo "Building the docker image ${{ inputs.docker_image }}-${{ inputs.id }}... try $n..."
-          if docker build . -f "${{ inputs.docker_image }}/Dockerfile" -t "${{ inputs.docker_image }}-${{ inputs.id }}"; then
+          if docker build --no-cache . -f "${{ inputs.docker_image }}/Dockerfile" -t "${{ inputs.docker_image }}-${{ inputs.id }}"; then
             # This can fail if a dangling images cleaning job runs in
             # parallel. So we try this a couple of times to minimize
             # conflict. This is because while building, docker creates a

--- a/.github/workflows/docker-images/README.md
+++ b/.github/workflows/docker-images/README.md
@@ -17,5 +17,5 @@ passing the appropriate `-f` argument.
 Here is an example for building the `dco-check` image:
 
 ```
-docker build . -f dco-check/Dockerfile -t dco-check
+docker build --no-cache . -f dco-check/Dockerfile -t dco-check
 ```


### PR DESCRIPTION
* --no-cache is needed to actually call apt update instead of using it from docker cache and then failing to fetch pruned packages as shown: https://github.com/agherzan/meta-raspberrypi/actions/runs/16327036376/job/46119768952?pr=1491