### PR TITLE
python3-adafruit-pureio: Upgrade 1.1.9 -> 1.1.11 and enable tests

### DIFF
--- a/recipes-devtools/python/python3-adafruit-pureio_1.1.11.bb
+++ b/recipes-devtools/python/python3-adafruit-pureio_1.1.11.bb
@@ -3,14 +3,18 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_Python_PureIO"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=2a21fcca821a506d4c36f7bbecc0d009"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_Python_PureIO.git;branch=main;protocol=https"
-SRCREV = "383b615ce9ff5bbefdf77652799f380016fda353"
+SRC_URI[sha256sum] = "c4cfbb365731942d1f1092a116f47dfdae0aef18c5b27f1072b5824ad5ea8c7c"
 
-inherit setuptools3
+PYPI_PACKAGE = "Adafruit_PureIO"
 
-DEPENDS += "python3-setuptools-scm-native"
+inherit pypi python_setuptools_build_meta
 
-RDEPENDS:${PN} += " \
+DEPENDS += "\
+    python3-setuptools-scm-native \
+    python3-wheel-native \
+"
+
+RDEPENDS:${PN} += "\
     python3-core \
     python3-ctypes \
     python3-fcntl \

--- a/recipes-devtools/python/python3-adafruit-pureio_1.1.11.bb
+++ b/recipes-devtools/python/python3-adafruit-pureio_1.1.11.bb
@@ -7,7 +7,7 @@ SRC_URI[sha256sum] = "c4cfbb365731942d1f1092a116f47dfdae0aef18c5b27f1072b5824ad5
 
 PYPI_PACKAGE = "Adafruit_PureIO"
 
-inherit pypi python_setuptools_build_meta
+inherit pypi python_setuptools_build_meta ptest-python-pytest
 
 DEPENDS += "\
     python3-setuptools-scm-native \
@@ -19,3 +19,9 @@ RDEPENDS:${PN} += "\
     python3-ctypes \
     python3-fcntl \
 "
+
+do_install_ptest:append() {
+    if [ "${ENABLE_I2C}" != "1" ]; then
+        bbwarn "The tests require I2C. Set ENABLE_I2C to \"1\" to enable it."
+    fi
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

- python3-adafruit-pureio: Upgrade 1.1.9 -> 1.1.11
- python3-adafruit-pureio: Enable tests

**- How I did it**

Switched recipe python3-adafruit-pureio from using the git source code to using PyPi. Replaced `setuptools3` with `python_setuptools_build_meta` and added `python3-wheel-native` to the dependencies.

Inherited `ptest-python-pytest`. The tests require I2C and are supposed to be run against a ADS1x15 I2C analog-to-digital converter (ADC). Added a warning if `ENABLE_I2C` has not been set to `"1"` which is shown during the installation of the tests.