### PR TITLE
python3-adafruit-platformdetect: 3.27.0 -> 3.89.1

### DIFF
--- a/recipes-devtools/python/python3-adafruit-platformdetect_3.89.1.bb
+++ b/recipes-devtools/python/python3-adafruit-platformdetect_3.89.1.bb
@@ -3,11 +3,15 @@ HOMEPAGE = "https://github.com/adafruit/Adafruit_Python_PlatformDetect"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fccd531dce4b989c05173925f0bbb76c"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_Python_PlatformDetect.git;branch=main;protocol=https"
-SRCREV = "e1460098eeca5ea573f92814691bb378e15530d9"
+SRC_URI[sha256sum] = "74552d1afcf779a84ca63527a1eaee9995c429ff422db15492bad0c3599cab4b"
 
-inherit setuptools3
+PYPI_PACKAGE = "adafruit_platformdetect"
 
-DEPENDS += "python3-setuptools-scm-native"
+inherit pypi python_setuptools_build_meta
+
+DEPENDS += "\
+    python3-setuptools-scm-native \
+    python3-wheel-native \
+"
 
 RDEPENDS:${PN} += "python3-core"


### PR DESCRIPTION
Upgrade to release 3.89.1:

- Fix BeagleBone ID Lookup for BeaglePlay on newest image

From release 3.89.0:

- Move XU4 detection above hardware field check
- Fix chip detection failure on Alpine Linux and other non-standard distros
- Bump max-module-lines from 1000 to 2000
- Fix Orange Pi detection on non-Armbian systems (Debian)
- Fix PocketBeagle 2 support: correct DT compatible string and black formatting
- Update Read the Docs configuration for latest Ubuntu and Python

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Upgrade `python3-adafruit-platformdetect` to release 3.89.1:

- Fix BeagleBone ID Lookup for BeaglePlay on newest image

From release 3.89.0:

- Move XU4 detection above hardware field check
- Fix chip detection failure on Alpine Linux and other non-standard distros
- Bump max-module-lines from 1000 to 2000
- Fix Orange Pi detection on non-Armbian systems (Debian)
- Fix PocketBeagle 2 support: correct DT compatible string and black formatting
- Update Read the Docs configuration for latest Ubuntu and Python


**- How I did it**


Upgraded `python3-adafruit-platformdetect` from 3.27.0 to 3.89.1. Switched to using PyPi and changed the inherit and build dependencies accordingly.
