### PR TITLE
5" Raspberry Pi Touch Display 2

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -79,6 +79,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/vc4-kms-v3d-pi5.dtbo \
     overlays/vc4-kms-dsi-7inch.dtbo \
     overlays/vc4-kms-dsi-ili9881-7inch.dtbo \
+    overlays/vc4-kms-dsi-ili9881-5inch.dtbo \
     overlays/rpi-backlight.dtbo \
     overlays/w1-gpio.dtbo \
     overlays/w1-gpio-pullup.dtbo \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Support the 5" Raspberry Pi Touch Display 2.

**- How I did it**

Added `vc4-kms-dsi-ili9881-5inch.dtbo` to `RPI_KERNEL_DEVICETREE_OVERLAYS` for the 5" version of Raspberry Pi Touch Display 2.
