### PR TITLE
Add configuration file to use bitbake-setup tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,25 @@ And the same for the `distro`.
 
 For further information, you can read more at <https://kas.readthedocs.io/en/latest/index.html>
 
+## Quick Start with bitbake-setup
+1. Initialize the setup,
+```
+bitbake/bin/bitbake-setup init meta-raspberrypi/configurations/poky-rpi-master.conf.json
+
+or
+
+bitbake/bin/bitbake-setup init https://raw.githubusercontent.com/agherzan/meta-raspberrypi/bitbake-setup/configurations/poky-rpi-master.conf.json
+```
+2. Select the required configurations.
+3. Source init-build-env from `bitbake-builds/oe-nodistro-rpi-master/build`.
+4. bitbake core-image-base
+5. Use bmaptool to copy the generated wic image to SD card
+6. Boot your RPI
+
+Currently following 2 configs are available,
+1. poky-rpi-master.conf.json
+2. oe-nodistro-rpi-master.conf.json
+
 ## Contributing
 
 You can send patches using the GitHub pull request process or/and through the

--- a/configurations/oe-nodistro-rpi-master.conf.json
+++ b/configurations/oe-nodistro-rpi-master.conf.json
@@ -1,0 +1,77 @@
+{
+    "description": "OpenEmbedded - 'nodistro' basic configuration",
+    "sources": {
+        "bitbake": {
+            "git-remote": {
+                "remotes": {
+                    "origin": {
+                        "uri": "https://git.openembedded.org/bitbake"
+                    }
+                },
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "openembedded-core": {
+            "git-remote": {
+                "remotes": {
+                    "origin": {
+                        "uri": "https://git.openembedded.org/openembedded-core"
+                    }
+                },
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "meta-yocto": {
+            "git-remote": {
+                "remotes": {
+                    "origin": {
+                        "uri": "https://git.yoctoproject.org/meta-yocto"
+                    }
+                },
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "meta-openembedded": {
+            "git-remote": {
+                "remotes": {
+                    "origin": {
+                        "uri": "http://git.openembedded.org/meta-openembedded"
+                    }
+                },
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "meta-raspberrypi": {
+            "git-remote": {
+                "remotes": {
+                    "origin": {
+                        "uri": "https://github.com/agherzan/meta-raspberrypi.git"
+                    }
+                },
+                "branch": "master",
+                "rev": "master"
+            }
+        }
+    },
+    "bitbake-setup": {
+        "configurations": [
+        {
+            "name": "nodistro",
+            "description": "OpenEmbedded 'nodistro'",
+            "setup-dir-name": "oe-nodistro-rpi-master",
+            "bb-layers": ["openembedded-core/meta","meta-yocto/meta-yocto-bsp","meta-yocto/meta-poky", "meta-openembedded/meta-oe","meta-openembedded/meta-python","meta-openembedded/meta-networking","meta-openembedded/meta-perl", "meta-raspberrypi"],
+            "oe-fragments-one-of": {
+                "machine": {
+                    "description": "Target machines",
+                    "options" : ["machine/raspberrypi-armv7", "machine/raspberrypi-armv8", "machine/raspberrypi-cm", "machine/raspberrypi-cm3", "machine/raspberrypi-cm5-io-board", "machine/raspberrypi", "machine/raspberrypi0-2w-64", "machine/raspberrypi0-2w", "machine/raspberrypi0-wifi", "machine/raspberrypi0", "machine/raspberrypi2-64", "machine/raspberrypi2", "machine/raspberrypi3-64", "machine/raspberrypi3", "machine/raspberrypi4-64", "machine/raspberrypi4", "machine/raspberrypi5"]
+                }
+            }
+        }
+        ]
+    },
+    "version": "1.0"
+}

--- a/configurations/poky-rpi-master.conf.json
+++ b/configurations/poky-rpi-master.conf.json
@@ -1,0 +1,90 @@
+{
+    "description": "Poky - The Yocto Project testing distribution configurations and hardware test platforms",
+    "sources": {
+        "bitbake": {
+            "git-remote": {
+                "remotes": {
+                    "origin": {
+                        "uri": "https://git.openembedded.org/bitbake"
+                    }
+                },
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "openembedded-core": {
+            "git-remote": {
+                "remotes": {
+                    "origin": {
+                        "uri": "https://git.openembedded.org/openembedded-core"
+                    }
+                },
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "meta-yocto": {
+            "git-remote": {
+                "remotes": {
+                    "origin": {
+                        "uri": "https://git.yoctoproject.org/meta-yocto"
+                    }
+                },
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "meta-openembedded": {
+            "git-remote": {
+                "remotes": {
+                    "origin": {
+                        "uri": "http://git.openembedded.org/meta-openembedded"
+                    }
+                },
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "meta-raspberrypi": {
+            "git-remote": {
+                "remotes": {
+                    "origin": {
+                        "uri": "https://github.com/agherzan/meta-raspberrypi.git"
+                    }
+                },
+                "branch": "master",
+                "rev": "master"
+            }
+        }
+    },
+    "bitbake-setup": {
+        "configurations": [
+        {
+            "bb-layers": ["openembedded-core/meta","meta-yocto/meta-yocto-bsp","meta-yocto/meta-poky", "meta-openembedded/meta-oe","meta-openembedded/meta-python","meta-openembedded/meta-networking","meta-openembedded/meta-perl", "meta-raspberrypi"],
+            "setup-dir-name": "$distro-rpi-master",
+            "oe-fragments-one-of": {
+                "machine": {
+                    "description": "Target machines",
+                    "options" : ["machine/raspberrypi-armv7", "machine/raspberrypi-armv8", "machine/raspberrypi-cm", "machine/raspberrypi-cm3", "machine/raspberrypi-cm5-io-board", "machine/raspberrypi", "machine/raspberrypi0-2w-64", "machine/raspberrypi0-2w", "machine/raspberrypi0-wifi", "machine/raspberrypi0", "machine/raspberrypi2-64", "machine/raspberrypi2", "machine/raspberrypi3-64", "machine/raspberrypi3", "machine/raspberrypi4-64", "machine/raspberrypi4", "machine/raspberrypi5"]
+                },
+                "distro": {
+                    "description": "Distribution configuration variants",
+                    "options" : ["distro/poky", "distro/poky-altcfg", "distro/poky-tiny"]
+                }
+            },
+            "configurations": [
+            {
+                "name": "poky",
+                "description": "Poky - The Yocto Project testing distribution"
+            },
+            {
+                "name": "poky-with-sstate",
+                "description": "Poky - The Yocto Project testing distribution with internet sstate acceleration. Use with caution as it requires a completely robust local network with sufficient bandwidth.",
+                "oe-fragments": ["core/yocto/sstate-mirror-cdn"]
+            }
+            ]
+        }
+        ]
+    },
+    "version": "1.0"
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Added new configuration file for setting workspace using the new bitbake-setup tool.
Only one configuration file is added currently, _poky-rpi-master.conf.json_.

**- How I did it**
1. Added configuration inside, `configurations/poky-rpi-master.conf.json`.
2. Updated `README.md` for bitbake-setup usage.