### PR TITLE
add raspi-utils recipe to scarthgap branch

### DIFF
--- a/recipes-devtools/raspi-utils/raspi-utils_git.bb
+++ b/recipes-devtools/raspi-utils/raspi-utils_git.bb
@@ -1,0 +1,53 @@
+SUMMARY = "A collection of scripts and simple applications"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENCE;md5=4c01239e5c3a3d133858dedacdbca63c"
+
+RCONFLICTS:${PN} = "userland"
+DEPENDS:append = " dtc"
+PACKAGES =+ " ${PN}-raspinfo"
+PACKAGES =+ " ${PN}-ovmerge"
+RDEPENDS:${PN}-raspinfo += " bash"
+RDEPENDS:${PN}-ovmerge += " perl"
+
+PV = "1.0+git"
+
+SRC_URI = "git://github.com/raspberrypi/utils;protocol=https;branch=master"
+
+SRCREV = "b9c63214c535d7df2b0fa6743b7b3e508363c25a"
+
+FILES:${PN}:append = " \
+    ${datadir}/bash-completion/completions/pinctrl \
+    ${datadir}/bash-completion/completions/vcgencmd \
+"
+FILES:${PN}-raspinfo += "${bindir}/raspinfo"
+FILES:${PN}-ovmerge += "${bindir}/ovmerge"
+
+S = "${WORKDIR}/git"
+
+OECMAKE_TARGET_COMPILE = "\
+    dtmerge/all \
+    eeptools/all \
+    otpset/all \
+    overlaycheck/all \
+    ovmerge/all \
+    pinctrl/all \
+    raspinfo/all \
+    vcgencmd/all \
+    vclog/all \
+    vcmailbox/all \
+"
+
+OECMAKE_TARGET_INSTALL = "\
+    dtmerge/install \
+    eeptools/install \
+    otpset/install \
+    overlaycheck/install \
+    ovmerge/install \
+    pinctrl/install \
+    raspinfo/install \
+    vcgencmd/install \
+    vclog/install \
+    vcmailbox/install \
+"
+
+inherit cmake


### PR DESCRIPTION
**- What I did**

I added the `raspi-utils` recipe to the `scarthgap` branch.

**- How I did it**

I simply copied the recipe from `master`, additionally defining the `S` variable in order to build correctly with Scarthgap.

Tested on `MACHINE=raspberrypi4-64`.  Builds without issue, and `vcmailbox` works:

```
root@raspberrypi4-64:~# vcmailbox 0x00010004 8 8 0 0
0x00000020 0x80000000 0x00010004 0x00000008 0x80000008 0xba160283 0x10000000 0x00000000
```

**- Why I did it**

I need access to the `vcmailbox` utility.  This is included in the `master` branch's `raspi-utils` recipe, but that recipe is not included in the `scarthgap` branch