### PR TITLE
linux-raspberrypi_6.12: bump SRCREV to rpi-6.12.y HEAD (6.12.93)

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_6.12.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_6.12.bb
@@ -1,9 +1,9 @@
-LINUX_VERSION ?= "6.12.25"
+LINUX_VERSION ?= "6.12.93"
 LINUX_RPI_BRANCH ?= "rpi-6.12.y"
 LINUX_RPI_KMETA_BRANCH ?= "yocto-6.12"
 
-SRCREV_machine = "3dd2c2c507c271d411fab2e82a2b3b7e0b6d3f16"
-SRCREV_meta = "1f6ab68a1d86836bf1b82b791df03da3cfeacb3f"
+SRCREV_machine = "d8ab4e908235da7727f22dd36ad5af224671677d"
+SRCREV_meta = "e66f40994fc740818776a0f3af55e8b6d74bfbef"
 
 KMETA = "kernel-meta"
 


### PR DESCRIPTION
Bumps `linux-raspberrypi_6.12` from 6.12.25 (April 2025) to 6.12.93 (rpi-6.12.y HEAD, 2026-06-12).

This captures `raspberrypi/linux` PR [#7023](https://github.com/raspberrypi/linux/pull/7023) ("ARM: dts: Select the PL011 platform driver", merged 2025-09-25), which switches the BCM2711 PL011 UART nodes in `bcm2711-rpi-ds.dtsi` to the `arm,pl011-axi` compatible. Without that change, the in-kernel `hci_uart_bcm` driver fails to bring up the BCM43455 Bluetooth chip on the Raspberry Pi 4 / CM4 (`hci0: command 0xfc18 tx timeout`);

Also brings ~14 months of stable point-release fixes including CVE backports — relevant to anyone running `cve-check` against current scarthgap images.

  ```
  LINUX_VERSION    : 6.12.25 -> 6.12.93
  SRCREV_machine   : 3dd2c2c5... -> d8ab4e90... (rpi-6.12.y HEAD)
  SRCREV_meta      : 1f6ab68a... -> e66f4099... (yocto-6.12 HEAD)
  ```

  Tested locally on `raspberrypi4-64` MACHINE on a Compute Module 4 carrier; BT bringup confirmed working (hci0 UP RUNNING with a real BD Address), WiFi unaffected, RAUC update flow unaffected.

  Closes: #1605