### PR TITLE
python3-adafruit-blinka: Upgrade 6.2.2 -> 9.2.0

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-blinka_9.2.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-adafruit-blinka_9.2.0.bb
@@ -1,14 +1,18 @@
 SUMMARY = "CircuitPython APIs for non-CircuitPython versions of Python such as CPython on Linux and MicroPython."
 HOMEPAGE = "https://github.com/adafruit/Adafruit_Blinka"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=660e614bc7efb0697cc793d8a22a55c2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=fccd531dce4b989c05173925f0bbb76c"
 
-SRC_URI = "git://github.com/adafruit/Adafruit_Blinka.git;branch=main;protocol=https"
-SRCREV = "dc688f354fe779c9267c208b99f310af87e79272"
+SRC_URI[sha256sum] = "0358f02840f91127246d9c5fa6d49660e2ab1134cc4e56fd5d88ce4c39a50942"
 
-inherit setuptools3
+PYPI_PACKAGE = "adafruit_blinka"
 
-DEPENDS += "python3-setuptools-scm-native"
+inherit pypi python_setuptools_build_meta
+
+DEPENDS += "\
+    python3-setuptools-scm-native \
+    python3-wheel-native \
+"
 
 do_install:append() {
 # it ships ./bcm283x/pulseio/libgpiod_pulsein which is a prebuilt
@@ -16,6 +20,11 @@ do_install:append() {
     if [ ${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', '1', '0', d)} = "0" ]; then
         rm -rf ${D}${PYTHON_SITEPACKAGES_DIR}/adafruit_blinka/microcontroller/bcm283x
     fi
+
+    # Remove Amlogic as it is not related to Raspberry Pi.
+    # When building for raspberrypi5 (AArch64) fixes:
+    # QA Issue: Architecture did not match (ARM, expected AArch64)
+    rm -rf ${D}${PYTHON_SITEPACKAGES_DIR}/adafruit_blinka/microcontroller/amlogic
 }
 
 RDEPENDS:${PN} += " \
@@ -23,6 +32,7 @@ RDEPENDS:${PN} += " \
     python3-adafruit-platformdetect \
     python3-adafruit-pureio \
     python3-core \
+    python3-lgpio \
 "
 
 RDEPENDS:${PN}:append:rpi = " rpi-gpio"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-lgpio/0001-PY_LGPIO-lgpio.i-Replace-undefined-functions.patch
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-lgpio/0001-PY_LGPIO-lgpio.i-Replace-undefined-functions.patch
@@ -1,0 +1,130 @@
+From 3319a0cd854552451c3fbc31b1abf334ce256583 Mon Sep 17 00:00:00 2001
+From: Leon Anavi <leon.anavi@konsulko.com>
+Date: Mon, 17 Aug 2026 16:26:16 +0300
+Subject: [PATCH] PY_LGPIO/lgpio.i: Replace undefined functions
+
+Replace functions PyInt_Check, PyInt_AsLong, PyInt_FromLong and
+PyString_FromString for Python3 because SWIG dropped its Python
+2/3 compat shim in version 4.1. Fixes:
+
+error: implicit declaration of function 'PyInt_FromLong';
+did you mean 'PyLong_FromLong'? [-Wimplicit-function-declaration]
+
+error: implicit declaration of function 'PyInt_Check';
+did you mean 'PySet_Check'? [-Wimplicit-function-declaration]
+
+error: implicit declaration of function 'PyInt_AsLong';
+did you mean 'PyLong_AsLong'? [-Wimplicit-function-declaration]
+
+Upstream-Status: Submitted [https://github.com/joan2937/lg/pull/46]
+
+Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
+---
+ PY_LGPIO/lgpio.i | 42 +++++++++++++++++++++---------------------
+ 1 file changed, 21 insertions(+), 21 deletions(-)
+
+diff --git a/PY_LGPIO/lgpio.i b/PY_LGPIO/lgpio.i
+index 5f1bfeb..bead4e3 100644
+--- a/lgpio.i
++++ b/lgpio.i
+@@ -296,12 +296,12 @@ error_text                Get the error text for an error code
+ // lgSpiRead
+ %typemap(in) (char *rxBuf, int count)
+ {
+-   if (!PyInt_Check($input))
++   if (!PyLong_Check($input))
+    {
+       PyErr_SetString(PyExc_ValueError, "Expecting an integer");
+       SWIG_fail;
+    }
+-   $2 = PyInt_AsLong($input);
++   $2 = PyLong_AsLong($input);
+    if ($2 < 0)
+    {
+       PyErr_SetString(PyExc_ValueError, "Positive integer expected");
+@@ -360,7 +360,7 @@ error_text                Get the error text for an error code
+    Py_XDECREF($result);   /* Blow away any previous result */
+ 
+    $result = PyList_New(2);
+-   o1 = PyInt_FromLong(result);
++   o1 = PyLong_FromLong(result);
+    PyList_SetItem($result, 0, o1);
+ 
+    if (result > 0) o2 = PyByteArray_FromStringAndSize($2, result);
+@@ -408,7 +408,7 @@ error_text                Get the error text for an error code
+    PyObject *o1, *o2;
+    Py_XDECREF($result);   /* Blow away any previous result */
+    $result = PyList_New(2);
+-   o1 = PyInt_FromLong(result);
++   o1 = PyLong_FromLong(result);
+    PyList_SetItem($result, 0, o1);
+    if (result > 0) o2 = PyByteArray_FromStringAndSize($1, result);
+    else o2 = PyByteArray_FromStringAndSize("", 0);
+@@ -428,7 +428,7 @@ error_text                Get the error text for an error code
+    Py_XDECREF($result);   /* Blow away any previous result */
+    $result = PyList_New(2);
+ 
+-   o1 = PyInt_FromLong(result);
++   o1 = PyLong_FromLong(result);
+    PyList_SetItem($result, 0, o1);
+ 
+    if (result > 0) o2 = PyByteArray_FromStringAndSize($1, result);
+@@ -494,18 +494,18 @@ error_text                Get the error text for an error code
+    {
+       result = 0;
+ 
+-      o2 = PyInt_FromLong(chipInf2.lines);
+-      o3 = PyString_FromString(chipInf2.name);
+-      o4 = PyString_FromString(chipInf2.label);
++      o2 = PyLong_FromLong(chipInf2.lines);
++      o3 = PyUnicode_FromString(chipInf2.name);
++      o4 = PyUnicode_FromString(chipInf2.label);
+    }
+    else
+    {
+-      o2 = PyInt_FromLong(0);
+-      o3 = PyString_FromString("");
+-      o4 = PyString_FromString("");
++      o2 = PyLong_FromLong(0);
++      o3 = PyUnicode_FromString("");
++      o4 = PyUnicode_FromString("");
+    }
+ 
+-   o1 = PyInt_FromLong(result);
++   o1 = PyLong_FromLong(result);
+ 
+    PyList_SetItem($result, 0, o1);
+    PyList_SetItem($result, 1, o2);
+@@ -530,20 +530,20 @@ error_text                Get the error text for an error code
+    {
+       result = 0;
+ 
+-      o2 = PyInt_FromLong(lineInf3.offset);
+-      o3 = PyInt_FromLong(lineInf3.lFlags);
+-      o4 = PyString_FromString(lineInf3.name);
+-      o5 = PyString_FromString(lineInf3.user);
++      o2 = PyLong_FromLong(lineInf3.offset);
++      o3 = PyLong_FromLong(lineInf3.lFlags);
++      o4 = PyUnicode_FromString(lineInf3.name);
++      o5 = PyUnicode_FromString(lineInf3.user);
+    }
+    else
+    {
+-      o2 = PyInt_FromLong(0);
+-      o3 = PyInt_FromLong(0);
+-      o4 = PyString_FromString("");
+-      o5 = PyString_FromString("");
++      o2 = PyLong_FromLong(0);
++      o3 = PyLong_FromLong(0);
++      o4 = PyUnicode_FromString("");
++      o5 = PyUnicode_FromString("");
+    }
+ 
+-   o1 = PyInt_FromLong(result);
++   o1 = PyLong_FromLong(result);
+ 
+    PyList_SetItem($result, 0, o1);
+    PyList_SetItem($result, 1, o2);
+-- 
+2.47.3
+

--- a/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-lgpio_0.2.2.0.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/python/python3-lgpio_0.2.2.0.bb
@@ -1,0 +1,15 @@
+SUMMARY = "Linux SBC GPIO module"
+DESCRIPTION = "Python module which allows control of the GPIO of a Linux SBC."
+HOMEPAGE = "https://abyz.me.uk/lg/py_lgpio.html"
+LICENSE = "Unlicense"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=61287f92700ec1bdf13bc86d8228cd13"
+
+SRC_URI[sha256sum] = "11372e653b200f76a0b3ef8a23a0735c85ec678a9f8550b9893151ed0f863fff"
+
+SRC_URI += "file://0001-PY_LGPIO-lgpio.i-Replace-undefined-functions.patch"
+
+DEPENDS += "swig-native lg"
+
+RDEPENDS:${PN} += "lg"
+
+inherit pypi setuptools3

--- a/recipes-support/lg/lg_git.bb
+++ b/recipes-support/lg/lg_git.bb
@@ -1,0 +1,41 @@
+SUMMARY = "Linux C libraries and Python modules for manipulating GPIO"
+DESCRIPTION = "lgpio is a library for Linux Single Board Computers\
+(SBC) which allows control of the General Purpose Input Outputs (GPIO)."
+HOMEPAGE = "https://github.com/joan2937/lg"
+LICENSE = "Unlicense"
+LIC_FILES_CHKSUM = "file://UNLICENCE;md5=61287f92700ec1bdf13bc86d8228cd13"
+
+SRC_URI = "git://github.com/joan2937/lg.git;protocol=https;branch=master"
+SRCREV = "bcccd782eceedc5b278b3056ea81d5fbbb89c489"
+
+EXTRA_OEMAKE = "CC='${CC}' AR='${AR}' RANLIB='${RANLIB}' STRIP=true"
+
+SOVERSION = "1"
+
+do_compile() {
+    oe_runmake
+}
+
+do_install() {
+    install -d ${D}${includedir}
+    install -m 0644 ${S}/lgpio.h ${D}${includedir}/
+    install -m 0644 ${S}/rgpio.h ${D}${includedir}/
+
+    install -d ${D}${libdir}
+    install -m 0755 ${S}/liblgpio.so.${SOVERSION} ${D}${libdir}/
+    install -m 0755 ${S}/librgpio.so.${SOVERSION} ${D}${libdir}/
+    ln -sf liblgpio.so.${SOVERSION} ${D}${libdir}/liblgpio.so
+    ln -sf librgpio.so.${SOVERSION} ${D}${libdir}/librgpio.so
+
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/rgpiod ${D}${bindir}/
+    install -m 0755 ${S}/rgs ${D}${bindir}/
+
+    install -d ${D}${mandir}/man1
+    install -m 0644 ${S}/rgpiod.1 ${D}${mandir}/man1/
+    install -m 0644 ${S}/rgs.1 ${D}${mandir}/man1/
+
+    install -d ${D}${mandir}/man3
+    install -m 0644 ${S}/lgpio.3 ${D}${mandir}/man3/
+    install -m 0644 ${S}/rgpio.3 ${D}${mandir}/man3/
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

Upgrade `python3-adafruit-blinka` from  6.2.2 to 9.2.0.

**- How I did it**

* lg: Add recipe for the Linux C libraries for manipulating GPIO. It is required for python3-lgpio.
* python3-lgpio: dd recipe for release 0.2.2.0. It is required for python3-adafruit-blinka.
* python3-adafruit-blinka: Upgrade 6.2.2 -> 9.2.0
