### PR TITLE
Fix compilation of RPI-Userland on Whinlatter

### DIFF
--- a/recipes-graphics/userland/files/0026-fix_callback_types.patch
+++ b/recipes-graphics/userland/files/0026-fix_callback_types.patch
@@ -1,0 +1,39 @@
+From c2337c83c627dd94f9b673361dca6ffafca7f59b Mon Sep 17 00:00:00 2001
+From: Jonas Kvinge <jonas@jkvinge.net>
+Date: Sun, 6 Jul 2025 20:21:00 +0200
+Subject: [PATCH] Fix conflicting types build error
+
+Upstream-Status: Pending
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ interface/vchiq_arm/vchiq_lib.c       | 2 +-
+ interface/vmcs_host/vc_vchi_gpuserv.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/interface/vchiq_arm/vchiq_lib.c b/interface/vchiq_arm/vchiq_lib.c
+index 133d5ca..7a2dae5 100755
+--- a/interface/vchiq_arm/vchiq_lib.c
++++ b/interface/vchiq_arm/vchiq_lib.c
+@@ -537,7 +537,7 @@ vchiq_bulk_receive_handle(VCHIQ_SERVICE_HANDLE_T handle,
+    int size,
+    void *userdata,
+    VCHIQ_BULK_MODE_T mode,
+-   int (*copy_pagelist)())
++   int (*copy_pagelist)(char *vcptr, const struct pagelist_struct *pagelist))
+ {
+    VCHIQ_SERVICE_T *service = find_service_by_handle(handle);
+    VCHIQ_QUEUE_BULK_TRANSFER_T args;
+diff --git a/interface/vmcs_host/vc_vchi_gpuserv.h b/interface/vmcs_host/vc_vchi_gpuserv.h
+index fc0bfee..ce6cb58 100755
+--- a/interface/vmcs_host/vc_vchi_gpuserv.h
++++ b/interface/vmcs_host/vc_vchi_gpuserv.h
+@@ -58,7 +58,7 @@ struct sync_job_s {
+ 
+ struct gpu_callback_s {
+   // callback to call when complete (can be NULL)
+-  void (*func)();
++  void (*func)(void*);
+   void *cookie;
+ };
+ 
+-- 

--- a/recipes-graphics/userland/userland_git.bb
+++ b/recipes-graphics/userland/userland_git.bb
@@ -13,11 +13,11 @@ COMPATIBLE_MACHINE = "^rpi$"
 
 SRCBRANCH = "master"
 SRCFORK = "raspberrypi"
-SRCREV = "cc1ca18fb0689b01cc2ca2aa4b400dcee624a213"
+SRCREV = "a54a0dbb2b8dcf9bafdddfc9a9374fb51d97e976"
 
 # Use the date of the above commit as the package version. Update this when
 # SRCREV is changed.
-PV = "20230419"
+PV = "20242312"
 
 SRC_URI = "\
     git://github.com/${SRCFORK}/userland.git;protocol=https;branch=${SRCBRANCH} \
@@ -47,6 +47,7 @@ SRC_URI = "\
     file://0023-hello_pi-optionally-build-wayland-specific-app.patch \
     file://0024-userland-Sync-needed-defines-for-weston-build.patch \
     file://0025-CMakeLists.txt-.pc-respect-CMAKE_INSTALL_LIBDIR.patch \
+    file://0026-fix_callback_types.patch \
 "
 
 SRC_URI:remove:toolchain-clang = "file://0021-cmake-Disable-format-overflow-warning-as-error.patch"
@@ -57,7 +58,9 @@ ASNEEDED = ""
 
 EXTRA_OECMAKE = "-DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS='-Wl,--no-as-needed' \
                  -DVMCS_INSTALL_PREFIX=${exec_prefix} \
+                 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 "
+
 
 EXTRA_OECMAKE:append:aarch64 = " -DARM64=ON "
 


### PR DESCRIPTION
Imports patch also used in Buildroot

**- What I did**
Fixes compilation of RPI Userland on Whinlatter
**- How I did it**
Import a patch also previously used in Buildroot (they've removed Userland support altogether at this point)

Also relates to issue #1536 