### PR TITLE
linux-raspberrypi: add recipe for 6.18

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-v7_6.18.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-v7_6.18.bb
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Andrei Gherzan <andrei.gherzan@huawei.com>
+#
+# SPDX-License-Identifier: MIT
+
+require linux-raspberrypi-v7.inc
+require linux-raspberrypi_6.18.bb

--- a/recipes-kernel/linux/linux-raspberrypi_6.18.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_6.18.bb
@@ -1,0 +1,31 @@
+LINUX_VERSION ?= "6.18.33"
+LINUX_RPI_BRANCH ?= "rpi-6.18.y"
+LINUX_RPI_KMETA_BRANCH ?= "yocto-6.18"
+
+SRCREV_machine = "95b85bebbedcaedfa7ca79116ed38b7376fba412"
+SRCREV_meta = "6d012fbc35201ba081efcc19c9519c1dc7b64c43"
+
+KMETA = "kernel-meta"
+
+SRC_URI = " \
+    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH};protocol=https \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
+    file://powersave.cfg \
+    file://android-drivers.cfg \
+    "
+
+require linux-raspberrypi.inc
+
+KERNEL_DTC_FLAGS += "-@ -H epapr"
+
+RDEPENDS:${KERNEL_PACKAGE_NAME}:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-base:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-base"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-image:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-image"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-dev:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-dev"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-vmlinux:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-vmlinux"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-modules:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-modules"
+RDEPENDS:${KERNEL_PACKAGE_NAME}-dbg:raspberrypi-armv7:append = " ${RASPBERRYPI_v7_KERNEL_PACKAGE_NAME}-dbg"
+
+DEPLOYDEP = ""
+DEPLOYDEP:raspberrypi-armv7 = "${RASPBERRYPI_v7_KERNEL}:do_deploy"
+do_deploy[depends] += "${DEPLOYDEP}"


### PR DESCRIPTION
**- What I did**

 Added recipes for the Linux 6.18 kernel alongside the existing 6.1, 6.6 and 6.12 recipes.

Note that 6.18 is **not yet considered stable on Raspberry Pi OS**: upstream has not cut a `stable_*` tag against the `rpi-6.18.y` series, and users on the Raspberry Pi forums are still reporting regressions. The default kernel in `conf/machine/include/rpi-default-versions.inc` is therefore intentionally left at 6.12.

**- How I did it**

Mirrored the existing 6.12 recipe pair, only changing the version-specific values