### PR TITLE
kas: Replace poky

### DIFF
--- a/kas-poky-rpi.yml
+++ b/kas-poky-rpi.yml
@@ -9,12 +9,25 @@ target:
 repos:
   meta-raspberry:
 
-  poky:
-    url: https://git.yoctoproject.org/git/poky
-    path: layers/poky
+  bitbake:
+    url: https://git.openembedded.org/bitbake
+    path: layers/bitbake
+    branch: master
+    layers:
+      bitbake: disabled
+
+  openembedded-core:
+    url: https://git.openembedded.org/openembedded-core
+    path: layers/openembedded-core
     branch: master
     layers:
       meta:
+
+  meta-yocto:
+    url: https://git.yoctoproject.org/meta-yocto
+    path: layers/meta-yocto
+    branch: master
+    layers:
       meta-poky:
       meta-yocto-bsp:
 


### PR DESCRIPTION
Inspired by
 - yocto-builder/entrypoint-build.sh: Replace Poky [1]
 - meta-arm [2]

[1] https://github.com/agherzan/meta-raspberrypi/commit/9806b9981ad2cfed7591d158e5e905aff5f79683
[2] https://git.yoctoproject.org/meta-arm/tree/kas/corstone1000-base.yml

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
