### PR TITLE
[Scarthgap] rpi-base.inc: Add w1-gpio-pi5.dtbo

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -78,6 +78,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/vc4-kms-dsi-ili9881-7inch.dtbo \
     overlays/w1-gpio.dtbo \
     overlays/w1-gpio-pullup.dtbo \
+    overlays/w1-gpio-pi5.dtbo \
     overlays/wm8960-soundcard.dtbo \
     overlays/bcm2712d0.dtbo \
     "


### PR DESCRIPTION
Add `w1-gpio-pi5.dtbo` to `RPI_KERNEL_DEVICETREE_OVERLAYS` to resolve the following issue noticed in `vclog --msg` on Raspberry Pi 5 when `ENABLE_W1` is set to `1`:
```
dtdebug: mapped overlay 'w1-gpio' to 'w1-gpio-pi5'
dtdebug: Failed to open overlay file 'overlays/w1-gpio-pi5.dtbo'
```
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Fixed 1-wire support on Raspberry Pi 5.

**- How I did it**

Added w1-gpio-pi5.dtbo to `RPI_KERNEL_DEVICETREE_OVERLAYS`

**NOTE:** This is GitHub pull request #1524 ported from master to Scarthgap.