### PR TITLE
Revert "rpi-default-versions: Switch default kernel to 6.12"

### DIFF
--- a/conf/machine/include/rpi-default-versions.inc
+++ b/conf/machine/include/rpi-default-versions.inc
@@ -1,4 +1,4 @@
 # RaspberryPi BSP default versions
 
-PREFERRED_VERSION_linux-raspberrypi ??= "6.12.%"
+PREFERRED_VERSION_linux-raspberrypi ??= "6.6.%"
 PREFERRED_VERSION_linux-raspberrypi-v7 ??= "${PREFERRED_VERSION_linux-raspberrypi}"


### PR DESCRIPTION
This reverts commit 8c916b683de8ca969b136524f03d2574af282bac.

Change like this doesn't belong to stable branch, people who want to use 6.12 can easily switch the P_V in their config.
