### PR TITLE
Hifiberry overlays update

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -28,11 +28,14 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/gpio-key.dtbo \
     overlays/gpio-poweroff.dtbo \
     overlays/gpio-shutdown.dtbo \
+    overlays/hifiberry-adc.dtbo \
+    overlays/hifiberry-adc8x.dtbo \
     overlays/hifiberry-amp.dtbo \
     overlays/hifiberry-amp100.dtbo \
     overlays/hifiberry-amp3.dtbo \
     overlays/hifiberry-amp4pro.dtbo \
     overlays/hifiberry-dac.dtbo \
+    overlays/hifiberry-dac8x.dtbo \
     overlays/hifiberry-dacplus-pro.dtbo \
     overlays/hifiberry-dacplus-std.dtbo \
     overlays/hifiberry-dacplus.dtbo \

--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -33,6 +33,8 @@ RPI_KERNEL_DEVICETREE_OVERLAYS ?= " \
     overlays/hifiberry-amp3.dtbo \
     overlays/hifiberry-amp4pro.dtbo \
     overlays/hifiberry-dac.dtbo \
+    overlays/hifiberry-dacplus-pro.dtbo \
+    overlays/hifiberry-dacplus-std.dtbo \
     overlays/hifiberry-dacplus.dtbo \
     overlays/hifiberry-dacplusadc.dtbo \
     overlays/hifiberry-dacplusadcpro.dtbo \


### PR DESCRIPTION
- What I did

Added five HiFiBerry device tree overlays to RPI_KERNEL_DEVICETREE_OVERLAYS in conf/machine/include/rpi-base.inc, as two commits.

hifiberry-dacplus-std and hifiberry-dacplus-pro:

HiFiBerry split the DAC+ overlay in two, because the Pi 5's driver infrastructure no longer lets a card reconfigure its clocking at runtime — the interface has to be declared master or slave in the overlay itself. A DAC+ Standard, Amp2 or Amp4 now needs -std, a DAC+ Pro or DAC2 Pro needs -pro. Neither is deployed by this layer, while the superseded hifiberry-dacplus still is — so the overlay a current DAC+ owner needs is the one that's missing, and every older guide points at the one that still loads.

- kernel commit: https://github.com/raspberrypi/linux/commit/9e31e8ce44ef
- HiFiBerry's explanation: https://www.hifiberry.com/blog/changes-in-hifiberry-drivers/

The other three — hifiberry-adc, hifiberry-adc8x and hifiberry-dac8x — are built by the kernel but not deployed by this layer.

In both cases the failure is silent: a dtoverlay= line naming a .dtbo that isn't on the boot partition doesn't stop the boot and prints nothing an ordinary user will look for. The card simply never appears.

- How I did it

Five lines added to the existing list.

hifiberry-studio-dac8x and -pro are deliberately excluded — added to the kernel in ba7ae2c9, absent from the kernel the 6.6 recipe pins. Verified on a build: with PREFERRED_VERSION_linux-raspberrypi = "6.6.%" the five overlays added here compile, while adding hifiberry-studio-dac8x on top fails do_compile with "No rule to make target 'arch/arm/boot/dts/overlays/hifiberry-studio-dac8x.dtbo'".

After reading #1168 I checked the same thing for 6.1: hifiberry-adc and hifiberry-adc8x are not in the kernel linux-raspberrypi_6.1.bb pins (fbd8b3fa), so they would break a 6.1 build the way imx708 broke 5.10 in #1158. Happy to drop those two if you'd prefer — the other three are present in all four kernels.

Btw, #1168 asked for hifiberry-dacplusadcpro. It was added in fc34bc3 (#1275) and is present in 6.1, 6.6, 6.12 and 6.18.