### PR TITLE
Fix QA Issue, Files/directories were installed but not shipped in any…

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera-apps/libcamera-apps_git.bb
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/libcamera-apps/libcamera-apps_git.bb
@@ -40,5 +40,5 @@ do_install:append() {
     rm -v ${D}/${bindir}/camera-bug-report
 }
 
-# not picked automatically, because it's missing common 'lib' prefix
+FILES:${PN} += "${libdir}/rpicam_app.so*"
 FILES:${PN}-dev += "${libdir}/rpicam_app.so"


### PR DESCRIPTION
Fixes QA issue in `walnascar` Branch.
Building `rpicam-apps` results in an Issue during `package` step:
`libcamera-apps-1.4.2+git-r0 do_package: QA Issue: libcamera-apps: Files/directories were installed but not shipped in any package:
  /usr/lib/rpicam_app.so.1.4.2
`

**- What I did**
- Shifted all `rpicacm_app.so*` to `FILES:${PN} `
- Shifted `rpicacm_app.so` to `FILES:${PN}-dev `
