### PR TITLE
raspberrypi2-64.conf: add machine for Raspberry Pi 2B V1.2 (64-bit)

### DIFF
--- a/.github/workflows/yocto-builds.yml
+++ b/.github/workflows/yocto-builds.yml
@@ -20,6 +20,7 @@ jobs:
           - raspberrypi0-2w
           - raspberrypi0
           - raspberrypi0-wifi
+          - raspberrypi2-64
           - raspberrypi2
           - raspberrypi3-64
           - raspberrypi3

--- a/conf/machine/raspberrypi-armv8.conf
+++ b/conf/machine/raspberrypi-armv8.conf
@@ -23,6 +23,7 @@ MACHINE_EXTRA_RRECOMMENDS += "\
 "
 
 RPI_KERNEL_DEVICETREE = " \
+    broadcom/bcm2710-rpi-2-b.dtb \
     broadcom/bcm2710-rpi-3-b.dtb \
     broadcom/bcm2710-rpi-3-b-plus.dtb \
     broadcom/bcm2837-rpi-3-b.dtb \

--- a/conf/machine/raspberrypi2-64.conf
+++ b/conf/machine/raspberrypi2-64.conf
@@ -1,15 +1,8 @@
 #@TYPE: Machine
-#@NAME: RaspberryPi 3 Development Board
-#@DESCRIPTION: Machine configuration for the RaspberryPi 3 in 64 bits mode
+#@NAME: RaspberryPi 2 V1.2 Development Board
+#@DESCRIPTION: Machine configuration for the RaspberryPi 2 in 64 bits mode
 
-MACHINEOVERRIDES =. "raspberrypi3:"
-
-MACHINE_EXTRA_RRECOMMENDS += "\
-    linux-firmware-rpidistro-bcm43430 \
-    linux-firmware-rpidistro-bcm43455 \
-    bluez-firmware-rpidistro-bcm43430a1-hcd \
-    bluez-firmware-rpidistro-bcm4345c0-hcd \
-"
+MACHINEOVERRIDES =. "raspberrypi3-64:"
 
 DEFAULTTUNE ?= "cortexa53-nocrypto"
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc
@@ -31,7 +24,7 @@ KERNEL_IMAGETYPE_UBOOT ?= "Image"
 KERNEL_IMAGETYPE_DIRECT ?= "Image"
 KERNEL_BOOTCMD ?= "booti"
 UBOOT_MACHINE = "rpi_arm64_config"
-SERIAL_CONSOLES ?= "115200;ttyS0"
+SERIAL_CONSOLES ?= "115200;ttyAMA0"
 
 VC4DTBO ?= "vc4-fkms-v3d"
 ARMSTUB ?= "armstub8.bin"

--- a/docs/layer-contents.md
+++ b/docs/layer-contents.md
@@ -7,6 +7,7 @@
 * raspberrypi0-wifi
 * raspberrypi0-2w-64
 * raspberrypi2
+* raspberrypi2-64 (64 bit kernel & userspace)
 * raspberrypi3
 * raspberrypi3-64 (64 bit kernel & userspace)
 * raspberrypi4
@@ -14,6 +15,9 @@
 * raspberrypi5
 * raspberrypi-cm (dummy alias for raspberrypi)
 * raspberrypi-cm3
+
+Note: The raspberrypi2-64 machine includes 64-bit support for Raspberry Pi 2B
+V1.2.
 
 Note: The raspberrypi3 machines include support for Raspberry Pi 3B+.
 


### PR DESCRIPTION
This machine configuration is for the Raspberry Pi 2B V1.2 (64-bit).

Note: Raspberry Pi 2 Model B V1.2[1] switched from BCM2836[2] (V1.0, V1.1) to BCM2837[3] that is 64-bit CPU used in Raspberry Pi 3 Model B.

	BCM2836[2]

	The Broadcom chip used in the Raspberry Pi 2 Model B. The
	underlying architecture in BCM2836 is identical to BCM2835. The
	only significant difference is the removal of the ARM1176JZF-S
	processor and replacement with a quad-core Cortex-A7 cluster.

	BCM2837[3]

	This is the Broadcom chip used in the Raspberry Pi 3 Model B,
	later models of the Raspberry Pi 2 Model B, and the Raspberry Pi
	Compute Module 3. The underlying architecture of the BCM2837 is
	identical to the BCM2836. The only significant difference is the
	replacement of the ARMv7 quad core cluster with a quad-core ARM
	Cortex A53 (ARMv8) cluster.

	The ARM cores run at 1.2GHz, making the device about 50% faster
	than the Raspberry Pi 2. The VideoCore IV runs at 400MHz.

See:

	Poky (Yocto Project Reference Distro) 5.2.99+snapshot-cfbb00657ab961a3c3a8e6619fc08a2a3f4255c7 raspberrypi2-64 ttyAMA0

	raspberrypi2-64 login: root

	WARNING: Poky is a reference Yocto Project distribution that should be used for testing and development purposes only. It is recommended that you create your own distribution for production use.

	root@raspberrypi2-64:~# uname -a
	Linux raspberrypi2-64 6.12.41-v8 #1 SMP PREEMPT Thu Aug  7 16:48:46 UTC 2025 aarch64 GNU/Linux
	root@raspberrypi2-64:~# cat /proc/device-tree/compatible
	raspberrypi,2-model-b-rev2brcm,bcm2837
	root@raspberrypi2-64:~# tty
	/dev/ttyAMA0
	root@raspberrypi2-64:~# dmesg | head
	[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
	[    0.000000] Linux version 6.12.41-v8 (oe-user@oe-host) (aarch64-poky-linux-gcc (GCC) 15.2.0, GNU ld (GNU Binutils) 2.45.0.20250908) #1 SMP PREEMPT Thu Aug  7 16:48:46 UTC 2025
	[    0.000000] KASLR enabled
	[    0.000000] random: crng init done
	[    0.000000] Machine model: Raspberry Pi 2 Model B Rev 1.2
	[    0.000000] efi: UEFI not found.
	[    0.000000] Reserved memory: created CMA memory pool at 0x000000001ec00000, size 256 MiB
	[    0.000000] OF: reserved mem: initialized node linux,cma, compatible id shared-dma-pool
	[    0.000000] OF: reserved mem: 0x000000001ec00000..0x000000002ebfffff (262144 KiB) map reusable linux,cma
	[    0.000000] NUMA: Faking a node at [mem 0x0000000000000000-0x000000003b3fffff]

[1]: https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#flagship-series
[2]: https://www.raspberrypi.com/documentation/computers/processors.html#bcm2836
[3]: https://www.raspberrypi.com/documentation/computers/processors.html#bcm2837