### PR TITLE
rpi-eeprom: devtool check-upgrade-status

### DIFF
--- a/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
+++ b/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
 "
 
 SRCREV = "2349daafacfb7a7abe2cfecf30a49ae837bdf2c6"
-PV = "v2025.07.17-2712"
+PV = "2025.07.17-2712"
 
 RDEPENDS:${PN} += " \
     coreutils \
@@ -65,3 +65,5 @@ INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 QAPATHTEST[arch] = ""
 
 COMPATIBLE_MACHINE = "raspberrypi4|raspberrypi4-64|raspberrypi5"
+
+UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d{4}\.\d{2}\.\d{2}-\d+)$"


### PR DESCRIPTION
before:
  rpi-eeprom                v2025.07.17-2712 UNKNOWN_BROKEN  None 05d94be4554ce44a057bfce8d0dd37d951703dab
now:
  rpi-eeprom                2025.07.17-2712 2026.05.11-2712 None e25fc5dcb8eb072eafb745cd546c3d9f73d102b5
