### PR TITLE
rpi-base: Add missing hat_map.dtb

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -16,6 +16,7 @@ XSERVER = " \
 
 RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/overlay_map.dtb \
+    overlays/hat_map.dtb \
     overlays/at86rf233.dtbo \
     overlays/disable-bt.dtbo \
     overlays/disable-bt-pi5.dtbo \
@@ -152,7 +153,7 @@ def make_dtb_boot_files(d):
 
     def transform(dtb):
         base = os.path.basename(dtb)
-        if dtb.endswith('dtbo') or base == 'overlay_map.dtb':
+        if dtb.endswith('dtbo') or base == 'overlay_map.dtb' or base == 'hat_map.dtb':
             # overlay dtb:
             # eg: overlays/hifiberry-amp.dtbo has:
             #     DEPLOYDIR file: hifiberry-amp.dtbo


### PR DESCRIPTION
hat_map.dtb is required by the firmware to match HAT UUIDs from EEPROM data to their corresponding device tree overlays during boot. Without this file, HATs may fail to initialize properly even when their overlay files are present.

hat_map.dtb is generated and treated the same way overlay_map.dtb is. On the boot partition, it goes into the overlays/ directory, hence the special treatment.

**- What I did**
I changed rpi-base.inc so that hat_map.dtb is deployed and installed into the boot partition at the correct path.

**- How I did it**
It behaves just as overlay_map.dtb so I copied what was already in place to correctly handle that file.
The changes are minimal.