### PR TITLE
linux-raspberrypi-6.12: Upgrade to 6.12.83

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_6.12.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_6.12.bb
@@ -1,9 +1,9 @@
-LINUX_VERSION ?= "6.12.58"
+LINUX_VERSION ?= "6.12.83"
 LINUX_RPI_BRANCH ?= "rpi-6.12.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-6.12"
 
-SRCREV_machine = "cf8f90deed1491b7ed365944b2a10799595373a6"
-SRCREV_meta = "6a551cd6cf63d4199bc51ef778692f23730dbcca"
+SRCREV_machine = "7ee4e3228980c49dada14ec98dd74c5dcfdddafc"
+SRCREV_meta = "1a28be589c9aa79335563af67fbce0dadf570537"
 
 KMETA = "kernel-meta"
 


### PR DESCRIPTION
This bumps to latest 6.12 on linux-rpi's rpi-6.12.y branch, matching linux-yocto in oe-core as of this posting.  The major motivator is to get the fix for building perf with glibc 2.43.