### PR TITLE
gstreamer1.0-plugins-bad: enable v4l2codecs

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,2 +1,2 @@
-PACKAGECONFIG:append:rpi = " hls \
+PACKAGECONFIG:append:rpi = " hls v4l2codecs \
                    ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'faad', '', d)}"


### PR DESCRIPTION
v4l2codecs provides v4l2slh265dec needed for using the hevc hw decoder.