### PR TITLE
[Scarthgap] u-boot: Disable interrupt timeout for Raspberry Pi 5

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -9,6 +9,17 @@ SRC_URI:append:raspberrypi4 = " file://maxsize.cfg"
 
 DEPENDS:append:rpi = " u-boot-default-script"
 
+do_configure:append:raspberrypi5() {
+    # Remove any existing CONFIG_BOOTDELAY= lines
+    sed -i '/^CONFIG_BOOTDELAY=/d' "${B}/.config"
+    # Disable U-Boot interrupt timeout to avoid
+    # boot issues without a connected debug UART
+    # This is a known U-Boot issue discussed in:
+    # https://bugzilla.opensuse.org/show_bug.cgi?id=1251192
+    # https://lists.denx.de/pipermail/u-boot/2025-January/576305.html
+    echo "CONFIG_BOOTDELAY=-2" >> ${B}/.config
+}
+
 do_install:append:rpi () {
     install -d ${D}${sysconfdir}
     install -m 0644 ${WORKDIR}/fw_env.config ${D}${sysconfdir}/fw_env.config


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Disable U-Boot interrupt timeout for Raspberry Pi 5 to avoid boot issues without a connected debug UART. This is a known U-Boot issue discussed in:
https://bugzilla.opensuse.org/show_bug.cgi?id=1251192
https://lists.denx.de/pipermail/u-boot/2025-January/576305.html

The issue affects Raspberry Pi 5 with U-Boot version 2025.04 from branch scarthgap/u-boot of layer meta-lts-mixins.


**- How I did it**

By configuring U-Boot with `CONFIG_BOOTDELAY=-2` as [discussed in the U-Boot mailing list](https://lists.denx.de/pipermail/u-boot/2025-January/576305.html).
