### PR TITLE
meta-raspberrypi: Add Xorg conf for raspberrypi5

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/rpi/xorg.conf.d/99-v3d.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/rpi/xorg.conf.d/99-v3d.conf
@@ -1,0 +1,6 @@
+Section "OutputClass"
+  Identifier "vc4"
+  MatchDriver "vc4"
+  Driver "modesetting"
+  Option "PrimaryGPU" "true"
+EndSection

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
@@ -3,14 +3,16 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append:rpi = " \
     file://xorg.conf.d/98-pitft.conf \
     file://xorg.conf.d/99-calibration.conf \
+    file://xorg.conf.d/99-v3d.conf \
 "
 do_install:append:rpi () {
+    install -d ${D}/${sysconfdir}/X11/xorg.conf.d/
     PITFT="${@bb.utils.contains("MACHINE_FEATURES", "pitft", "1", "0", d)}"
     if [ "${PITFT}" = "1" ]; then
-        install -d ${D}/${sysconfdir}/X11/xorg.conf.d/
         install -m 0644 ${UNPACKDIR}/xorg.conf.d/98-pitft.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
         install -m 0644 ${UNPACKDIR}/xorg.conf.d/99-calibration.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
     fi
+    install -m 0644 ${UNPACKDIR}/xorg.conf.d/99-v3d.conf ${D}/${sysconfdir}/X11/xorg.conf.d/
 }
 
 FILES:${PN}:append:rpi = " ${sysconfdir}/X11/xorg.conf.d/*"


### PR DESCRIPTION
Specifying xorg to use the Raspberry Pi 5 GPU prevents boot failures caused by the xorg load framebuffer module.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
