### PR TITLE
weston: add patch to adapt to 64-bit plane ids

### DIFF
--- a/recipes-graphics/wayland/weston/0001-Adapt-weston-to-64-bit-plane-IDs.patch
+++ b/recipes-graphics/wayland/weston/0001-Adapt-weston-to-64-bit-plane-IDs.patch
@@ -1,0 +1,76 @@
+From 845682f33511da676bfe9237102b6979efa11f93 Mon Sep 17 00:00:00 2001
+From: Gyorgy Sarvari <skandigraun@gmail.com>
+Date: Fri, 21 Nov 2025 18:07:00 +0100
+Subject: [PATCH] Adapt weston to 64-bit plane IDs
+
+The raspberry pi kernel has changed the plane IDs in their drm
+driver[1], which causes weston to crash upon mouse movement.
+
+This patch adapts the relevant variable sizes from 32-bit to
+64-bit.
+
+[1]: https://github.com/raspberrypi/linux/commit/8181e682d6f4ef209845ec24f0a1eb37764d6731
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/1902]
+---
+ libweston/backend-drm/drm-internal.h  |  4 ++--
+ libweston/backend-drm/state-propose.c | 10 +++++-----
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/libweston/backend-drm/drm-internal.h b/libweston/backend-drm/drm-internal.h
+index 48bc2432..c4391b39 100644
+--- a/libweston/backend-drm/drm-internal.h
++++ b/libweston/backend-drm/drm-internal.h
+@@ -410,7 +410,7 @@ struct drm_fb {
+ 	int width, height;
+ 	int fd;
+ 
+-	uint32_t plane_mask;
++	uint64_t plane_mask;
+ 
+ 	/* Used by gbm fbs */
+ 	struct gbm_bo *bo;
+diff --git a/libweston/backend-drm/state-propose.c b/libweston/backend-drm/state-propose.c
+index 2b42e3dc..0793b8fe 100644
+--- a/libweston/backend-drm/state-propose.c
++++ b/libweston/backend-drm/state-propose.c
+@@ -393,7 +393,7 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 	struct drm_fb *fb = NULL;
+ 
+ 	bool view_matches_entire_output, scanout_has_view_assigned;
+-	uint32_t possible_plane_mask = 0;
++	uint64_t possible_plane_mask = 0;
+ 
+ 	pnode->try_view_on_plane_failure_reasons = FAILURE_REASONS_NONE;
+ 
+@@ -437,7 +437,7 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 			return NULL;
+ 		}
+ 
+-		possible_plane_mask = (1 << output->cursor_plane->plane_idx);
++		possible_plane_mask = (1UL << output->cursor_plane->plane_idx);
+ 	} else {
+ 		if (mode == DRM_OUTPUT_PROPOSE_STATE_RENDERER_ONLY) {
+ 			drm_debug(b, "\t\t\t\t[view] not assigning view %p "
+@@ -450,7 +450,7 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 				continue;
+ 
+ 			if (drm_paint_node_transform_supported(pnode, plane))
+-				possible_plane_mask |= 1 << plane->plane_idx;
++				possible_plane_mask |= 1UL << plane->plane_idx;
+ 		}
+ 
+ 		if (!possible_plane_mask) {
+@@ -483,10 +483,10 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 		if (possible_plane_mask == 0)
+ 			break;
+ 
+-		if (!(possible_plane_mask & (1 << plane->plane_idx)))
++		if (!(possible_plane_mask & (1UL << plane->plane_idx)))
+ 			continue;
+ 
+-		possible_plane_mask &= ~(1 << plane->plane_idx);
++		possible_plane_mask &= ~(1UL << plane->plane_idx);
+ 
+ 		switch (plane->type) {
+ 		case WDRM_PLANE_TYPE_CURSOR:

--- a/recipes-graphics/wayland/weston_%.bbappend
+++ b/recipes-graphics/wayland/weston_%.bbappend
@@ -1,10 +1,4 @@
-PACKAGECONFIG:remove:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'fbdev', 'egl clients', d)}"
+PACKAGECONFIG:remove:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'egl clients', d)}"
 
-EXTRA_OECONF:append:rpi = " \
-    --disable-xwayland-test \
-    --disable-simple-egl-clients \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' \
-        --disable-resize-optimization \
-        --disable-setuid-install \
-    ', d)} \
-"
+FILESEXTRAPATHS:prepend := "${THISDIR}/weston:"
+SRC_URI:append:rpi = " file://0001-Adapt-weston-to-64-bit-plane-IDs.patch"


### PR DESCRIPTION
The raspberry pi kernel has [changed](https://github.com/raspberrypi/linux/commit/8181e682d6f4ef209845ec24f0a1eb37764d6731) the plane IDs in their drm driver, which causes weston to crash upon mouse movement.

This patch adapts the relevant variable sizes from 32-bit to 64-bit.

Since the kernel modification hasn't been upstreamed by rpi, this patch is deemed to be inappropriate for upstreaming to weston. (Edit: since then I contacted upstream weston about this. They didn't reject the idea outright, so I submitted it to them)

Also, clean up this bbappend: the main recipe has switched to meson long time ago, the autotools config options are obsolete, so remove them.

Beside that the `fbdev` PACKAGECONFIG doesn't exist anymore, so drop it from the removal list.

I have tested this patch successfully with rpi4-64, using scarthgap, core-image-weston.

Note: it is also possible to revert the kernel change (since it wasn't upstreamed by the rpi folks, reverting it would make it closer to the mainline kernel). If you would prefer that instead of this, let me know - I have the patch ready.

Fixes #1407 


<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
