### PR TITLE
Fix license warnings about the old syntax by updating to the new identifiers

### DIFF
--- a/dynamic-layers/multimedia-layer/recipes-multimedia/libpisp/libpisp_1.3.0.bb
+++ b/dynamic-layers/multimedia-layer/recipes-multimedia/libpisp/libpisp_1.3.0.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "A helper library to generate run-time configuration for the Raspberry Pi \
 ISP (PiSP), consisting of the Frontend and Backend hardware components."
 HOMEPAGE = "https://github.com/raspberrypi/libpisp"
-LICENSE = "BSD-2-Clause & GPL-2.0-only & GPL-2.0-or-later"
+LICENSE = "BSD-2-Clause AND GPL-2.0-only AND GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3417a46e992fdf62e5759fba9baef7a7 \
                     file://LICENSES/GPL-2.0-only.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
                     file://LICENSES/GPL-2.0-or-later.txt;md5=fed54355545ffd980b814dab4a3b312c"

--- a/recipes-bsp/bootfiles/rpi-bootfiles.bb
+++ b/recipes-bsp/bootfiles/rpi-bootfiles.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Closed source binary files to help boot all raspberry pi devices."
-LICENSE = "Broadcom-RPi"
+LICENSE = "LicenseRef-Broadcom-RPi"
 
 LIC_FILES_CHKSUM = "file://LICENCE.broadcom;md5=c403841ff2837657b2ed8e5bb474ac8d"
 

--- a/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
+++ b/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Installation scripts and binaries for the Raspberry Pi 4 EEPROM"
 DESCRIPTION = "This repository contains the rpi4/rpi5 bootloader and scripts \
 for updating it in the spi eeprom"
-LICENSE = "BSD-3-Clause & Broadcom-RPi"
+LICENSE = "BSD-3-Clause AND LicenseRef-Broadcom-RPi"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a6c5149578a16272119f3f9c13d6549b"
 
 SRC_URI = " \

--- a/recipes-graphics/vc-graphics/vc-graphics.inc
+++ b/recipes-graphics/vc-graphics/vc-graphics.inc
@@ -1,5 +1,5 @@
 DESCRIPTION = "Graphics libraries for BCM2835."
-LICENSE = "Broadcom-RPi"
+LICENSE = "LicenseRef-Broadcom-RPi"
 
 LIC_FILES_CHKSUM = "file://LICENCE;md5=86e53f5f5909ee66900418028de11780"
 

--- a/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
+++ b/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bb
@@ -14,7 +14,7 @@ SECTION = "kernel"
 # conflicts with linux-firmware.
 #
 # [^1]: https://github.com/RPi-Distro/bluez-firmware/issues/1
-LICENSE = "Firmware-cypress-rpidistro"
+LICENSE = "LicenseRef-Firmware-cypress-rpidistro"
 LIC_FILES_CHKSUM = "\
     file://LICENCE.cypress-rpidistro;md5=be80828daf682762f392131141288a74 \
 "
@@ -61,12 +61,12 @@ PACKAGES = "\
     ${PN}-bcm4345c5-hcd \
 "
 
-LICENSE:${PN}-bcm43430a1-hcd = "Firmware-cypress-rpidistro"
-LICENSE:${PN}-bcm43430b0-hcd = "Firmware-cypress-rpidistro"
-LICENSE:${PN}-bcm4343a2-hcd = "Firmware-cypress-rpidistro"
-LICENSE:${PN}-bcm4345c0-hcd = "Firmware-cypress-rpidistro"
-LICENSE:${PN}-bcm4345c5-hcd = "Firmware-cypress-rpidistro"
-LICENSE:${PN}-cypress-license = "Firmware-cypress-rpidistro"
+LICENSE:${PN}-bcm43430a1-hcd = "LicenseRef-Firmware-cypress-rpidistro"
+LICENSE:${PN}-bcm43430b0-hcd = "LicenseRef-Firmware-cypress-rpidistro"
+LICENSE:${PN}-bcm4343a2-hcd = "LicenseRef-Firmware-cypress-rpidistro"
+LICENSE:${PN}-bcm4345c0-hcd = "LicenseRef-Firmware-cypress-rpidistro"
+LICENSE:${PN}-bcm4345c5-hcd = "LicenseRef-Firmware-cypress-rpidistro"
+LICENSE:${PN}-cypress-license = "LicenseRef-Firmware-cypress-rpidistro"
 
 FILES:${PN}-cypress-license = "\
     ${nonarch_base_libdir}/firmware/LICENCE.cypress-rpidistro \

--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -5,7 +5,7 @@ to linux-firmware for general use."
 HOMEPAGE = "https://github.com/RPi-Distro/firmware-nonfree"
 SECTION = "kernel"
 
-LICENSE = "GPL-2.0-only & binary-redist-Cypress-rpidistro & Synaptics-rpidistro"
+LICENSE = "GPL-2.0-only AND LicenseRef-binary-redist-Cypress-rpidistro AND LicenseRef-Synaptics-rpidistro"
 LIC_FILES_CHKSUM = "\
     file://debian/copyright;md5=454e44c688dc909e16223e4aee63568c \
 "
@@ -66,12 +66,12 @@ PACKAGES = "\
     ${PN}-module-conf \
 "
 
-LICENSE:${PN}-bcm43430 = "binary-redist-Cypress-rpidistro"
-LICENSE:${PN}-bcm43436 = "Synaptics-rpidistro"
-LICENSE:${PN}-bcm43436s = "Synaptics-rpidistro"
-LICENSE:${PN}-bcm43439 = "Synaptics-rpidistro"
-LICENSE:${PN}-bcm43455 = "binary-redist-Cypress-rpidistro"
-LICENSE:${PN}-bcm43456 = "Synaptics-rpidistro"
+LICENSE:${PN}-bcm43430 = "LicenseRef-binary-redist-Cypress-rpidistro"
+LICENSE:${PN}-bcm43436 = "LicenseRef-Synaptics-rpidistro"
+LICENSE:${PN}-bcm43436s = "LicenseRef-Synaptics-rpidistro"
+LICENSE:${PN}-bcm43439 = "LicenseRef-Synaptics-rpidistro"
+LICENSE:${PN}-bcm43455 = "LicenseRef-binary-redist-Cypress-rpidistro"
+LICENSE:${PN}-bcm43456 = "LicenseRef-Synaptics-rpidistro"
 LICENSE:${PN}-license = "GPL-2.0-only"
 
 FILES:${PN}-bcm43430 = " \

--- a/recipes-multimedia/picamera-libs/picamera-libs.bb
+++ b/recipes-multimedia/picamera-libs/picamera-libs.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Raspberrypi firmware libraries which are required by picamera library"
 DESCRIPTION = "Raspberrypi firmware libraries required by picamera library"
-LICENSE = "Broadcom-RPi"
+LICENSE = "LicenseRef-Broadcom-RPi"
 
 LIC_FILES_CHKSUM = "file://opt/vc/LICENCE;md5=86e53f5f5909ee66900418028de11780"
 

--- a/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_7.1.13.bb
+++ b/recipes-multimedia/rpidistro-ffmpeg/rpidistro-ffmpeg_7.1.13.bb
@@ -5,7 +5,7 @@ DESCRIPTION = "FFmpeg is the leading multimedia framework, able to decode, encod
 HOMEPAGE = "https://www.ffmpeg.org/"
 SECTION = "libs"
 
-LICENSE = "GPL-2.0-or-later & LGPL-2.1-or-later & ISC & MIT & BSD-2-Clause & BSD-3-Clause & IJG"
+LICENSE = "GPL-2.0-or-later AND LGPL-2.1-or-later AND ISC AND MIT AND BSD-2-Clause AND BSD-3-Clause AND IJG"
 LICENSE:${PN} = "GPL-2.0-or-later"
 LICENSE:libavcodec = "${@bb.utils.contains('PACKAGECONFIG', 'gpl', 'GPL-2.0-or-later', 'LGPL-2.1-or-later', d)}"
 LICENSE:libavdevice = "${@bb.utils.contains('PACKAGECONFIG', 'gpl', 'GPL-2.0-or-later', 'LGPL-2.1-or-later', d)}"


### PR DESCRIPTION
Resolve license warnings regarding the old syntax by updating to the new identifiers: LicenseRef-binary-redist-Cypress-rpidistro, LicenseRef-Synaptics-rpidistro and LicenseRef-Firmware-cypress-rpidistro.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

* `linux-firmware-rpidistro`

Fix license warnings like:

```
WARNING: linux-firmware-rpidistro: LICENSE is using an old syntax and should be upgraded to: "GPL-2.0-only AND LicenseRef-Synaptics-rpidistro AND LicenseRef-binary-redist-Cypress-rpidistro"
WARNING: linux-firmware-rpidistro: LICENSE:linux-firmware-rpidistro-bcm43430 is using an old syntax and should be upgraded to: "LicenseRef-binary-redist-Cypress-rpidistro"
WARNING: linux-firmware-rpidistro: LICENSE:linux-firmware-rpidistro-bcm43436 is using an old syntax and should be upgraded to: "LicenseRef-Synaptics-rpidistro"
```

* `LICENSE` for `rpi-eeprom`, `rpi-bootfiles` and `vc-graphics`

* `bluez-firmware-rpidistro`

Replaced `Firmware-cypress-rpidistro` with `LicenseRef-Firmware-cypress-rpidistro`.
    
Fixes:

```
WARNING: bluez-firmware-rpidistro: LICENSE is using an old syntax and should be upgraded to: "LicenseRef-Firmware-cypress-rpidistro"
```

**- How I did it**

Replaced `binary-redist-Cypress-rpidistro` with `LicenseRef-binary-redist-Cypress-rpidistro`, `Synaptics-rpidistro` with `LicenseRef-Synaptics-rpidistro` and `Firmware-cypress-rpidistro` with `LicenseRef-Firmware-cypress-rpidistro`.
