### PR TITLE
python3-adafruit-circuitpython-register: 1.9.10 -> 1.12.1

### DIFF
--- a/recipes-devtools/python/python3-adafruit-circuitpython-register_1.12.1.bb
+++ b/recipes-devtools/python/python3-adafruit-circuitpython-register_1.12.1.bb
@@ -3,11 +3,15 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_CircuitPython_Register"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=6ec69d6e9e6c85adfb7799d7f8cf044e"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_CircuitPython_Register.git;branch=main;protocol=https"
-SRCREV = "d1e8ac7ad9dcd65ab83749db3e5c96ffee80ebb7"
+SRC_URI[sha256sum] = "ed00f49d40fc7cb1b64dc2fefed2a8ca463cc728959e70718ed7152f6591734d"
 
-DEPENDS += "python3-setuptools-scm-native"
+PYPI_PACKAGE = "adafruit_circuitpython_register"
 
-inherit setuptools3
+inherit pypi python_setuptools_build_meta
+
+DEPENDS += "\
+    python3-setuptools-scm-native \
+    python3-wheel-native \
+"
 
 RDEPENDS:${PN} += "python3-core"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Upgrade to release 1.12.1:

- Document alarm date placeholders

From release 1.12.0:

- Add register_struct and register_bits fix

**- How I did it**

Upgraded python3-adafruit-circuitpython-register from 1.9.10 to 1.12.1. Switched to using PyPi and changed the inherit and build dependencies accordingly.