### PR TITLE
rpi-u-boot-scr: oe.kernel.map_uboot_arch

### DIFF
--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -16,7 +16,7 @@ do_compile() {
         -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
         -e 's/@@BOOT_MEDIA@@/${BOOT_MEDIA}/' \
         "${UNPACKDIR}/boot.cmd.in" > "${WORKDIR}/boot.cmd"
-    mkimage -A ${UBOOT_ARCH} -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
+    mkimage -A ${@oe.kernel.map_uboot_arch(d)} -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
 }
 
 inherit kernel-arch deploy nopackages


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Fixed:

```
ERROR: rpi-u-boot-scr-1.0-r0 do_compile:
```

```
Log data follows:
| DEBUG: Executing shell function do_compile
| 
| Invalid architecture, supported are:
| 	alpha            Alpha
| 	arc              ARC
| 	arm              ARM
| 	arm64            AArch64
| 	avr32            AVR32
| 	blackfin         Blackfin
| 	ia64             IA64
| 	invalid          Invalid ARCH
| 	m68k             M68K
| 	microblaze       MicroBlaze
| 	mips             MIPS
| 	mips64           MIPS 64 Bit
| 	nds32            NDS32
| 	nios2            NIOS II
| 	or1k             OpenRISC 1000
| 	powerpc          PowerPC
| 	riscv            RISC-V
| 	s390             IBM S390
| 	sandbox          Sandbox
| 	sh               SuperH
| 	sparc            SPARC
| 	sparc64          SPARC 64 Bit
| 	x86              Intel x86
| 	x86_64           AMD x86_64
| 	xtensa           Xtensa
| 
| Error: Invalid architecture
| Usage: mkimage [-T type] -l image
|           -l ==> list image header information
|           -T ==> parse image file as 'type'
|           -q ==> quiet
|        mkimage [-x] -A arch -O os -T type -C comp -a addr -e ep -n name -d data_file[:data_file...] image
|           -A ==> set architecture to 'arch'
|           -O ==> set operating system to 'os'
|           -T ==> set image type to 'type'
|           -C ==> set compression type 'comp'
|           -a ==> set load address to 'addr' (hex)
|           -e ==> set entry point to 'ep' (hex)
|           -n ==> set image name to 'name'
|           -R ==> set second image name to 'name'
|           -d ==> use image data from 'datafile'
|           -x ==> set XIP (execute in place)
|           -s ==> create an image with no data
|           -y ==> append TFA BL31 file to the image
|           -Y ==> set TFA BL31 file load and entry point address
|           -z ==> append raw TEE file to the image
|           -Z ==> set raw TEE file load and entry point address
|           -v ==> verbose
|        mkimage [-D dtc_options] [-f fit-image.its|-f auto|-f auto-conf|-F] [-b <dtb> [-b <dtb>]] [-E] [-B size] [-i <ramdisk.cpio.gz>] fit-image
|            <dtb> file is used with -f auto, it may occur multiple times.
|           -D => set all options for device tree compiler
|           -f => input filename for FIT source
|           -i => input filename for ramdisk file
|           -E => place data outside of the FIT structure
|           -B => align size in hex for FIT structure and header
|           -b => append the device tree binary to the FIT
|           -t => update the timestamp in the FIT
| Signing / verified boot options: [-k keydir] [-K dtb] [ -c <comment>] [-p addr] [-r] [-N engine]
|           -k => set directory containing private keys
|           -K => write public keys to this .dtb file
|           -g => set key name hint
|           -G => use this signing key (in lieu of -k)
|           -c => add comment in signature node
|           -F => re-sign existing FIT image
|           -p => place external data at a static position
|           -r => mark keys used as 'required' in dtb
|           -N => openssl engine to use for signing
|           -o => algorithm to use for signing
|        mkimage -V ==> print version information and exit
| Use '-T list' to see a list of available image types
| Long options are available; read the man page
```

Caused by missing variable `UBOOT_ARCH`

**- How I did it**

Replace `UBOOT_ARCH` with `oe.kernel.map_uboot_arch(d)` because the variable has been dropped and all OE-Core usages are now independent of kernel-arch, following the change in [oe-core with git commit 7e8523f3c16efb29657effd732a88e939eb0cf84](https://git.openembedded.org/openembedded-core/commit/?h=master-next&id=7e8523f3c16efb29657effd732a88e939eb0cf84).
