### PR TITLE
raspberrypi3-64,raspberrypi4-64: Use nocrypto default tunes

### DIFF
--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -11,6 +11,7 @@ MACHINE_EXTRA_RRECOMMENDS += "\
     bluez-firmware-rpidistro-bcm4345c0-hcd \
 "
 
+DEFAULTTUNE ?= "cortexa53-nocrypto"
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 include conf/machine/include/rpi-base.inc
 

--- a/conf/machine/raspberrypi4-64.conf
+++ b/conf/machine/raspberrypi4-64.conf
@@ -12,6 +12,8 @@ MACHINE_EXTRA_RRECOMMENDS += "\
     bluez-firmware-rpidistro-bcm4345c5-hcd \
 "
 
+DEFAULTTUNE = "cortexa72-nocrypto"
+
 require conf/machine/include/arm/armv8a/tune-cortexa72.inc
 include conf/machine/include/rpi-base.inc
 


### PR DESCRIPTION
SOCs used in rpi3 and rpi4 do not have AES crypto HW engine denote it by using more appropriate default tune, this ensures that it enforces +nocrypto into -mtune regardless of gcc or clang compiler.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
