### PR TITLE
raspberrypi2.conf: add QB_ variables for runqemu

### DIFF
--- a/conf/machine/raspberrypi2.conf
+++ b/conf/machine/raspberrypi2.conf
@@ -12,3 +12,19 @@ SERIAL_CONSOLES ?= "115200;ttyAMA0"
 UBOOT_MACHINE = "rpi_2_config"
 
 ARMSTUB ?= "armstub7.bin"
+
+#
+# Below are variables ONLY needed for running with Yocto/OE's runqemu script
+#
+IMAGE_CLASSES += "qemuboot"
+
+QB_SYSTEM_NAME = "qemu-system-arm"
+QB_MACHINE = "-machine raspi2b"
+QB_MEM = "-m 1024"
+QB_DTB = "bcm2709-rpi-2-b.dtb"
+QB_NET = "none"
+QB_KERNEL_ROOT = "/dev/mmcblk0"
+QB_KERNEL_CMDLINE_APPEND = "rootwait"
+QB_RNG = ""
+QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=sd,format=raw"
+QB_DEFAULT_FSTYPE = "ext3"


### PR DESCRIPTION
Add the relevant QB_ variables sufficient to get the QEMU raspi2b model running with runqemu.

These changes require 
https://lists.openembedded.org/g/openembedded-core/message/222548
https://lists.openembedded.org/g/openembedded-core/message/222549
