### PR TITLE
[Scarthgap] rpi-base.inc: Add rpi-backlight.dtbo

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -76,6 +76,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/vc4-kms-v3d-pi5.dtbo \
     overlays/vc4-kms-dsi-7inch.dtbo \
     overlays/vc4-kms-dsi-ili9881-7inch.dtbo \
+    overlays/rpi-backlight.dtbo \
     overlays/w1-gpio.dtbo \
     overlays/w1-gpio-pullup.dtbo \
     overlays/w1-gpio-pi5.dtbo \


### PR DESCRIPTION
Add `rpi-backlight.dtbo` to `RPI_KERNEL_DEVICETREE_OVERLAYS`. This is a devicetree overlay for mailbox-driven Raspberry Pi DSI Display backlight controller.

Backported from https://github.com/agherzan/meta-raspberrypi/pull/1533 to **Scarthgap**.

This work was sponsored by GOVCERT.LU.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Enabled `/sys/class/backlight/`. For example on Raspberry Pi 5:

```
root@raspberrypi5:~# cat /sys/class/backlight/10-0045/max_brightness
31
root@raspberrypi5:~# echo 5 > /sys/class/backlight/10-0045/brightness
root@raspberrypi5:~# echo 31 > /sys/class/backlight/10-0045/brightness
```

**- How I did it**

Addеd `rpi-backlight.dtbo` to `RPI_KERNEL_DEVICETREE_OVERLAYS`.