### PR TITLE
rpi-config: enable RPi 3 x64 audio support only with 'ENABLE_AUDIO_BCM2835'

### DIFF
--- a/docs/extra-build-config.md
+++ b/docs/extra-build-config.md
@@ -398,6 +398,13 @@ discovered via all 1-Wire busses check the interface with this command
 
 `ls /sys/bus/w1/devices/`
 
+## Enable audio BCM2835 sound support
+
+Audio driver for BCM2835 depends on the 'snd_bcm2835' module.
+To enable the audio support explicitly set it in `local.conf`
+
+    ENABLE_AUDIO_BCM2835 = "1"
+
 ## Manual additions to config.txt
 
 The `RPI_EXTRA_CONFIG` variable can be used to manually add additional lines to

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -339,8 +339,11 @@ do_deploy:append:raspberrypi3-64() {
     echo "# have a properly sized image" >> $CONFIG
     echo "disable_overscan=1" >> $CONFIG
 
-    echo "# Enable audio (loads snd_bcm2835)" >> $CONFIG
-    echo "dtparam=audio=on" >> $CONFIG
+    # Audio support
+    if [ "${ENABLE_AUDIO_BCM2835}" = "1" ]; then
+        echo "# Enable audio (loads snd_bcm2835)" >> $CONFIG
+        echo "dtparam=audio=on" >> $CONFIG
+    fi
 }
 
 do_deploy:append() {

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -200,7 +200,7 @@ do_deploy() {
         esac
     fi
 
-    if [ "${ENABLE_UART}"  = "1" ] && [ "${MACHINE}" = "raspberrypi-cm5-io-board" ]; then
+    if [ "${ENABLE_UART}" = "1" ] && [ "${MACHINE}" = "raspberrypi-cm5-io-board" ]; then
         # Enable UART on the 40-pin header of the CM5 IO Board
         echo "dtoverlay=uart0" >>$CONFIG
         echo "dtparam=uart0_console" >>$CONFIG


### PR DESCRIPTION
By enabling the audio module automatically only on RPi 3 x64 machines, the PWM* lines may get reused for audio purposes unwillingly, introducing a disparity with other RPi boards using the same sources

Create 'ENABLE_AUDIO' build constant to enable the audio support