### PR TITLE
linux-raspberrypi: switch protocol of yocto-kernel-cache to https

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-dev.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-dev.bb
@@ -21,7 +21,7 @@ KMETA = "kernel-meta"
 
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH};protocol=https \
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA};protocol=https \
     file://powersave.cfg \
     file://android-drivers.cfg \
     "

--- a/recipes-kernel/linux/linux-raspberrypi_6.1.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_6.1.bb
@@ -9,7 +9,7 @@ KMETA = "kernel-meta"
 
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH};protocol=https \
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA};protocol=https \
     file://powersave.cfg \
     file://android-drivers.cfg \
     "

--- a/recipes-kernel/linux/linux-raspberrypi_6.12.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_6.12.bb
@@ -9,7 +9,7 @@ KMETA = "kernel-meta"
 
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH};protocol=https \
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA};protocol=https \
     file://powersave.cfg \
     file://android-drivers.cfg \
     "

--- a/recipes-kernel/linux/linux-raspberrypi_6.6.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_6.6.bb
@@ -9,7 +9,7 @@ KMETA = "kernel-meta"
 
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH};protocol=https \
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA};protocol=https \
     file://powersave.cfg \
     file://android-drivers.cfg \
     "


### PR DESCRIPTION
For upstream yocto mirrors the git protocol was disabled lately. Appended 'protocol=https' in corresponding SRC_URIs to fixes following error:

   ERROR: ExpansionError during parsing [...]/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi-dev.bb
   bb.data_smart.ExpansionError: [...] \
   	ls-remote git://git.yoctoproject.org/yocto-kernel-cache  failed with exit code 128, output:
   fatal: unable to connect to git.yoctoproject.org:
   git.yoctoproject.org[0: 104.18.0.115]: errno=Connection timed out
   git.yoctoproject.org[1: 104.18.1.115]: errno=Connection timed out
   git.yoctoproject.org[2: 2606:4700::6812:73]: errno=Network is unreachable
   git.yoctoproject.org[3: 2606:4700::6812:173]: errno=Network is unreachable

   The variable dependency chain for the failure is: fetcher_hashes_dummyfunc[vardepvalue]

   ERROR: Parsing halted due to errors, see error messages above

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
Fixed the fetcher failure during recipe parsing due to lately disabled git protocol on git.yoctoproject.org
**- How I did it**
Added protocol=https to switch to now only available https protocol