### PR TITLE
[scarthgap] Revert "rpi-default-versions: Switch default kernel to 6.12"

### DIFF
--- a/conf/machine/include/rpi-default-versions.inc
+++ b/conf/machine/include/rpi-default-versions.inc
@@ -1,4 +1,4 @@
 # RaspberryPi BSP default versions
 
-PREFERRED_VERSION_linux-raspberrypi ??= "6.12.%"
+PREFERRED_VERSION_linux-raspberrypi ??= "6.6.%"
 PREFERRED_VERSION_linux-raspberrypi-v7 ??= "${PREFERRED_VERSION_linux-raspberrypi}"


### PR DESCRIPTION
This reverts commit 8c916b683de8ca969b136524f03d2574af282bac.

Change like this doesn't belong to stable branch, people who want to use 6.12 can easily switch the P_V in their config.

As reported in:
https://github.com/agherzan/meta-raspberrypi/pull/1483

lttng-modules version in scarthgap fails to build with 6.12:

```
lttng-modules/2.13.12/lttng-modules-2.13.12/src/../include/wrapper/uprobes.h:28:16: error: too few arguments to function 'uprobe_register' lttng-modules-2.13.12/src/../include/wrapper/uprobes.h:34:9: error: implicit declaration of function 'uprobe_unregister'; did you mean 'uprobe_register'? [-Werror=implicit-function-declaration]
   34 |         uprobe_unregister(inode, offset, uc);
      |         ^~~~~~~~~~~~~~~~~
```